### PR TITLE
Update DurableClient to support local RPC

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "node_modules\\typescript\\lib"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,15 @@
         "@types/chai": "*"
       }
     },
+    "@types/chai-string": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@types/chai-string/-/chai-string-1.4.1.tgz",
+      "integrity": "sha512-aRNMs6TKgjgPlCHwDfq/YNy5VtRR2hJ4AUWByddrT0TRVVD8eX4MiHW6/iHvmQHRlVuuPZcwnTUE7b4yFt7bEA==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*"
+      }
+    },
     "@types/commander": {
       "version": "2.3.31",
       "resolved": "https://registry.npmjs.org/@types/commander/-/commander-2.3.31.tgz",
@@ -214,6 +223,12 @@
       "requires": {
         "check-error": "^1.0.2"
       }
+    },
+    "chai-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/chai-string/-/chai-string-1.5.0.tgz",
+      "integrity": "sha512-sydDC3S3pNAQMYwJrs6dQX0oBQ6KfIPuOZ78n7rocW0eJJlsHPh2t3kwW7xfwYA/1Bf6/arGtSUo16rxR2JFlw==",
+      "dev": true
     },
     "chalk": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@types/chai": "~4.1.6",
+    "@types/chai-string": "~1.4.1",
     "@types/chai-as-promised": "~7.1.0",
     "@types/commander": "~2.3.31",
     "@types/debug": "0.0.29",
@@ -48,6 +49,7 @@
     "@types/rimraf": "0.0.28",
     "@types/sinon": "~5.0.5",
     "chai": "~4.2.0",
+    "chai-string": "~1.5.0",
     "chai-as-promised": "~7.1.1",
     "mocha": "~5.2.0",
     "moment": "~2.22.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "1.3.2",
   "description": "Durable Functions library for Node.js Azure Functions",
   "license": "MIT",
-  "repository": "github:Azure/azure-functions-durable-js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Azure/azure-functions-durable-js.git"
+  },
   "author": "Microsoft Corporation",
   "keywords": [
     "azure-functions"
@@ -61,5 +64,13 @@
   },
   "engines": {
     "node": ">=6.5.0"
+  },
+  "bugs": {
+    "url": "https://github.com/Azure/azure-functions-durable-js/issues"
+  },
+  "homepage": "https://github.com/Azure/azure-functions-durable-js#readme",
+  "directories": {
+    "lib": "lib",
+    "test": "test"
   }
 }

--- a/src/durableorchestrationclient.ts
+++ b/src/durableorchestrationclient.ts
@@ -5,7 +5,6 @@ import axios, { AxiosInstance, AxiosResponse } from "axios";
 import cloneDeep = require("lodash/cloneDeep");
 import process = require("process");
 import url = require("url");
-import uuid = require("uuid/v1");
 import { isURL } from "validator";
 import { Constants, DurableOrchestrationStatus, EntityId, EntityStateResponse,
     GetStatusOptions, HttpCreationPayload, HttpManagementPayload,
@@ -13,6 +12,8 @@ import { Constants, DurableOrchestrationStatus, EntityId, EntityStateResponse,
     OrchestrationRuntimeStatus, PurgeHistoryResult, Utils,
 } from "./classes";
 import { WebhookUtils } from "./webhookutils";
+
+const URL = url.URL;
 
 /**
  * Returns an OrchestrationClient instance.

--- a/src/entities/entityid.ts
+++ b/src/entities/entityid.ts
@@ -24,6 +24,7 @@ export class EntityId {
      */
     constructor(
         // TODO: consider how to name these fields more accurately without interfering with JSON serialization
+        // TODO: entity keys are supposed to be optional
         /** The name of the entity class. */
         public readonly name: string,
         /** The entity key. Uniquely identifies an entity among all instances of the same class. */

--- a/src/entities/entityid.ts
+++ b/src/entities/entityid.ts
@@ -24,7 +24,6 @@ export class EntityId {
      */
     constructor(
         // TODO: consider how to name these fields more accurately without interfering with JSON serialization
-        // TODO: entity keys are supposed to be optional
         /** The name of the entity class. */
         public readonly name: string,
         /** The entity key. Uniquely identifies an entity among all instances of the same class. */

--- a/src/orchestrationclientinputdata.ts
+++ b/src/orchestrationclientinputdata.ts
@@ -22,5 +22,6 @@ export class OrchestrationClientInputData {
         public managementUrls: HttpManagementPayload,
         public baseUrl?: string,
         public requiredQueryStringParameters?: string,
+        public rpcBaseUrl?: string,
     ) { }
 }

--- a/src/orchestrationfailureerror.ts
+++ b/src/orchestrationfailureerror.ts
@@ -6,17 +6,17 @@ const outOfProcDataLabel = "\n\n$OutOfProcData$:";
  * A wrapper for all errors thrown within an orchestrator function. This exception will embed
  * the orchestrator state in a way that the C# extension knows how to read so that it can replay the
  * actions scheduled before throwing an exception. This prevents non-determinism errors in Durable Task.
- * 
+ *
  * Note that making any changes to the following schema to OrchestrationFailureError.message could be considered a breaking change:
- * 
+ *
  * "<error message as a string>\n\n$OutOfProcData$<json representation of state>"
  */
 export class OrchestrationFailureError extends Error {
     constructor(error: any, state: OrchestratorState) {
-        let errorMessage : String;
+        let errorMessage: string;
         if (error instanceof Error) {
-            errorMessage= error.message;
-        } else if (error instanceof String) {
+            errorMessage = error.message;
+        } else if (typeof(error) === "string") {
             errorMessage = error;
         } else {
             errorMessage = JSON.stringify(error);

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -592,7 +592,7 @@ export class Orchestrator {
         switch (directiveResult.EventType) {
             case (HistoryEventType.EventRaised):
                 const eventRaised = directiveResult as EventRaisedEvent;
-                parsedDirectiveResult = (eventRaised && eventRaised.Input) 
+                parsedDirectiveResult = (eventRaised && eventRaised.Input)
                     ? JSON.parse(eventRaised.Input) : undefined;
                 break;
             case (HistoryEventType.SubOrchestrationInstanceCompleted):

--- a/src/webhookutils.ts
+++ b/src/webhookutils.ts
@@ -19,7 +19,15 @@ export class WebhookUtils {
         return requestUrl;
     }
 
-    public static getSignalEntityUrl(baseUrl: string, requiredQueryStrings: string, entityName: string, entityKey: string, operationName?: string, taskHubName?: string, connectionName?: string) {
+    public static getSignalEntityUrl(
+        baseUrl: string,
+        requiredQueryStrings: string,
+        entityName: string,
+        entityKey: string,
+        operationName?: string,
+        taskHubName?: string,
+        connectionName?: string,
+    ) {
         let requestUrl = baseUrl + "/entities/"
         + entityName + "/"
         + entityKey + "?";

--- a/test/unit/durableclient-spec.ts
+++ b/test/unit/durableclient-spec.ts
@@ -17,6 +17,7 @@ chai.use(chaiString);
 const expect = chai.expect;
 const URL = url.URL;
 
+// DNS failures are expected if we accidentally try to reach this fake domain (durable.gov).
 const externalOrigin = "https://durable.gov";
 const externalBaseUrl = `${externalOrigin}/runtime/webhooks/durableTask`;
 const testRpcOrigin = "http://127.0.0.1:17071";

--- a/test/unit/durableclient-spec.ts
+++ b/test/unit/durableclient-spec.ts
@@ -1,11 +1,21 @@
 import { HttpRequest } from "@azure/functions";
 import chai = require("chai");
 import chaiString = require("chai-string");
-import { DurableOrchestrationClient, HttpManagementPayload, OrchestrationClientInputData, OrchestrationRuntimeStatus } from "../../src/classes";
 import nock = require("nock");
+import url = require("url");
+import {
+    DurableOrchestrationClient,
+    EntityId,
+    EntityStateResponse,
+    HttpManagementPayload,
+    OrchestrationClientInputData,
+    OrchestrationRuntimeStatus,
+    PurgeHistoryResult,
+} from "../../src/classes";
 
 chai.use(chaiString);
 const expect = chai.expect;
+const URL = url.URL;
 
 const externalOrigin = "https://durable.gov";
 const externalBaseUrl = `${externalOrigin}/runtime/webhooks/durableTask`;
@@ -30,7 +40,7 @@ const durableClientBindingInputJson = JSON.stringify({
     rpcBaseUrl: testRpcBaseUrl,
 });
 
-describe("Durable Client", () => {
+describe("Durable client RPC endpoint", () => {
     before(() => {
         if (!nock.isActive()) {
             nock.activate();
@@ -69,7 +79,7 @@ describe("Durable Client", () => {
             const response = client.createCheckStatusResponse(request, instanceId);
             const payload = response.body as HttpManagementPayload;
 
-            expect(payload).is.not.undefined;
+            expect(payload).is.an("object");
             expect(payload.id).to.be.equal(instanceId);
 
             // Verify that even when using local RPC, we still expose the external
@@ -119,9 +129,8 @@ describe("Durable Client", () => {
                 .post(expectedUrl.pathname, eventData)
                 .reply(202);
 
-            const result = await client.raiseEvent(instanceId, eventName, eventData);
+            await client.raiseEvent(instanceId, eventName, eventData);
             expect(scope.isDone()).to.be.equal(true);
-            expect(result).to.be.undefined;
         });
 
         it("uses the RPC endpoint (with query params)", async () => {
@@ -143,9 +152,8 @@ describe("Durable Client", () => {
                 .query({ taskHub, connection })
                 .reply(202);
 
-            const result = await client.raiseEvent(instanceId, eventName, eventData, taskHub, connection);
+            await client.raiseEvent(instanceId, eventName, eventData, taskHub, connection);
             expect(scope.isDone()).to.be.equal(true);
-            expect(result).to.be.undefined;
         });
     });
 
@@ -204,7 +212,7 @@ describe("Durable Client", () => {
             const input = JSON.parse(durableClientBindingInputJson) as OrchestrationClientInputData;
             const client = new DurableOrchestrationClient(input);
 
-            // The getStatus() method should do a GET to http://127.0.0.1:17071/durabletask/instances/?createdTimeFrom=2020-01-01T00:00:00Z&createdTimeTo=2020-01-01T23:59:59Z&runtimeStatus=Pending,Running,Completed,Terminated,Failed
+            // The getStatusBy() method should do a GET to http://127.0.0.1:17071/durabletask/instances/?createdTimeFrom=2020-01-01T00:00:00Z&createdTimeTo=2020-01-01T23:59:59Z&runtimeStatus=Pending,Running,Completed,Terminated,Failed
             const expectedUrl = new URL(`${testRpcOrigin}/durabletask/instances/`);
             const createdTimeFrom = "2020-01-01T00:00:00.000Z";
             const createdTimeTo = "2020-01-01T23:59:59.000Z";
@@ -223,6 +231,193 @@ describe("Durable Client", () => {
                 statusList);
             expect(scope.isDone()).to.be.equal(true);
             expect(result).to.be.an("array");
+        });
+    });
+
+    describe("terminate()", () => {
+        it("uses the RPC endpoint", async () => {
+            const input = JSON.parse(durableClientBindingInputJson) as OrchestrationClientInputData;
+            const client = new DurableOrchestrationClient(input);
+
+            // The terminate() method should do a POST to http://127.0.0.1:17071/durabletask/instances/abc123/terminate?reason=because
+            const instanceId = "abc123";
+            const reason = "because";
+            const expectedUrl = new URL(`${testRpcOrigin}/durabletask/instances/${instanceId}/terminate?reason=${reason}`);
+
+            const scope = nock(expectedUrl.origin)
+                .post(expectedUrl.pathname + expectedUrl.search)
+                .reply(202);
+
+            await client.terminate(instanceId, reason);
+            expect(scope.isDone()).to.be.equal(true);
+        });
+    });
+
+    describe("purgeInstanceHistory[By]()", () => {
+        it ("uses the RPC endpoint (single instance)", async () => {
+            const input = JSON.parse(durableClientBindingInputJson) as OrchestrationClientInputData;
+            const client = new DurableOrchestrationClient(input);
+
+            // The purgeInstanceHistory() method should do a DELETE to http://127.0.0.1:17071/durabletask/instances/abc123
+            const instanceId = "abc123";
+            const expectedUrl = new URL(`${testRpcOrigin}/durabletask/instances/${instanceId}`);
+
+            const scope = nock(expectedUrl.origin)
+                .delete(expectedUrl.pathname)
+                .reply(200, { instancesDeleted: 1 });
+
+            const result: PurgeHistoryResult = await client.purgeInstanceHistory(instanceId);
+            expect(scope.isDone()).to.be.equal(true);
+            expect(result.instancesDeleted).to.be.equal(1);
+        });
+
+        it ("uses the RPC endpoint (multiple instances)", async () => {
+            const input = JSON.parse(durableClientBindingInputJson) as OrchestrationClientInputData;
+            const client = new DurableOrchestrationClient(input);
+
+            // The purgeInstanceHistoryBy() method should do a DELETE to
+            // http://127.0.0.1:17071/durabletask/instances/?createdTimeFrom=2020-01-01T00:00:00Z&createdTimeTo=2020-01-01T23:59:59Z&runtimeStatus=Pending,Running,Completed,Terminated,Failed
+            const expectedUrl = new URL(`${testRpcOrigin}/durabletask/instances/`);
+            const createdTimeFrom = "2020-01-01T00:00:00.000Z";
+            const createdTimeTo = "2020-01-01T23:59:59.000Z";
+            const runtimeStatus = "Pending,Running,Completed,Terminated,Failed";
+
+            const scope = nock(expectedUrl.origin)
+                .delete(expectedUrl.pathname)
+                .query({ createdTimeFrom, createdTimeTo, runtimeStatus })
+                .reply(200, { instancesDeleted: 10 });
+
+            const statusList = runtimeStatus.split(",").map(
+                (status) => OrchestrationRuntimeStatus[status as keyof typeof OrchestrationRuntimeStatus]);
+            const result: PurgeHistoryResult = await client.purgeInstanceHistoryBy(
+                new Date(createdTimeFrom),
+                new Date(createdTimeTo),
+                statusList);
+            expect(scope.isDone()).to.be.equal(true);
+            expect(result.instancesDeleted).to.be.equal(10);
+        });
+    });
+
+    describe("rewind()", () => {
+        it("uses the RPC endpoint (no optional query params)", async () => {
+            const input = JSON.parse(durableClientBindingInputJson) as OrchestrationClientInputData;
+            const client = new DurableOrchestrationClient(input);
+
+            // The rewind() method should do a POST to http://127.0.0.1:17071/durabletask/instances/abc123/rewind?reason=because
+            const instanceId = "abc123";
+            const reason = "because";
+            const expectedUrl = new URL(`${testRpcOrigin}/durabletask/instances/${instanceId}/rewind?reason=${reason}`);
+
+            const scope = nock(expectedUrl.origin)
+                .post(expectedUrl.pathname + expectedUrl.search)
+                .reply(202);
+
+            await client.rewind(instanceId, reason);
+            expect(scope.isDone()).to.be.equal(true);
+        });
+
+        it("uses the RPC endpoint (all query params)", async () => {
+            const input = JSON.parse(durableClientBindingInputJson) as OrchestrationClientInputData;
+            const client = new DurableOrchestrationClient(input);
+
+            // The rewind() method should do a POST to http://127.0.0.1:17071/durabletask/instances/abc123/rewind?reason=because&taskHub=hub&connection=Storage
+            const instanceId = "abc123";
+            const reason = "because";
+            const taskHub = "hub";
+            const connection = "Storage";
+            const expectedUrl = new URL(`${testRpcOrigin}/durabletask/instances/${instanceId}/rewind?reason=${reason}&taskHub=${taskHub}&connection=${connection}`);
+
+            const scope = nock(expectedUrl.origin)
+                .post(expectedUrl.pathname)
+                .query({ reason, taskHub, connection })
+                .reply(202);
+
+            await client.rewind(instanceId, reason, taskHub, connection);
+            expect(scope.isDone()).to.be.equal(true);
+        });
+    });
+
+    describe("signalEntity()", () => {
+        it("uses the RPC endpoint (no arguments)", async () => {
+            const input = JSON.parse(durableClientBindingInputJson) as OrchestrationClientInputData;
+            const client = new DurableOrchestrationClient(input);
+
+            // The signalEntity() method should do a POST to http://127.0.0.1:17071/durabletask/entities/counter/abc123?op=MyEvent
+            const entityId = new EntityId("counter", "abc123");
+            const expectedUrl = new URL(`${testRpcOrigin}/durabletask/entities/${entityId.name}/${entityId.key}`);
+
+            const scope = nock(expectedUrl.origin)
+                .post(expectedUrl.pathname)
+                .reply(202);
+
+            await client.signalEntity(entityId);
+            expect(scope.isDone()).to.be.equal(true);
+        });
+
+        it("uses the RPC endpoint (with all arguments)", async () => {
+            const input = JSON.parse(durableClientBindingInputJson) as OrchestrationClientInputData;
+            const client = new DurableOrchestrationClient(input);
+
+            // The signalEntity() method should do a POST to http://127.0.0.1:17071/durabletask/entities/counter/abc123?op=incr&taskHub=hub&connection=Storage
+            // with a application/json payload matching { "value": 42 }.
+            const entityId = new EntityId("counter", "abc123");
+            const taskHub = "hub";
+            const connection = "Storage";
+            const op = "incr";
+            const payload = { value: 42 };
+            const expectedUrl = new URL(`${testRpcOrigin}/durabletask/entities/${entityId.name}/${entityId.key}?op=${op}&taskHub=${taskHub}&connection=${connection}`);
+            const expectedHeaders = { reqheaders: { "Content-Type": "application/json" } };
+
+            const scope = nock(expectedUrl.origin, expectedHeaders)
+                .post(expectedUrl.pathname, payload)
+                .query({ op, taskHub, connection })
+                .reply(202);
+
+            await client.signalEntity(entityId, op, payload, taskHub, connection);
+            expect(scope.isDone()).to.equal(true);
+        });
+    });
+
+    describe("readEntityState()", () => {
+        it("uses the RPC endpoint (no optional params)", async () => {
+            const input = JSON.parse(durableClientBindingInputJson) as OrchestrationClientInputData;
+            const client = new DurableOrchestrationClient(input);
+
+            // The readEntityState() method should do a GET to http://127.0.0.1:17071/durabletask/entities/counter/abc123
+            const entityId = new EntityId("counter", "abc123");
+            const expectedUrl = new URL(`${testRpcOrigin}/durabletask/entities/${entityId.name}/${entityId.key}`);
+            const expectedEntityState = 5;
+
+            const scope = nock(expectedUrl.origin)
+                .get(expectedUrl.pathname)
+                .reply(200, expectedEntityState);
+
+            const result: EntityStateResponse<number> = await client.readEntityState<number>(entityId);
+            expect(scope.isDone()).to.equal(true);
+            expect(result.entityExists).to.equal(true);
+            expect(result.entityState).to.equal(expectedEntityState);
+        });
+
+        it("uses the RPC endpoint (with optional params)", async () => {
+            const input = JSON.parse(durableClientBindingInputJson) as OrchestrationClientInputData;
+            const client = new DurableOrchestrationClient(input);
+
+            // The readEntityState() method should do a GET to http://127.0.0.1:17071/durabletask/entities/counter/abc123?taskHub=hub&connection=Storage
+            const entityId = new EntityId("counter", "abc123");
+            const expectedUrl = new URL(`${testRpcOrigin}/durabletask/entities/${entityId.name}/${entityId.key}`);
+            const taskHub = "hub";
+            const connection = "Storage";
+            const expectedEntityState = { value: 42 };
+
+            const scope = nock(expectedUrl.origin)
+                .get(expectedUrl.pathname)
+                .query({ taskHub, connection })
+                .reply(200, expectedEntityState);
+
+            const result = await client.readEntityState(entityId, taskHub, connection);
+            expect(scope.isDone()).to.equal(true);
+            expect(result.entityExists).to.equal(true);
+            expect(result.entityState).to.deep.equal(expectedEntityState);
         });
     });
 });

--- a/test/unit/durableclient-spec.ts
+++ b/test/unit/durableclient-spec.ts
@@ -1,0 +1,228 @@
+import { HttpRequest } from "@azure/functions";
+import chai = require("chai");
+import chaiString = require("chai-string");
+import { DurableOrchestrationClient, HttpManagementPayload, OrchestrationClientInputData, OrchestrationRuntimeStatus } from "../../src/classes";
+import nock = require("nock");
+
+chai.use(chaiString);
+const expect = chai.expect;
+
+const externalOrigin = "https://durable.gov";
+const externalBaseUrl = `${externalOrigin}/runtime/webhooks/durableTask`;
+const testRpcOrigin = "http://127.0.0.1:17071";
+const testRpcBaseUrl = `${testRpcOrigin}/durabletask/`;
+const testTaskHubName = "MyTaskHub";
+const testConnectionName = "MyStorageAccount";
+
+// We start with the JSON that matches the expected contract.
+const durableClientBindingInputJson = JSON.stringify({
+    taskHubName: testTaskHubName,
+    creationUrls: { },
+    managementUrls: {
+        id: "INSTANCEID",
+        statusQueryGetUri: `${externalBaseUrl}/instances/INSTANCEID?taskHub=${testTaskHubName}&connection=${testConnectionName}`,
+        sendEventPostUri: `${externalBaseUrl}/instances/INSTANCEID/raiseEvent/{eventName}?taskHub=${testTaskHubName}&connection=${testConnectionName}`,
+        terminatePostUri: `${externalBaseUrl}/instances/INSTANCEID/?taskHub=${testTaskHubName}&connection=${testConnectionName}`,
+        rewindPostUri: `${externalBaseUrl}/instances/INSTANCEID/?taskHub=${testTaskHubName}&connection=${testConnectionName}`,
+        purgeHistoryDeleteUri: `${externalBaseUrl}/instances/INSTANCEID/?taskHub=${testTaskHubName}&connection=${testConnectionName}`,
+    },
+    baseUrl: externalBaseUrl,
+    rpcBaseUrl: testRpcBaseUrl,
+});
+
+describe("Durable Client", () => {
+    before(() => {
+        if (!nock.isActive()) {
+            nock.activate();
+        }
+    });
+
+    after(() => {
+        nock.restore();
+    });
+
+    describe("initialization", () => {
+        it("deserializes the durable client JSON schema correctly", () => {
+            // cast the JSON into the typed object
+            const input = JSON.parse(durableClientBindingInputJson) as OrchestrationClientInputData;
+            expect(input.taskHubName).to.be.equal(testTaskHubName);
+            expect(input.rpcBaseUrl).to.be.equal(testRpcBaseUrl);
+            expect(input.managementUrls).to.be.an("object");
+            expect(input.managementUrls.id).to.be.equal("INSTANCEID");
+            expect(input.managementUrls.statusQueryGetUri).to.startsWith(externalBaseUrl);
+        });
+    });
+
+    describe("createCheckStatusResponse()", () => {
+        it("does NOT reference the RPC endpoint", async () => {
+            const input = JSON.parse(durableClientBindingInputJson) as OrchestrationClientInputData;
+            const client = new DurableOrchestrationClient(input);
+            const request: HttpRequest = {
+                method: "GET",
+                url: `${externalOrigin}/api/Foo`,
+                headers: { },
+                query: { },
+                params: { },
+            };
+
+            const instanceId = "abc123";
+            const response = client.createCheckStatusResponse(request, instanceId);
+            const payload = response.body as HttpManagementPayload;
+
+            expect(payload).is.not.undefined;
+            expect(payload.id).to.be.equal(instanceId);
+
+            // Verify that even when using local RPC, we still expose the external
+            // URLs in the createCheckStatusResponse API result.
+            expect(payload.purgeHistoryDeleteUri).to.startWith(externalBaseUrl);
+            expect(payload.rewindPostUri).to.startWith(externalBaseUrl);
+            expect(payload.sendEventPostUri).to.startWith(externalBaseUrl);
+            expect(payload.statusQueryGetUri).to.startWith(externalBaseUrl);
+            expect(payload.terminatePostUri).to.startWith(externalBaseUrl);
+        });
+    });
+
+    describe("startNew()", () => {
+        it("uses the RPC endpoint", async () => {
+            const input = JSON.parse(durableClientBindingInputJson) as OrchestrationClientInputData;
+            const client = new DurableOrchestrationClient(input);
+
+            // The startNew() method should do a POST to http://127.0.0.1:17071/durabletask/orchestrators/MyFunction
+            const functionName = "MyFunction";
+            const expectedUrl = new URL(`${testRpcOrigin}/durabletask/orchestrators/${functionName}`);
+            const expectedHeaders = { reqheaders: { "Content-Type": "application/json" } };
+
+            const scope = nock(expectedUrl.origin, expectedHeaders)
+                .post(expectedUrl.pathname)
+                .reply(202, { id: "abc123" });
+
+            const result = await client.startNew(functionName);
+            expect(scope.isDone()).to.be.equal(true);
+            expect(result).to.be.equal("abc123");
+        });
+    });
+
+    describe("raiseEvent()", () => {
+        it("uses the RPC endpoint (no query params)", async () => {
+            const input = JSON.parse(durableClientBindingInputJson) as OrchestrationClientInputData;
+            const client = new DurableOrchestrationClient(input);
+
+            // The raiseEvent() method should do a POST to http://127.0.0.1:17071/durabletask/instances/abc123/raiseEvent/MyEvent
+            // with a application/json payload matching { "value": 5 }.
+            const instanceId = "abc123";
+            const eventName = "MyEvent";
+            const eventData = { value: 5 };
+            const expectedUrl = new URL(`${testRpcOrigin}/durabletask/instances/${instanceId}/raiseEvent/${eventName}`);
+            const expectedHeaders = { reqheaders: { "Content-Type": "application/json" } };
+
+            const scope = nock(expectedUrl.origin, expectedHeaders)
+                .post(expectedUrl.pathname, eventData)
+                .reply(202);
+
+            const result = await client.raiseEvent(instanceId, eventName, eventData);
+            expect(scope.isDone()).to.be.equal(true);
+            expect(result).to.be.undefined;
+        });
+
+        it("uses the RPC endpoint (with query params)", async () => {
+            const input = JSON.parse(durableClientBindingInputJson) as OrchestrationClientInputData;
+            const client = new DurableOrchestrationClient(input);
+
+            // The raiseEvent() method should do a POST to http://127.0.0.1:17071/durabletask/instances/abc123/raiseEvent/MyEvent?taskHub=hub&connection=Storage
+            // with a application/json payload matching { "value": 42 }.
+            const instanceId = "abc123";
+            const eventName = "MyEvent";
+            const taskHub = "hub";
+            const connection = "Storage";
+            const eventData = { value: 42 };
+            const expectedUrl = new URL(`${testRpcOrigin}/durabletask/instances/${instanceId}/raiseEvent/${eventName}`);
+            const expectedHeaders = { reqheaders: { "Content-Type": "application/json" } };
+
+            const scope = nock(expectedUrl.origin, expectedHeaders)
+                .post(expectedUrl.pathname, eventData)
+                .query({ taskHub, connection })
+                .reply(202);
+
+            const result = await client.raiseEvent(instanceId, eventName, eventData, taskHub, connection);
+            expect(scope.isDone()).to.be.equal(true);
+            expect(result).to.be.undefined;
+        });
+    });
+
+    describe("getStatus()", () => {
+        it("uses the RPC endpoint (no query params)", async () => {
+            const input = JSON.parse(durableClientBindingInputJson) as OrchestrationClientInputData;
+            const client = new DurableOrchestrationClient(input);
+
+            // The getStatus() method should do a GET to http://127.0.0.1:17071/durabletask/instances/abc123
+            const instanceId = "abc123";
+            const expectedUrl = new URL(`${testRpcOrigin}/durabletask/instances/${instanceId}`);
+
+            const scope = nock(expectedUrl.origin)
+                .get(expectedUrl.pathname)
+                .reply(202, {
+                    createdTime: "2020-01-01T05:00:00Z",
+                    lastUpdatedTime: "2020-01-01T05:00:00Z",
+                    runtimeStatus: "Running",
+                });
+
+            const result = await client.getStatus(instanceId);
+            expect(scope.isDone()).to.be.equal(true);
+            expect(result).to.be.an("object");
+        });
+
+        it("uses the RPC endpoint (with all query params)", async () => {
+            const input = JSON.parse(durableClientBindingInputJson) as OrchestrationClientInputData;
+            const client = new DurableOrchestrationClient(input);
+
+            // The getStatus() method should do a GET to http://127.0.0.1:17071/durabletask/instances/abc123?showInput=true&showHistory=true&showHistoryOutput=true
+            const instanceId = "abc123";
+            const expectedUrl = new URL(`${testRpcOrigin}/durabletask/instances/${instanceId}`);
+
+            const scope = nock(expectedUrl.origin)
+                .get(expectedUrl.pathname)
+                .query({
+                    showInput: true,
+                    showHistory: true,
+                    showHistoryOutput: true,
+                })
+                .reply(202, {
+                    createdTime: "2020-01-01T05:00:00Z",
+                    lastUpdatedTime: "2020-01-01T05:00:00Z",
+                    runtimeStatus: "Pending",
+                    history: [],
+                });
+
+            const result = await client.getStatus(instanceId, true, true, true);
+            expect(scope.isDone()).to.be.equal(true);
+            expect(result).to.be.an("object");
+        });
+    });
+
+    describe("getStatusBy()", () => {
+        it("uses the RPC endpoint (all query params)", async () => {
+            const input = JSON.parse(durableClientBindingInputJson) as OrchestrationClientInputData;
+            const client = new DurableOrchestrationClient(input);
+
+            // The getStatus() method should do a GET to http://127.0.0.1:17071/durabletask/instances/?createdTimeFrom=2020-01-01T00:00:00Z&createdTimeTo=2020-01-01T23:59:59Z&runtimeStatus=Pending,Running,Completed,Terminated,Failed
+            const expectedUrl = new URL(`${testRpcOrigin}/durabletask/instances/`);
+            const createdTimeFrom = "2020-01-01T00:00:00.000Z";
+            const createdTimeTo = "2020-01-01T23:59:59.000Z";
+            const runtimeStatus = "Pending,Running,Completed,Terminated,Failed";
+
+            const scope = nock(expectedUrl.origin)
+                .get(expectedUrl.pathname)
+                .query({ createdTimeFrom, createdTimeTo, runtimeStatus })
+                .reply(200, []);
+
+            const statusList = runtimeStatus.split(",").map(
+                (status) => OrchestrationRuntimeStatus[status as keyof typeof OrchestrationRuntimeStatus]);
+            const result = await client.getStatusBy(
+                new Date(createdTimeFrom),
+                new Date(createdTimeTo),
+                statusList);
+            expect(scope.isDone()).to.be.equal(true);
+            expect(result).to.be.an("array");
+        });
+    });
+});

--- a/test/unit/orchestrationclient-spec.ts
+++ b/test/unit/orchestrationclient-spec.ts
@@ -290,7 +290,7 @@ describe("Orchestration Client", () => {
             const scope = nock(expectedWebhookUrl.origin)
                 .get(expectedWebhookUrl.pathname)
                 .query((actualQueryObject: object) => urlQueryEqualsQueryObject(expectedWebhookUrl, actualQueryObject))
-                .reply(202, expectedStatuses);
+                .reply(200, expectedStatuses);
 
             const result = await client.getStatusAll();
             expect(scope.isDone()).to.be.equal(true);
@@ -335,7 +335,7 @@ describe("Orchestration Client", () => {
             const scope = nock(expectedWebhookUrl.origin)
                 .get(expectedWebhookUrl.pathname)
                 .query((actualQueryObject: object) => urlQueryEqualsQueryObject(expectedWebhookUrl, actualQueryObject))
-                .reply(202, expectedStatuses);
+                .reply(200, expectedStatuses);
 
             const result = await client.getStatusBy(createdTimeFrom, createdTimeTo, runtimeStatuses);
             expect(scope.isDone()).to.be.equal(true);
@@ -355,7 +355,7 @@ describe("Orchestration Client", () => {
             const scope = nock(expectedWebhookUrl.origin)
                 .get(expectedWebhookUrl.pathname)
                 .query((actualQueryObject: object) => urlQueryEqualsQueryObject(expectedWebhookUrl, actualQueryObject))
-                .reply(202, expectedStatuses);
+                .reply(200, expectedStatuses);
 
             const result = await client.getStatusBy(undefined, undefined, runtimeStatuses);
             expect(scope.isDone()).to.be.equal(true);
@@ -716,10 +716,10 @@ describe("Orchestration Client", () => {
             const scope = nock(expectedWebhookUrl.origin, requiredPostHeaders)
                 .post(expectedWebhookUrl.pathname)
                 .query((actualQueryObject: object) => urlQueryEqualsQueryObject(expectedWebhookUrl, actualQueryObject))
-                .reply(500);
+                .reply(500, { error: "Something blew up!" });
 
             await expect(client.rewind(testId, testReason)).to.be
-                .rejectedWith(`Webhook returned unrecognized status code 500`);
+                .rejectedWith(`The operation failed with an unexpected status code: 500. Details: {"error":"Something blew up!"}`);
             expect(scope.isDone()).to.be.equal(true);
         });
     });
@@ -904,10 +904,10 @@ describe("Orchestration Client", () => {
             const scope = nock(expectedWebhookUrl.origin, requiredPostHeaders)
                 .post(expectedWebhookUrl.pathname)
                 .query((actualQueryObject: object) => urlQueryEqualsQueryObject(expectedWebhookUrl, actualQueryObject))
-                .reply(500);
+                .reply(500, "Kah-BOOOM!!");
 
             await expect(client.terminate(id, testReason)).to.be
-                .rejectedWith(`Webhook returned unrecognized status code 500`);
+                .rejectedWith(`The operation failed with an unexpected status code: 500. Details: "Kah-BOOOM!!"`);
             expect(scope.isDone()).to.be.equal(true);
         });
     });


### PR DESCRIPTION
As part of [this Durable Extension PR](https://github.com/Azure/azure-functions-durable-extension/pull/1166), we're exposting a local RPC endpoint so that the Durable Client binding can make local RPC calls into the extension rather than making HTTP requests that route through the FE.

Fixes https://github.com/Azure/azure-functions-durable-js/issues/62
Fixes https://github.com/Azure/azure-functions-durable-js/issues/86
Fixes https://github.com/Azure/azure-functions-durable-js/issues/90
Fixes https://github.com/Azure/azure-functions-durable-js/issues/150


Some important notes:
* This change is intended to be 100% backwards compatible with previous extension versions.
* I created a new test file, `durableclient-spec.ts`, for testing the new code paths.
* The existing `durableorchestrationclient-spec.ts` will remain for validating the back-compat behavior.

Remaining work:
- [x] Implement all client APIs
- [x] End-to-end validation in func.exe
- [x] End-to-end validation in Azure
- [x] Full unit test coverage
- [x] Fix linting warnings
- [x] End to end validation of _all APIs_ in Azure with Easy Auth enabled
