### PR TITLE
Rework generator result handling logic

### DIFF
--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -151,7 +151,7 @@ export class Orchestrator {
                     continue;
                 }
 
-                // Handles the case where an orchestration completes with a returns a return value of
+                // Handles the case where an orchestration completes with a return value of a
                 // completed (non-faulted) task. This shouldn't generally happen as hopefully the customer
                 // would yield the task before returning out of the generator function.
                 if (g.done) {

--- a/test/testobjects/TestOrchestrations.ts
+++ b/test/testobjects/TestOrchestrations.ts
@@ -93,10 +93,20 @@ export class TestOrchestrations {
         return `Hello, ${input}!`;
     });
 
+    public static SayHelloInlineInproperYield: any = df.orchestrator(function*(context: any) {
+        const input = yield context.df.getInput();
+        return `Hello, ${input}!`;
+    });
+
     public static SayHelloWithActivity: any = df.orchestrator(function*(context: any) {
         const input = context.df.getInput();
         const output = yield context.df.callActivity("Hello", input);
         return output;
+    });
+
+    public static SayHelloWithActivityDirectReturn: any = df.orchestrator(function*(context: any) {
+        const input = context.df.getInput();
+        return context.df.callActivity("Hello", input);
     });
 
     public static SayHelloWithActivityRetry: any = df.orchestrator(function*(context: any) {


### PR DESCRIPTION
Fixes continueAsNew() for 1.8.0 and later, as well as handles some edge
cases, like customers yielding non-Task objects and returning unyielded
Tasks. Addresses #57 and #81.