### PR TITLE
Move the uuid module from devDependencies to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,8 +86,7 @@
     "@types/node": {
       "version": "6.14.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.2.tgz",
-      "integrity": "sha512-JWB3xaVfsfnFY8Ofc9rTB/op0fqqTSqy4vBcVk1LuRJvta7KTX+D//fCkiTMeLGhdr2EbFZzQjC97gvmPilk9Q==",
-      "dev": true
+      "integrity": "sha512-JWB3xaVfsfnFY8Ofc9rTB/op0fqqTSqy4vBcVk1LuRJvta7KTX+D//fCkiTMeLGhdr2EbFZzQjC97gvmPilk9Q=="
     },
     "@types/rimraf": {
       "version": "0.0.28",
@@ -105,7 +104,6 @@
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.4.tgz",
       "integrity": "sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -858,8 +856,7 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "dev": true
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "validator": {
       "version": "10.8.0",

--- a/package.json
+++ b/package.json
@@ -28,12 +28,14 @@
     "@azure/functions": "^1.0.2-beta2",
     "@types/lodash": "^4.14.119",
     "@types/validator": "^9.4.3",
+    "@types/uuid": "~3.4.4",
     "axios": "~0.18.0",
     "commander": "~2.9.0",
     "debug": "~2.6.9",
     "lodash": "^4.17.11",
     "rimraf": "~2.5.4",
-    "validator": "~10.8.0"
+    "validator": "~10.8.0",
+    "uuid": "~3.3.2"
   },
   "devDependencies": {
     "@types/chai": "~4.1.6",
@@ -45,7 +47,6 @@
     "@types/node": "~6.14.0",
     "@types/rimraf": "0.0.28",
     "@types/sinon": "~5.0.5",
-    "@types/uuid": "~3.4.4",
     "chai": "~4.2.0",
     "chai-as-promised": "~7.1.1",
     "mocha": "~5.2.0",
@@ -54,8 +55,7 @@
     "sinon": "~7.1.1",
     "ts-node": "~1.0.0",
     "tslint": "^5.11.0",
-    "typescript": "~3.1.6",
-    "uuid": "~3.3.2"
+    "typescript": "~3.1.6"
   },
   "engines": {
     "node": ">=6.5.0"


### PR DESCRIPTION
 Fixes #74

## What is This

This pull request is to fix the issue #74. The issue is that `Error: Cannot find module 'uuid/v5'` error thrown.

## How to Solve the Issue

In the pull request #71, the `GuidManager` class has been provided to generate GUID string. The class is using the `uuid/v5` module to generate a UUID string. That is, the `uuid` npm module is necessary at using the version 1.2.0 including the `GuidManager`.

However, the `uuid` module is defined as the `devDependencies` in the `package.json` file. Therefore, when installing the `durable-functions` module with the `npm install durable-functions`, the `uuid` module might not be installed. As the result, at the runtime, the `uuid` module can not be loaded, and the error thrown.

To solve this issue, the `uuid` module should be defined as `dependencies` in the `package.json` file.