### PR TITLE
Lifted axios maxContentLength limit. Partially resolves #93.

### DIFF
--- a/src/durableorchestrationclient.ts
+++ b/src/durableorchestrationclient.ts
@@ -127,6 +127,7 @@ export class DurableOrchestrationClient {
                     "Content-Type": "application/json",
                 },
             },
+            maxContentLength: Infinity,
         });
         this.taskHubName = this.clientData.taskHubName;
         this.uniqueWebhookOrigins = this.extractUniqueWebhookOrigins(this.clientData);


### PR DESCRIPTION
The Functions host still imposes a maxAllowedContentLength limit of 100 MB.

Suggested workaround for large messages is to write them to storage, pass the endpoint, and retrieve from within an activity function. See [longer comment in #93.](https://github.com/Azure/azure-functions-durable-js/issues/93#issuecomment-506525692)