### PR TITLE
fix: orchestrator shouldn't swallow thrown errors fixes #48

### DIFF
--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -109,7 +109,7 @@ export class Orchestrator {
         } catch (error) {
             log(`Error: ${error}`);
             context.done(
-                null,
+                error,
                 new OrchestratorState({
                     isDone: false,
                     actions,


### PR DESCRIPTION
By not passing null, the orchestrator swallows any errors that are intentionally thrown. Fixes #48 

This apparently exposes a bunch of errors in the unit tests that were being silently swallowed by the orchestrator. So unit tests are failing and will need to be addressed.

Here's an example function that can be used to test this:
```
const df = require('durable-functions')

module.exports = df.orchestrator(function * (context) {
  throw new Error(`This should throw and show up in the log.`)
})
```