### PR TITLE
Fix task.any() sorting and timer usage

### DIFF
--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -568,8 +568,8 @@ export class Orchestrator {
         const completedTasks = tasks
             .filter(TaskFilter.isSuccessfulSingleTask)
             .sort((a, b) => {
-                if (a.completedHistoryEventIndex > b.completedHistoryEventIndex) { return 1; }
-                if (a.completedHistoryEventIndex < b.completedHistoryEventIndex) { return -1; }
+                if (a.completionIndex > b.completionIndex) { return 1; }
+                if (a.completionIndex < b.completionIndex) { return -1; }
                 return 0;
             });
 

--- a/src/tasks/taskfilter.ts
+++ b/src/tasks/taskfilter.ts
@@ -33,7 +33,7 @@ export class TaskFilter {
     }
 
     public static isSuccessfulSingleTask(task: Task): task is SuccessfulSingleTask  {
-        return TaskFilter.isSingleTask(task) && task.isCompleted === true && task.isFaulted === false && task.result !== undefined;
+        return TaskFilter.isSingleTask(task) && task.isCompleted === true && task.isFaulted === false && task.completionIndex !== undefined;
     }
 
     public static isFailedTask(task: Task | TaskSet): task is FailedTask {

--- a/src/tasks/taskinterfaces.ts
+++ b/src/tasks/taskinterfaces.ts
@@ -17,7 +17,7 @@ export interface UncompletedSingleTask extends TaskBase {
 }
 
 export interface CompletedSingleTask extends SingleTask {
-    completedHistoryEventIndex: number;
+    completionIndex: number;
     readonly timestamp: Date;
     readonly id: number;
     readonly isCompleted: true;

--- a/test/testobjects/testhistories.ts
+++ b/test/testobjects/testhistories.ts
@@ -180,6 +180,114 @@ export class TestHistories {
         return history;
     }
 
+    public static GetTimerActivityRaceTimerWinsHistory(firstTimestamp: Date, iteration: number): HistoryEvent[] {
+        const firstIteration = moment(firstTimestamp);
+        const fireAt = firstIteration.add(1, "s").toDate();
+        const secondIteration = firstIteration.add(1100, "ms").toDate();
+        const finalIteration = firstIteration.add(2, "s").toDate();
+
+        const history = [];
+
+        if (iteration >= 1) {
+            history.push(new OrchestratorStartedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: false,
+            }));
+            history.push(new ExecutionStartedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: true,
+                name: "TimerActivityRace",
+            }));
+            history.push(new TimerCreatedEvent({
+                eventId: 0,
+                timestamp: firstTimestamp,
+                isPlayed: false,
+                fireAt,
+            }));
+            history.push(new TaskScheduledEvent({
+                eventId: 1,
+                timestamp: firstTimestamp,
+                isPlayed: iteration > 1,
+                name: "TaskA",
+            }));
+            history.push(new OrchestratorCompletedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: iteration > 1,
+            }));
+        }
+
+        if (iteration >= 2) {
+            history.push(new OrchestratorStartedEvent({
+                eventId: -1,
+                timestamp: secondIteration,
+                isPlayed: iteration > 2,
+            }));
+            history.push(new TimerFiredEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                fireAt,
+                isPlayed: iteration > 2,
+                timerId: 0,
+            }));
+            history.push(new TaskScheduledEvent({
+                eventId: 2,
+                timestamp: secondIteration,
+                isPlayed: iteration > 2,
+                name: "TaskB",
+            }));
+            history.push(new OrchestratorCompletedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: iteration > 2,
+            }));
+        }
+
+        if (iteration >= 3) {
+            history.push(new OrchestratorStartedEvent({
+                eventId: -1,
+                timestamp: thirdIteration,
+                isPlayed: iteration > 3,
+            }));
+            history.push(new TimerFiredEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                fireAt,
+                isPlayed: iteration > 3,
+                timerId: 0,
+            }));
+            history.push(new OrchestratorCompletedEvent({
+                eventId: -1,
+                timestamp: thirdIteration,
+                isPlayed: iteration > 3,
+            }));
+        }
+
+        if (iteration === 4) {
+            history.push(new OrchestratorStartedEvent({
+                eventId: -1,
+                timestamp: finalIteration,
+                isPlayed: false,
+            }));
+            history.push(new TaskCompletedEvent({
+                eventId: -1,
+                timestamp: thirdIteration,
+                isPlayed: false,
+                taskScheduledId: 2,
+                result: "{}",
+            }));
+            history.push(new OrchestratorCompletedEvent({
+                eventId: -1,
+                timestamp: finalIteration,
+                isPlayed: false,
+            }));
+        }
+
+        return history;
+    }
+
     public static GetCallEntitySet(firstTimestamp: Date, entityId: EntityId) {
         const firstMoment = moment(firstTimestamp);
         const orchestratorId = uuidv1();

--- a/test/testobjects/testhistories.ts
+++ b/test/testobjects/testhistories.ts
@@ -184,10 +184,8 @@ export class TestHistories {
         const firstIteration = moment(firstTimestamp);
         const fireAt = firstIteration.add(1, "s").toDate();
         const secondIteration = firstIteration.add(1100, "ms").toDate();
-        const finalIteration = firstIteration.add(2, "s").toDate();
 
         const history = [];
-
         if (iteration >= 1) {
             history.push(new OrchestratorStartedEvent({
                 eventId: -1,
@@ -231,57 +229,6 @@ export class TestHistories {
                 fireAt,
                 isPlayed: iteration > 2,
                 timerId: 0,
-            }));
-            history.push(new TaskScheduledEvent({
-                eventId: 2,
-                timestamp: secondIteration,
-                isPlayed: iteration > 2,
-                name: "TaskB",
-            }));
-            history.push(new OrchestratorCompletedEvent({
-                eventId: -1,
-                timestamp: firstTimestamp,
-                isPlayed: iteration > 2,
-            }));
-        }
-
-        if (iteration >= 3) {
-            history.push(new OrchestratorStartedEvent({
-                eventId: -1,
-                timestamp: thirdIteration,
-                isPlayed: iteration > 3,
-            }));
-            history.push(new TimerFiredEvent({
-                eventId: -1,
-                timestamp: firstTimestamp,
-                fireAt,
-                isPlayed: iteration > 3,
-                timerId: 0,
-            }));
-            history.push(new OrchestratorCompletedEvent({
-                eventId: -1,
-                timestamp: thirdIteration,
-                isPlayed: iteration > 3,
-            }));
-        }
-
-        if (iteration === 4) {
-            history.push(new OrchestratorStartedEvent({
-                eventId: -1,
-                timestamp: finalIteration,
-                isPlayed: false,
-            }));
-            history.push(new TaskCompletedEvent({
-                eventId: -1,
-                timestamp: thirdIteration,
-                isPlayed: false,
-                taskScheduledId: 2,
-                result: "{}",
-            }));
-            history.push(new OrchestratorCompletedEvent({
-                eventId: -1,
-                timestamp: finalIteration,
-                isPlayed: false,
             }));
         }
 


### PR DESCRIPTION
A regression was introduced in 1.3.2 that causes Task.any() to never select Timers, as well as a bug in the new sorting logic introduced in 1.3.2. These two bugs in combination ensured that the test "Task.all() and Task.any(): Timer in combination with Task.any() executes deterministically" passed. A new test has been added to ensure this regression does not reappear. 