### PR TITLE
Fix tokenSource format issue in callHttp API

### DIFF
--- a/samples/ListAzureSubscriptions/function.json
+++ b/samples/ListAzureSubscriptions/function.json
@@ -1,0 +1,9 @@
+{
+  "bindings": [
+  {
+    "name": "context",
+    "type": "orchestrationTrigger",
+    "direction": "in"
+    }
+  ]
+}

--- a/samples/ListAzureSubscriptions/index.js
+++ b/samples/ListAzureSubscriptions/index.js
@@ -1,0 +1,13 @@
+const df = require("durable-functions");
+
+module.exports = df.orchestrator(function*(context) {
+    // More information on the use of managed identities in the callHttp API:
+    // https://docs.microsoft.com/azure/azure-functions/durable/durable-functions-http-features#managed-identities
+    var res = yield context.df.callHttp(
+        "GET",
+        "https://management.azure.com/subscriptions?api-version=2019-06-01",
+        undefined,
+        undefined,
+        new df.ManagedIdentityTokenSource("https://management.core.windows.net"));
+    return res;
+});

--- a/src/tokensource.ts
+++ b/src/tokensource.ts
@@ -17,7 +17,7 @@
  */
 export class ManagedIdentityTokenSource {
     /** @hidden */
-    public kind: "AzureManagedIdentity";
+    public readonly kind: string = "AzureManagedIdentity";
 
     /**
      * Returns a `ManagedIdentityTokenSource` object.

--- a/test/integration/orchestrator-spec.ts
+++ b/test/integration/orchestrator-spec.ts
@@ -709,15 +709,26 @@ describe("Orchestrator", () => {
 
             orchestrator(mockContext);
 
+            // This is the exact protocol expected by the durable extension
             expect(mockContext.doneValue).to.be.deep.equal(
-                new OrchestratorState({
+                {
                     isDone: false,
                     output: undefined,
                     actions:
-                    [
-                        [ new CallHttpAction(req) ],
-                    ],
-                }),
+                    [[{
+                        actionType: 8,
+                        httpRequest: {
+                            method: req.method,
+                            uri: req.uri,
+                            content: req.content,
+                            headers: req.headers,
+                            tokenSource: {
+                                resource: "https://management.core.windows.net",
+                                kind: "AzureManagedIdentity",
+                            },
+                        },
+                    }]],
+                },
             );
         });
 


### PR DESCRIPTION
There was an issue with the `callHttp` API where it didn't correctly encode token source values in a way that was understood by the Durable extension. If a user tried to use managed identities, they would see an error similar to the following:

> Could not create an instance of type Microsoft.Azure.WebJobs.Extensions.DurableTask.ITokenSource. Type is an interface or abstract class and cannot be instantiated. Path 'resource', line 11, position 25."

The problem was that the JSON returned by Durable JS that represented a `callHttp` action was missing the `kind` field that tells the durable extension parser how to interpret the token source data. The implementation of this field made incorrect assumptions about how TypeScript works. This field has been fixed.

The unit test for this was unfortunately flawed. It verified that `callHttp` produced the right TypeScript output but it failed to verify whether that TypeScript object correctly represented the JSON expected by the durable extension. I've fixed this test as well as part of the PR.

**Pending tasks**
- [x] Test end-to-end on Functions 2.0 host
- [x] Add sample function to demonstrate `callHttp` usage

FYI @mhoeger this is the issue you ran into!