### PR TITLE
[Fix] Changed callHttp signature to match exposed type

### DIFF
--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -394,18 +394,12 @@ export class Orchestrator {
         );
     }
 
-    private callHttp(
-        state: HistoryEvent[],
-        method: string,
-        uri: string,
-        content?: string | object,
-        headers?: { [key: string]: string },
-        tokenSource?: TokenSource) {
+    private callHttp(state: HistoryEvent[], req: DurableHttpRequest) {
+        let { content } = req;
         if (content && typeof content !== "string") {
             content = JSON.stringify(content);
         }
 
-        const req = new DurableHttpRequest(method, uri, content as string, headers, tokenSource);
         const newAction = new CallHttpAction(req);
 
         // callHttp is internally implemented as a well-known activity function

--- a/test/testobjects/TestOrchestrations.ts
+++ b/test/testobjects/TestOrchestrations.ts
@@ -1,4 +1,5 @@
 import * as df from "../../src";
+import { DurableOrchestrationContext } from "../../src/classes";
 
 export class TestOrchestrations {
     public static AnyAOrB: any = df.orchestrator(function*(context: any) {
@@ -184,12 +185,7 @@ export class TestOrchestrations {
 
     public static SendHttpRequest: any = df.orchestrator(function*(context: any) {
         const input = context.df.getInput() as df.DurableHttpRequest;
-        const output = yield context.df.callHttp(
-            input.method,
-            input.uri,
-            input.content,
-            input.headers,
-            input.tokenSource);
+        const output = yield (context.df).callHttp(input);
         return output;
     });
 


### PR DESCRIPTION
Hi!, 

So I found that the data passed to the callHttp was wrong, and figure there were two different paths on passing parameters to functions, one is a comma-separated arguments, and the other being an object containing both of them.

Obviously I would love to unify this , but it might require braking changes for already exposed types.

## _callActivity_ 
We can see that a comma-separated parameters was used:
#### Described in Context Type:    
`callActivity(name: string, input?: unknown)`
#### Implemented in Orchestrator:  
`callActivity(state: HistoryEvent[], name: string, input?: unknown)`


## _callHttp_ 
Exposed type does not match the implemented signature of the orchestrator's method.
#### Described in Context Type:    
`callHttp(req: DurableHttpRequest)`
#### Implemented in Orchestrator:  
`callHttp(state: HistoryEvent[], method: string, uri: string, content?: string | object, headers?: { [key: string]: string }, tokenSource?: TokenSource)`


I would have prefer to fix this in a way that keep consistency high, BUT, I'd rather not break code.
Tho, no one might be using this method because it's not working at all, so we can consider to undo this PR and remove the `DurableHttpRequest` from the exposed type(DurableOrchestrationContext) 

Best,
JC