### PR TITLE
Fix creating sub orchestrations without specifying instance ids

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,8 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
+
+
         {
             "type": "node",
             "request": "launch",
@@ -48,6 +50,28 @@
                 "${workspaceFolder}/lib/test/**/**-spec.js",
                 "-g",
                 ".*"
+            ],
+            "internalConsoleOptions": "openOnSessionStart",
+            "sourceMaps": true,
+            "outFiles": [
+                "${workspaceFolder}/lib/**"
+            ],
+            "preLaunchTask": "build"
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Mocha Tests Debug",
+            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+            "args": [
+                "-u",
+                "tdd",
+                "--colors",
+                "${workspaceFolder}/lib/test/**/**-spec.js",
+                "-g",
+                ".*",
+                "--timeout",
+                "300000"
             ],
             "internalConsoleOptions": "openOnSessionStart",
             "sourceMaps": true,

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -254,7 +254,7 @@ export class Orchestrator {
 
     private callSubOrchestrator(state: HistoryEvent[], name: string, input?: unknown, instanceId?: string): Task {
         if (!name) {
-            throw new Error("A suborchestration function name must be provided when attempting to create a suborchestration");
+            throw new Error("A sub-orchestration function name must be provided when attempting to create a suborchestration");
         }
 
         const newAction = new CallSubOrchestratorAction(name, instanceId, input);
@@ -302,7 +302,7 @@ export class Orchestrator {
         instanceId?: string)
         : Task {
         if (!name) {
-            throw new Error("A suborchestration function name must be provided when attempting to create a suborchestration");
+            throw new Error("A sub-orchestration function name must be provided when attempting to create a suborchestration");
         }
 
         const newAction = new CallSubOrchestratorWithRetryAction(name, retryOptions, input, instanceId);

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -14,10 +14,6 @@ import { TokenSource } from "./tokensource";
 /** @hidden */
 const log = debug("orchestrator");
 
-interface SubOrchestrationCounter {
-    [key: string]: number | undefined;
-}
-
 /** @hidden */
 export class Orchestrator {
     private currentUtcDateTime: Date;
@@ -50,7 +46,7 @@ export class Orchestrator {
             ? new Date(decisionStartedEvent.Timestamp)
             : undefined;
 
-        // Reset counters
+        // Reset newGuidCounter
         this.newGuidCounter = 0;
 
         // Create durable orchestration context
@@ -599,7 +595,7 @@ export class Orchestrator {
         state: HistoryEvent[],
         name: string,
         instanceId: string)
-        : SubOrchestrationInstanceCreatedEvent {
+        : SubOrchestrationInstanceCreatedEvent | undefined {
 
         if (name) {
             const matches = state.filter((val: HistoryEvent) => {
@@ -616,6 +612,8 @@ export class Orchestrator {
                     throw new Error(`The suborchestration ${name} replayed with an instance id of ${actualInstanceId} instead of the provided instance id of ${instanceId}`);
                 }
                 return returnValue as SubOrchestrationInstanceCreatedEvent;
+            } else {
+                return undefined;
             }
         } else {
             throw new Error("A suborchestration function name must be provided when attempting to create a suborchestration");

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -630,11 +630,11 @@ export class Orchestrator {
         // called in the same order this replay that they were scheduled in.
         const returnValue = matches[0] as SubOrchestrationInstanceCreatedEvent;
         if (returnValue.Name !== name) {
-            throw new Error(`The suborchestration call (n = ${this.subOrchestratorCounter}) should be executed with a function name of ${returnValue.Name} instead of the provided function name of ${name}. Check your code for non-deterministic behavior.`);
+            throw new Error(`The sub-orchestration call (n = ${this.subOrchestratorCounter}) should be executed with a function name of ${returnValue.Name} instead of the provided function name of ${name}. Check your code for non-deterministic behavior.`);
         }
 
         if (instanceId && returnValue.InstanceId !== instanceId) {
-            throw new Error(`The suborchestration call (n = ${this.subOrchestratorCounter}) should be executed with an instance id of ${returnValue.InstanceId} instead of the provided instance id of ${instanceId}. Check your code for non-deterministic behavior.`);
+            throw new Error(`The sub-orchestration call (n = ${this.subOrchestratorCounter}) should be executed with an instance id of ${returnValue.InstanceId} instead of the provided instance id of ${instanceId}. Check your code for non-deterministic behavior.`);
         }
         return returnValue;
     }

--- a/test/integration/orchestrator-spec.ts
+++ b/test/integration/orchestrator-spec.ts
@@ -840,6 +840,34 @@ describe("Orchestrator", () => {
             );
         });
 
+        it("Succesfully runs multiple suborchestrator function with no instanceId", async () => {
+            const orchestrator = TestOrchestrations.MultipleSubOrchestratorNoSubId;
+            const name = "World";
+            const id = uuidv1();
+            const mockContext = new MockContext({
+                context: new DurableOrchestrationBindingInfo(
+                    TestHistories.GetMultipleSubOrchestratorNoIdsSubOrchestrationsFinished(
+                        moment.utc().toDate(),
+                        orchestrator,
+                        ["SayHelloWithActivity", "SayHelloInline", "SayHelloWithActivity", "SayHelloInline"],
+                        name,
+                    ),
+                    name,
+                    id
+                ),
+            });
+
+            orchestrator(mockContext);
+
+            expect(mockContext.doneValue).to.be.deep.equal(
+                new OrchestratorState({
+                    isDone: true,
+                    output: [`Hello, ${name}_SayHelloWithActivity_0!`, `Hello, ${name}_SayHelloInline_1!`, `Hello, ${name}_SayHelloWithActivity_2!`, `Hello, ${name}_SayHelloInline_3!`],
+                    actions: [],
+                }),
+            );
+        });
+
         it("handles a completed suborchestrator function", async () => {
             const orchestrator = TestOrchestrations.SayHelloWithSubOrchestrator;
             const name = "World";

--- a/test/integration/orchestrator-spec.ts
+++ b/test/integration/orchestrator-spec.ts
@@ -853,7 +853,7 @@ describe("Orchestrator", () => {
                         name,
                     ),
                     name,
-                    id
+                    id,
                 ),
             });
 
@@ -863,7 +863,14 @@ describe("Orchestrator", () => {
                 new OrchestratorState({
                     isDone: true,
                     output: [`Hello, ${name}_SayHelloWithActivity_0!`, `Hello, ${name}_SayHelloInline_1!`, `Hello, ${name}_SayHelloWithActivity_2!`, `Hello, ${name}_SayHelloInline_3!`],
-                    actions: [],
+                    actions: [
+                                [
+                                    new CallSubOrchestratorAction("SayHelloWithActivity", undefined, `${name}_SayHelloWithActivity_0`),
+                                    new CallSubOrchestratorAction("SayHelloInline", undefined, `${name}_SayHelloInline_1`),
+                                    new CallSubOrchestratorAction("SayHelloWithActivity", undefined, `${name}_SayHelloWithActivity_2`),
+                                    new CallSubOrchestratorAction("SayHelloInline", undefined, `${name}_SayHelloInline_3`),
+                                ],
+                            ],
                 }),
             );
         });

--- a/test/integration/orchestrator-spec.ts
+++ b/test/integration/orchestrator-spec.ts
@@ -895,7 +895,7 @@ describe("Orchestrator", () => {
 
             orchestrator(mockContext);
 
-            const expectedErr = "The suborchestration call (n = 1) should be executed with a function name of SayHelloInline instead of the provided function name of SayHelloWithActivity. Check your code for non-deterministic behavior.";
+            const expectedErr = "The sub-orchestration call (n = 1) should be executed with a function name of SayHelloInline instead of the provided function name of SayHelloWithActivity. Check your code for non-deterministic behavior.";
 
             expect(mockContext.doneValue!.error).to
                 .include(expectedErr);
@@ -924,7 +924,7 @@ describe("Orchestrator", () => {
 
             orchestrator(mockContext);
 
-            const expectedErr = `The suborchestration call (n = 1) should be executed with an instance id of ${subId} instead of the provided instance id of ${id}:0. Check your code for non-deterministic behavior.`;
+            const expectedErr = `The sub-orchestration call (n = 1) should be executed with an instance id of ${subId} instead of the provided instance id of ${id}:0. Check your code for non-deterministic behavior.`;
 
             expect(mockContext.doneValue!.error).to
                 .include(expectedErr);

--- a/test/testobjects/TestOrchestrations.ts
+++ b/test/testobjects/TestOrchestrations.ts
@@ -140,13 +140,12 @@ export class TestOrchestrations {
     public static MultipleSubOrchestratorNoSubId: any = df.orchestrator(function*(context: any) {
         const input = context.df.getInput();
         const subOrchName1 = "SayHelloWithActivity";
-        const subOrchName2 = "SayHelloInline"
+        const subOrchName2 = "SayHelloInline";
         const output = context.df.callSubOrchestrator(subOrchName1, `${input}_${subOrchName1}_0`);
         const output2 = context.df.callSubOrchestrator(subOrchName2, `${input}_${subOrchName2}_1`);
         const output3 = context.df.callSubOrchestrator(subOrchName1, `${input}_${subOrchName1}_2`);
         const output4 = context.df.callSubOrchestrator(subOrchName2, `${input}_${subOrchName2}_3`);
-        let outputs = yield context.df.Task.all([output, output2, output3, output4]);
-        return outputs;
+        return yield context.df.Task.all([output, output2, output3, output4]);
     });
 
     public static SayHelloWithSubOrchestratorRetry: any = df.orchestrator(function*(context: any) {

--- a/test/testobjects/TestOrchestrations.ts
+++ b/test/testobjects/TestOrchestrations.ts
@@ -137,6 +137,18 @@ export class TestOrchestrations {
         return output;
     });
 
+    public static MultipleSubOrchestratorNoSubId: any = df.orchestrator(function*(context: any) {
+        const input = context.df.getInput();
+        const subOrchName1 = "SayHelloWithActivity";
+        const subOrchName2 = "SayHelloInline"
+        const output = context.df.callSubOrchestrator(subOrchName1, `${input}_${subOrchName1}_0`);
+        const output2 = context.df.callSubOrchestrator(subOrchName2, `${input}_${subOrchName2}_1`);
+        const output3 = context.df.callSubOrchestrator(subOrchName1, `${input}_${subOrchName1}_2`);
+        const output4 = context.df.callSubOrchestrator(subOrchName2, `${input}_${subOrchName2}_3`);
+        let outputs = yield context.df.Task.all([output, output2, output3, output4]);
+        return outputs;
+    });
+
     public static SayHelloWithSubOrchestratorRetry: any = df.orchestrator(function*(context: any) {
         const input = context.df.getInput();
         const childId = context.df.instanceId + ":0";

--- a/test/testobjects/testhistories.ts
+++ b/test/testobjects/testhistories.ts
@@ -4,7 +4,7 @@ import { DurableHttpRequest, DurableHttpResponse, EntityId, EventRaisedEvent, Ev
     ExecutionStartedEvent, HistoryEvent, OrchestratorCompletedEvent, OrchestratorStartedEvent,
     SubOrchestrationInstanceCompletedEvent, SubOrchestrationInstanceCreatedEvent,
     SubOrchestrationInstanceFailedEvent, TaskCompletedEvent, TaskFailedEvent, TaskScheduledEvent,
-    TimerCreatedEvent, TimerFiredEvent, GuidManager } from "../../src/classes";
+    TimerCreatedEvent, TimerFiredEvent } from "../../src/classes";
 
 export class TestHistories {
     public static GetAnyAOrB(firstTimestamp: Date, completeInOrder: boolean): HistoryEvent[] {
@@ -1492,7 +1492,7 @@ export class TestHistories {
         const firstMoment = moment(firstTimestamp);
 
         const baseSubInstanceId = "dummy-unique-id";
-        let historyEvents =  [
+        const historyEvents =  [
             new OrchestratorStartedEvent(
                 {
                     eventId: -1,
@@ -1546,7 +1546,7 @@ export class TestHistories {
                     result: JSON.stringify(`Hello, ${input}_${subOrchestratorNames[i]}_${i}!`),
                     taskScheduledId: i,
                 },
-            ))
+            ));
         }
 
         return historyEvents;

--- a/test/testobjects/testhistories.ts
+++ b/test/testobjects/testhistories.ts
@@ -1483,6 +1483,9 @@ export class TestHistories {
         ];
     }
 
+    // Covers the scenario for TestOrchestrations.MultipleSubOrchestratorNoSubId in which
+    // all of the scheduled sub orchestrations are completed around the same time and processed
+    // in the same orchestration replay.
     public static GetMultipleSubOrchestratorNoIdsSubOrchestrationsFinished(
         firstTimestamp: Date,
         orchestratorName: string,


### PR DESCRIPTION
Currently, only the first sub orchestration created without specifying
an instance id will ever be marked as completed. This fix aims to
address that. Addresses issue #54.

The new approach should also more aggressively find non-deterministic replays, and added some tests to emulate these errors.