### PR TITLE
Default POST headers Content-Type to application/json

### DIFF
--- a/samples/extensions.csproj
+++ b/samples/extensions.csproj
@@ -5,7 +5,7 @@
 	<DefaultItemExcludes>**</DefaultItemExcludes>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="1.7.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="1.7.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Twilio" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.0.0" />

--- a/samples/package-lock.json
+++ b/samples/package-lock.json
@@ -1,13 +1,18 @@
 {
   "name": "durable-functions-samples",
-  "version": "1.1.0",
+  "version": "1.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/lodash": {
+      "version": "4.14.120",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.120.tgz",
+      "integrity": "sha512-jQ21kQ120mo+IrDs1nFNVm/AsdFxIx2+vZ347DbogHJPd/JzKNMOqU6HCYin1W6v8l5R9XSO2/e9cxmn7HAnVw=="
+    },
     "@types/validator": {
-      "version": "9.4.3",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-9.4.3.tgz",
-      "integrity": "sha512-D4zRrAs2pTg5cva6+hJ6GrQlb/UX5NxNtk/da3Gw27enoLvbRMTTloZ1w6CCqc+kHyZvT3DsyWQZ8baTGgSg0g=="
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-9.4.4.tgz",
+      "integrity": "sha512-7bWNKQ3lDMhRS2lxe1aHGTBijZ/a6wQfZmCtKJDefpb81sYd+FrfNqj6Gda1Tcw8bYK0gG1CVuNLWV2JS7K8Dw=="
     },
     "ajv": {
       "version": "6.5.5",
@@ -77,6 +82,15 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+    },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
+      }
     },
     "azure-functions-typescript": {
       "version": "github:christopheranderson/azure-functions-typescript#bbb6b0fd67fcdf82cabaf1af41e65fa6d8496ff5",
@@ -355,14 +369,17 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "durable-functions": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/durable-functions/-/durable-functions-1.1.0.tgz",
-      "integrity": "sha512-mk3Hf+CbSQnlE+MTO1/sGcqYup5gxAE6H7xGieM/F7jSCYgSKzMfhiRelJPRakNOJRMevthLErnjDMt3Kf67bA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/durable-functions/-/durable-functions-1.1.3.tgz",
+      "integrity": "sha512-YH+ah8E0bQTgFkcgiPmvep62TNsolLmKL2e9QUgGokuxV8vln+exJr9aJjKv6Q620BtAq95lYTOND0A9/9LyAw==",
       "requires": {
+        "@types/lodash": "^4.14.119",
         "@types/validator": "^9.4.3",
-        "azure-functions-typescript": "github:christopheranderson/azure-functions-typescript#bbb6b0fd67fcdf82cabaf1af41e65fa6d8496ff5",
+        "axios": "~0.18.0",
+        "azure-functions-typescript": "github:christopheranderson/azure-functions-typescript",
         "commander": "~2.9.0",
         "debug": "~2.6.9",
+        "lodash": "^4.17.11",
         "rimraf": "~2.5.4",
         "validator": "~10.8.0"
       },
@@ -530,6 +547,24 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "follow-redirects": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
+      "integrity": "sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
           }
         }
       }
@@ -841,6 +876,11 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
       "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "map-cache": {
       "version": "0.2.2",

--- a/samples/package.json
+++ b/samples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "durable-functions-samples",
-  "version": "1.1.1",
+  "version": "1.1.3",
   "description": "Durable Functions sample library for Node.js Azure Functions",
   "license": "MIT",
   "repository": "",
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "azure-storage": "^2.10.2",
-    "durable-functions": "^1.1.1",
+    "durable-functions": "^1.1.3",
     "moment": "^2.22.2",
     "readdirp": "^2.2.1",
     "request": "^2.87.0",


### PR DESCRIPTION
Fixes #42:

- The POST requests from axios default their `Content-Type` header to `x-www-form-urlencoded`, which causes problems on our extension's end. I set a global header (added to each POST request) for `Content-Type` to be `application/json`, since we don't plan to send anything else.
- While I was updating tests I caught a second bug. The `axios` library, which is for making HTTP requests, will throw Errors in certain cases. I wanted to pare down the information we bubble up in the event one happens, hence the try-catch, but that was also catching the errors I meant to throw based on returned status codes. Using return `Promise.reject` should mean those errors don't get caught in the catch block, which was eating their messages.