### PR TITLE
Allow task sets in df.task.all and df.task.any

### DIFF
--- a/src/aggregatederror.ts
+++ b/src/aggregatederror.ts
@@ -1,0 +1,27 @@
+const separator = "-----------------------------------";
+
+/**
+ * A specfic error thrown when context.df.Task.all() fails. Its message
+ * contains an aggregation of all the exceptions that failed. It should follow the
+ * below format:
+ *
+ * context.df.Task.all() encountered the below error messages:
+ *
+ * Name: DurableError
+ * Message: The activity function "ActivityA" failed.
+ * StackTrace: <stacktrace>
+ * -----------------------------------
+ * Name: DurableError
+ * Message: The activity function "ActivityB" failed.
+ * StackTrace: <stacktrace>
+ */
+export class AggregatedError extends Error {
+    public errors: Error[];
+
+    constructor(errors: Error[]) {
+        const errorStrings = errors.map((error, num) => `Name: ${error.name}\nMessage: ${error.message}\nStackTrace: ${error.stack}`);
+        const message = `context.df.Task.all() encountered the below error messages:\n\n${errorStrings.join(`\n${separator}\n`)}`;
+        super(message);
+        this.errors = errors;
+    }
+}

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -550,6 +550,7 @@ export class Orchestrator {
 
             const failedTasks = completedTasks.filter(TaskFilter.isFailedTask);
             if (failedTasks.length > 0) {
+                // TODO: aggregate all failures into one clean error.
                 return TaskFactory.FailedTaskSet(tasks, completionIndex, (failedTasks[0] as FailedTask).exception);
             } else {
                 const results = completedTasks.map((task) => task.result);

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -546,9 +546,14 @@ export class Orchestrator {
     private all(state: HistoryEvent[], tasks: TaskBase[]): TaskSet {
         const completedTasks = tasks.filter(TaskFilter.isCompletedTask);
         if (completedTasks.length === tasks.length) {
-            const completionIndex = Math.max.apply(
+            const maximumCompletionIndex = Math.max.apply(
                 null,
                 completedTasks.map((task) => task.completionIndex));
+
+            // Add a small amount to the completion index for the task
+            // returned by this method, so that it doesn't tie with
+            // its child task that finished last.
+            const completionIndex = maximumCompletionIndex + .0001;
 
             const failedTasks = completedTasks.filter(TaskFilter.isFailedTask);
             if (failedTasks.length > 0) {

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -113,7 +113,7 @@ export class Orchestrator {
                 }
 
                 partialResult = g.value as TaskBase;
-                let newActions = partialResult.yield();
+                const newActions = partialResult.yieldNewActions();
                 if (newActions && newActions.length > 0) {
                     actions.push(newActions);
                 }
@@ -545,8 +545,8 @@ export class Orchestrator {
     private all(state: HistoryEvent[], tasks: TaskBase[]): TaskSet {
         const completedTasks = tasks.filter(TaskFilter.isCompletedTask);
         if (completedTasks.length === tasks.length) {
-            const sortedTasks = completedTasks.sort(TaskFilter.CompareFinishedTime) 
-            const completionIndex = sortedTasks[tasks.length-1].completionIndex;
+            const sortedTasks = completedTasks.sort(TaskFilter.CompareFinishedTime);
+            const completionIndex = sortedTasks[tasks.length - 1].completionIndex;
 
             const failedTasks = completedTasks.filter(TaskFilter.isFailedTask);
             if (failedTasks.length > 0) {

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -1,5 +1,5 @@
 import { IAction } from "../classes";
-import { SingleTask } from "./taskinterfaces";
+import { TaskBase } from "./taskinterfaces";
 
 /**
  * Represents some pending action. Similar to a native JavaScript promise in
@@ -33,12 +33,12 @@ import { SingleTask } from "./taskinterfaces";
  * return firstDone.result;
  * ```
  */
-export class Task implements SingleTask {
+export class Task implements TaskBase {
     /**
      * Used to keep track of how many times the task has been yielded to avoid
      * scheduling the internal action multiple times _Internal use only._
      */
-    public wasYielded = false;
+    private wasYielded = false;
 
     /** @hidden */
     constructor(
@@ -79,4 +79,17 @@ export class Task implements SingleTask {
          */
         public readonly completionIndex?: number,
     ) { }
+
+    getCompletionIndex(): number | undefined {
+        return this.completionIndex;
+    }
+
+    yield(): IAction[] {
+        if (!this.wasYielded) {
+            this.wasYielded = true;
+            return [ this.action ];
+        }
+        
+        return [];
+    }
 }

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -80,16 +80,15 @@ export class Task implements TaskBase {
         public readonly completionIndex?: number,
     ) { }
 
-    getCompletionIndex(): number | undefined {
-        return this.completionIndex;
-    }
-
-    yield(): IAction[] {
+    /**
+     * _Internal use only._
+     */
+    public yieldNewActions(): IAction[] {
         if (!this.wasYielded) {
             this.wasYielded = true;
             return [ this.action ];
         }
-        
+
         return [];
     }
 }

--- a/src/tasks/taskfactory.ts
+++ b/src/tasks/taskfactory.ts
@@ -1,8 +1,8 @@
 import { CreateTimerAction, IAction } from "../classes";
 import { Task} from "./task";
+import { TaskBase} from "./taskinterfaces";
 import { TaskSet } from "./taskset";
 import { TimerTask } from "./timertask";
-import { TaskBase} from "./taskinterfaces";
 
 export class TaskFactory {
     public static UncompletedTask(action: IAction): Task {

--- a/src/tasks/taskfactory.ts
+++ b/src/tasks/taskfactory.ts
@@ -2,6 +2,7 @@ import { CreateTimerAction, IAction } from "../classes";
 import { Task} from "./task";
 import { TaskSet } from "./taskset";
 import { TimerTask } from "./timertask";
+import { TaskBase} from "./taskinterfaces";
 
 export class TaskFactory {
     public static UncompletedTask(action: IAction): Task {
@@ -42,31 +43,34 @@ export class TaskFactory {
         return new TimerTask(false, action);
     }
 
-    public static SuccessfulTaskSet(tasks: Task[], result: unknown): TaskSet {
+    public static SuccessfulTaskSet(tasks: TaskBase[], completionIndex: number, result: unknown): TaskSet {
         return new TaskSet(
             true,
             false,
             tasks,
+            completionIndex,
             result,
             undefined,
         );
     }
 
-    public static FailedTaskSet(tasks: Task[], exception: Error): TaskSet {
+    public static FailedTaskSet(tasks: TaskBase[], completionIndex: number, exception: Error): TaskSet {
         return new TaskSet(
             true,
             true,
             tasks,
+            completionIndex,
             undefined,
             exception,
         );
     }
 
-    public static UncompletedTaskSet(tasks: Task[]): TaskSet {
+    public static UncompletedTaskSet(tasks: TaskBase[]): TaskSet {
         return new TaskSet(
             false,
             false,
             tasks,
+            undefined,
             undefined,
             undefined,
         );

--- a/src/tasks/taskfilter.ts
+++ b/src/tasks/taskfilter.ts
@@ -1,34 +1,35 @@
 import { Task } from "./task";
-import { CompletedTask, FailedTask, SuccessfulSingleTask, SuccessfulTask, UncompletedTask } from "./taskinterfaces";
+import { CompletedYieldable, FailedYieldable, SuccessfulSingleTask, SuccessfulYieldable, UncompletedYieldable } from "./taskinterfaces";
 import { TaskSet } from "./taskset";
+import { Yieldable } from "./yieldable";
 
 export class TaskFilter {
-    public static isTask(value: unknown): value is (Task | TaskSet) {
+    public static isYieldable(value: unknown): value is Yieldable {
         if (!value) {
             return false;
         }
-        const task = value as (Task | TaskSet);
+        const task = value as (Yieldable);
         return task.isCompleted !== undefined && task.isFaulted !== undefined;
     }
 
-    public static isSingleTask(task: Task | TaskSet): task is Task {
+    public static isSingleTask(task: Yieldable): task is Task {
         return (task instanceof Task);
     }
 
-    public static isTaskSet(task: Task | TaskSet): task is TaskSet {
+    public static isTaskSet(task: Yieldable): task is TaskSet {
         return (task instanceof TaskSet);
     }
 
-    public static isCompletedTask(task: Task | TaskSet): task is CompletedTask {
+    public static isCompletedTask(task: Yieldable): task is CompletedYieldable {
         return task.isCompleted;
     }
 
-    public static isUncompletedTask(task: Task | TaskSet): task is UncompletedTask  {
+    public static isUncompletedTask(task: Yieldable): task is UncompletedYieldable  {
         return task.isCompleted === false;
     }
 
-    public static isSuccessfulTask(task: Task | TaskSet): task is SuccessfulTask  {
-        const successfulTask = task as SuccessfulTask;
+    public static isSuccessfulTask(task: Yieldable): task is SuccessfulYieldable  {
+        const successfulTask = task as SuccessfulYieldable;
         return successfulTask.isCompleted === true && successfulTask.isFaulted === false && successfulTask.result !== undefined;
     }
 
@@ -36,7 +37,7 @@ export class TaskFilter {
         return TaskFilter.isSingleTask(task) && task.isCompleted === true && task.isFaulted === false && task.completionIndex !== undefined;
     }
 
-    public static isFailedTask(task: Task | TaskSet): task is FailedTask {
+    public static isFailedTask(task: Yieldable): task is FailedYieldable {
         return task.isCompleted === true && task.isFaulted === true;
     }
 }

--- a/src/tasks/taskfilter.ts
+++ b/src/tasks/taskfilter.ts
@@ -1,43 +1,39 @@
 import { Task } from "./task";
-import { CompletedYieldable, FailedYieldable, SuccessfulSingleTask, SuccessfulYieldable, UncompletedYieldable } from "./taskinterfaces";
 import { TaskSet } from "./taskset";
-import { Yieldable } from "./yieldable";
+import { CompletedTask, TaskBase, SuccessfulTask, FailedTask, UncompletedTask } from "./taskinterfaces"
 
 export class TaskFilter {
-    public static isYieldable(value: unknown): value is Yieldable {
-        if (!value) {
-            return false;
-        }
-        const task = value as (Yieldable);
-        return task.isCompleted !== undefined && task.isFaulted !== undefined;
+    public static CompareFinishedTime(taskA: CompletedTask, taskB: CompletedTask) {
+        if (taskA.completionIndex > taskB.completionIndex) { return 1; }
+        if (taskA.completionIndex < taskB.completionIndex) { return -1; }
+        return 0;
     }
 
-    public static isSingleTask(task: Yieldable): task is Task {
+    public static isYieldable(task: any) : task is TaskBase {
+        return (task instanceof Task) || (task instanceof TaskSet);
+    }
+
+    public static isSingleTask(task: TaskBase): task is Task {
         return (task instanceof Task);
     }
 
-    public static isTaskSet(task: Yieldable): task is TaskSet {
+    public static isTaskSet(task: TaskBase): task is TaskSet {
         return (task instanceof TaskSet);
     }
 
-    public static isCompletedTask(task: Yieldable): task is CompletedYieldable {
+    public static isCompletedTask(task: TaskBase): task is CompletedTask {
         return task.isCompleted;
     }
 
-    public static isUncompletedTask(task: Yieldable): task is UncompletedYieldable  {
+    public static isUncompletedTask(task: TaskBase): task is UncompletedTask  {
         return task.isCompleted === false;
     }
 
-    public static isSuccessfulTask(task: Yieldable): task is SuccessfulYieldable  {
-        const successfulTask = task as SuccessfulYieldable;
-        return successfulTask.isCompleted === true && successfulTask.isFaulted === false && successfulTask.result !== undefined;
+    public static isSuccessfulTask(task: TaskBase): task is SuccessfulTask {
+        return task.isCompleted === true && task.isFaulted === false;
     }
 
-    public static isSuccessfulSingleTask(task: Task): task is SuccessfulSingleTask  {
-        return TaskFilter.isSingleTask(task) && task.isCompleted === true && task.isFaulted === false && task.completionIndex !== undefined;
-    }
-
-    public static isFailedTask(task: Yieldable): task is FailedYieldable {
+    public static isFailedTask(task: TaskBase): task is FailedTask {
         return task.isCompleted === true && task.isFaulted === true;
     }
 }

--- a/src/tasks/taskfilter.ts
+++ b/src/tasks/taskfilter.ts
@@ -1,6 +1,6 @@
 import { Task } from "./task";
+import { CompletedTask, FailedTask, SuccessfulTask, TaskBase, UncompletedTask } from "./taskinterfaces";
 import { TaskSet } from "./taskset";
-import { CompletedTask, TaskBase, SuccessfulTask, FailedTask, UncompletedTask } from "./taskinterfaces"
 
 export class TaskFilter {
     public static CompareFinishedTime(taskA: CompletedTask, taskB: CompletedTask) {
@@ -9,7 +9,7 @@ export class TaskFilter {
         return 0;
     }
 
-    public static isYieldable(task: any) : task is TaskBase {
+    public static isYieldable(task: any): task is TaskBase {
         return (task instanceof Task) || (task instanceof TaskSet);
     }
 

--- a/src/tasks/taskfilter.ts
+++ b/src/tasks/taskfilter.ts
@@ -12,9 +12,9 @@ export class TaskFilter {
     public static isYieldable(task: any): task is TaskBase {
         const taskBase = task as TaskBase;
         return taskBase
-            && taskBase.isCompleted != null
-            && taskBase.isFaulted != null
-            && taskBase.yieldNewActions != null;
+            && taskBase.isCompleted !== undefined
+            && taskBase.isFaulted !== undefined
+            && taskBase.yieldNewActions !== undefined;
     }
 
     public static isSingleTask(task: TaskBase): task is Task {

--- a/src/tasks/taskfilter.ts
+++ b/src/tasks/taskfilter.ts
@@ -10,7 +10,11 @@ export class TaskFilter {
     }
 
     public static isYieldable(task: any): task is TaskBase {
-        return (task instanceof Task) || (task instanceof TaskSet);
+        const taskBase = task as TaskBase;
+        return taskBase
+            && taskBase.isCompleted != null
+            && taskBase.isFaulted != null
+            && taskBase.yieldNewActions != null;
     }
 
     public static isSingleTask(task: TaskBase): task is Task {

--- a/src/tasks/taskinterfaces.ts
+++ b/src/tasks/taskinterfaces.ts
@@ -1,69 +1,31 @@
 import { IAction } from "../classes";
 
  // Base interfaces
-interface TaskBase {
+export interface TaskBase {
     readonly isCompleted: boolean;
     readonly isFaulted: boolean;
+    yield(): IAction[];
  }
 
-export interface SingleTask extends TaskBase {
-    readonly action: IAction;
-    wasYielded: boolean;
-}
-
-export interface UncompletedSingleTask extends TaskBase {
+ export interface UncompletedTask extends TaskBase {
     readonly isCompleted: false;
     readonly isFaulted: false;
 }
 
-export interface CompletedSingleTask extends SingleTask {
-    completionIndex: number;
-    readonly timestamp: Date;
-    readonly id: number;
-    readonly isCompleted: true;
-    readonly result: unknown;
+export interface CompletedTask extends TaskBase {
+    readonly completionIndex: number;
+    readonly isCompleted: true
+    readonly result: unknown | undefined;
 }
 
-export interface SuccessfulSingleTask extends CompletedSingleTask {
+export interface SuccessfulTask extends CompletedTask {
     readonly isFaulted: false;
+    readonly result: unknown;
     readonly exception: undefined;
 }
 
-export interface FailedSingleTask extends CompletedSingleTask {
+export interface FailedTask extends CompletedTask {
     readonly isFaulted: true;
     readonly exception: Error;
     readonly result: undefined;
 }
-
-interface TaskCollection extends TaskBase {
-    readonly tasks: SingleTask[];
-}
-
-export interface CompletedTaskSet extends TaskCollection {
-    readonly isCompleted: true;
-    readonly result: unknown;
-}
-
-export interface UncompletedTaskSet extends TaskCollection {
-    readonly isCompleted: false;
-    readonly isFaulted: false;
-}
-
-export interface FailedTaskSet extends CompletedTaskSet {
-    readonly isFaulted: true;
-    readonly exception: Error;
-    readonly result: undefined;
-}
-
-export interface SuccessfulTaskSet extends CompletedTaskSet {
-    readonly isFaulted: false;
-    readonly exception: undefined;
-}
-
-export type CompletedYieldable = CompletedSingleTask & CompletedTaskSet;
-
-export type UncompletedYieldable = UncompletedTaskSet & UncompletedSingleTask;
-
-export type SuccessfulYieldable =  SuccessfulTaskSet & SuccessfulSingleTask;
-
-export type FailedYieldable = FailedTaskSet & FailedSingleTask;

--- a/src/tasks/taskinterfaces.ts
+++ b/src/tasks/taskinterfaces.ts
@@ -60,10 +60,10 @@ export interface SuccessfulTaskSet extends CompletedTaskSet {
     readonly exception: undefined;
 }
 
-export type CompletedTask = CompletedSingleTask | CompletedTaskSet;
+export type CompletedYieldable = CompletedSingleTask & CompletedTaskSet;
 
-export type UncompletedTask = UncompletedTaskSet & UncompletedSingleTask;
+export type UncompletedYieldable = UncompletedTaskSet & UncompletedSingleTask;
 
-export type SuccessfulTask =  SuccessfulTaskSet & SuccessfulSingleTask;
+export type SuccessfulYieldable =  SuccessfulTaskSet & SuccessfulSingleTask;
 
-export type FailedTask = FailedTaskSet & FailedSingleTask;
+export type FailedYieldable = FailedTaskSet & FailedSingleTask;

--- a/src/tasks/taskinterfaces.ts
+++ b/src/tasks/taskinterfaces.ts
@@ -4,17 +4,17 @@ import { IAction } from "../classes";
 export interface TaskBase {
     readonly isCompleted: boolean;
     readonly isFaulted: boolean;
-    yield(): IAction[];
+    yieldNewActions(): IAction[];
  }
 
- export interface UncompletedTask extends TaskBase {
+export interface UncompletedTask extends TaskBase {
     readonly isCompleted: false;
     readonly isFaulted: false;
 }
 
 export interface CompletedTask extends TaskBase {
     readonly completionIndex: number;
-    readonly isCompleted: true
+    readonly isCompleted: true;
     readonly result: unknown | undefined;
 }
 

--- a/src/tasks/taskset.ts
+++ b/src/tasks/taskset.ts
@@ -1,11 +1,11 @@
-import { SingleTask } from "./taskinterfaces";
+import { Yieldable } from "./yieldable";
 
 /** @hidden */
 export class TaskSet {
     constructor(
         public readonly isCompleted: boolean,
         public readonly isFaulted: boolean,
-        public readonly tasks: SingleTask[],
+        public readonly tasks: Yieldable[],
         public result?: unknown,
         public exception?: Error,
     ) { }

--- a/src/tasks/taskset.ts
+++ b/src/tasks/taskset.ts
@@ -16,6 +16,6 @@ export class TaskSet implements TaskBase {
     public yieldNewActions(): IAction[] {
         // Get all of the actions in subtasks and flatten into one array.
         return this.tasks.map((task) => task.yieldNewActions())
-            .reduce((acc, arr) => acc.concat(arr));
+            .reduce((actions, subTaskActions) => actions.concat(subTaskActions));
     }
 }

--- a/src/tasks/taskset.ts
+++ b/src/tasks/taskset.ts
@@ -1,4 +1,4 @@
-import { IAction } from "../classes"; 
+import { IAction } from "../classes";
 import { TaskBase } from "./taskinterfaces";
 
 /** @hidden */
@@ -13,9 +13,9 @@ export class TaskSet implements TaskBase {
         public exception?: Error,
     ) { }
 
-    yield(): IAction[] {
+    public yieldNewActions(): IAction[] {
         // Get all of the actions in subtasks and flatten into one array.
-        return this.tasks.map((task) => task.yield())
+        return this.tasks.map((task) => task.yieldNewActions())
             .reduce((acc, arr) => acc.concat(arr));
     }
 }

--- a/src/tasks/taskset.ts
+++ b/src/tasks/taskset.ts
@@ -1,12 +1,21 @@
-import { Yieldable } from "./yieldable";
+import { IAction } from "../classes"; 
+import { TaskBase } from "./taskinterfaces";
 
 /** @hidden */
-export class TaskSet {
+export class TaskSet implements TaskBase {
+
     constructor(
         public readonly isCompleted: boolean,
         public readonly isFaulted: boolean,
-        public readonly tasks: Yieldable[],
+        private readonly tasks: TaskBase[],
+        private readonly completionIndex?: number,
         public result?: unknown,
         public exception?: Error,
     ) { }
+
+    yield(): IAction[] {
+        // Get all of the actions in subtasks and flatten into one array.
+        return this.tasks.map((task) => task.yield())
+            .reduce((acc, arr) => acc.concat(arr));
+    }
 }

--- a/src/tasks/yieldable.ts
+++ b/src/tasks/yieldable.ts
@@ -1,4 +1,0 @@
-import { Task } from "./task";
-import { TaskSet } from "./taskset";
-
-export type Yieldable = Task | TaskSet;

--- a/src/tasks/yieldable.ts
+++ b/src/tasks/yieldable.ts
@@ -1,0 +1,4 @@
+import { Task } from "./task";
+import { TaskSet } from "./taskset";
+
+export type Yieldable = Task | TaskSet;

--- a/test/integration/orchestrator-spec.ts
+++ b/test/integration/orchestrator-spec.ts
@@ -1809,7 +1809,7 @@ describe("Orchestrator", () => {
         it("Task.any proceeds if a scheduled parallel task completes in order", async () => {
             const orchestrator = TestOrchestrations.AnyAOrB;
             const completeInOrder = true;
-            const initialDate = moment.utc().toDate()
+            const initialDate = moment.utc().toDate();
             const mockContext = new MockContext({
                 context: new DurableOrchestrationBindingInfo(
                     TestHistories.GetAnyAOrB(
@@ -1844,7 +1844,7 @@ describe("Orchestrator", () => {
                         initialTime.toDate(),
                         1,
                         eventsWin,
-                    )
+                    ),
                 ),
             });
 
@@ -1858,10 +1858,10 @@ describe("Orchestrator", () => {
                         [
                             new WaitForExternalEventAction("A"),
                             new WaitForExternalEventAction("B"),
-                            new CreateTimerAction(initialTime.add(300, "s").toDate())
+                            new CreateTimerAction(initialTime.add(300, "s").toDate()),
                         ],
                     ],
-                    output: undefined
+                    output: undefined,
                 }),
             );
 
@@ -1871,7 +1871,7 @@ describe("Orchestrator", () => {
                         initialTime.toDate(),
                         2,
                         eventsWin,
-                    )
+                    ),
                 ),
             });
 
@@ -1885,11 +1885,11 @@ describe("Orchestrator", () => {
                         [
                             new WaitForExternalEventAction("A"),
                             new WaitForExternalEventAction("B"),
-                            new CreateTimerAction(initialTime.add(300, "s").toDate())
+                            new CreateTimerAction(initialTime.add(300, "s").toDate()),
                         ],
                         [ new CallActivityAction("Hello", "Tokyo") ],
                     ],
-                    output: undefined
+                    output: undefined,
                 }),
             );
         });
@@ -1904,7 +1904,7 @@ describe("Orchestrator", () => {
                         initialTime.toDate(),
                         1,
                         eventsWin,
-                    )
+                    ),
                 ),
             });
 
@@ -1918,10 +1918,10 @@ describe("Orchestrator", () => {
                         [
                             new WaitForExternalEventAction("A"),
                             new WaitForExternalEventAction("B"),
-                            new CreateTimerAction(initialTime.add(300, "s").toDate())
+                            new CreateTimerAction(initialTime.add(300, "s").toDate()),
                         ],
                     ],
-                    output: undefined
+                    output: undefined,
                 }),
             );
 
@@ -1931,7 +1931,7 @@ describe("Orchestrator", () => {
                         initialTime.toDate(),
                         2,
                         eventsWin,
-                    )
+                    ),
                 ),
             });
 
@@ -1945,10 +1945,10 @@ describe("Orchestrator", () => {
                         [
                             new WaitForExternalEventAction("A"),
                             new WaitForExternalEventAction("B"),
-                            new CreateTimerAction(initialTime.add(300, "s").toDate())
+                            new CreateTimerAction(initialTime.add(300, "s").toDate()),
                         ],
                     ],
-                    output: ["timeout"]
+                    output: ["timeout"],
                 }),
             );
         });

--- a/test/integration/orchestrator-spec.ts
+++ b/test/integration/orchestrator-spec.ts
@@ -1730,7 +1730,8 @@ describe("Orchestrator", () => {
                 ),
             });
 
-            const expectedErr = "Activity function 'GetFileSize' failed: Could not find file.";
+            const expectedErr1 = "Activity function 'GetFileSize' failed: Could not find file file2.png";
+            const expectedErr2 = "Activity function 'GetFileSize' failed: Could not find file file3.csx";
 
             orchestrator(mockContext);
 
@@ -1749,7 +1750,9 @@ describe("Orchestrator", () => {
                     ],
                 },
             );
-            expect(orchestrationState.error).to.include(expectedErr);
+
+            expect(orchestrationState.error).to.include(expectedErr1);
+            expect(orchestrationState.error).to.include(expectedErr2);
         });
 
         it("Task.any proceeds if a scheduled parallel task completes in order", async () => {
@@ -1809,7 +1812,6 @@ describe("Orchestrator", () => {
         it("Task.any proceeds if a scheduled parallel task completes in order", async () => {
             const orchestrator = TestOrchestrations.AnyAOrB;
             const completeInOrder = true;
-            const initialDate = moment.utc().toDate();
             const mockContext = new MockContext({
                 context: new DurableOrchestrationBindingInfo(
                     TestHistories.GetAnyAOrB(
@@ -1856,8 +1858,8 @@ describe("Orchestrator", () => {
                     actions:
                     [
                         [
-                            new WaitForExternalEventAction("A"),
-                            new WaitForExternalEventAction("B"),
+                            new WaitForExternalEventAction("firstRequiredEvent"),
+                            new WaitForExternalEventAction("secondRequiredEvent"),
                             new CreateTimerAction(initialTime.add(300, "s").toDate()),
                         ],
                     ],
@@ -1883,8 +1885,8 @@ describe("Orchestrator", () => {
                     actions:
                     [
                         [
-                            new WaitForExternalEventAction("A"),
-                            new WaitForExternalEventAction("B"),
+                            new WaitForExternalEventAction("firstRequiredEvent"),
+                            new WaitForExternalEventAction("secondRequiredEvent"),
                             new CreateTimerAction(initialTime.add(300, "s").toDate()),
                         ],
                         [ new CallActivityAction("Hello", "Tokyo") ],
@@ -1916,8 +1918,8 @@ describe("Orchestrator", () => {
                     actions:
                     [
                         [
-                            new WaitForExternalEventAction("A"),
-                            new WaitForExternalEventAction("B"),
+                            new WaitForExternalEventAction("firstRequiredEvent"),
+                            new WaitForExternalEventAction("secondRequiredEvent"),
                             new CreateTimerAction(initialTime.add(300, "s").toDate()),
                         ],
                     ],
@@ -1943,8 +1945,8 @@ describe("Orchestrator", () => {
                     actions:
                     [
                         [
-                            new WaitForExternalEventAction("A"),
-                            new WaitForExternalEventAction("B"),
+                            new WaitForExternalEventAction("firstRequiredEvent"),
+                            new WaitForExternalEventAction("secondRequiredEvent"),
                             new CreateTimerAction(initialTime.add(300, "s").toDate()),
                         ],
                     ],

--- a/test/testobjects/TestOrchestrations.ts
+++ b/test/testobjects/TestOrchestrations.ts
@@ -49,27 +49,23 @@ export class TestOrchestrations {
         const now = new Date(context.df.currentUtcDateTime).getTime();
         const deadline = new Date(now + 300000);
         const timeoutTask = context.df.createTimer(deadline);
-     
+
         const gate1 = context.df.waitForExternalEvent("A");
         const gate2 = context.df.waitForExternalEvent("B");
-       
-        //this line below will not work because Task.all returns a taskset instead of a task, so 
-        //in Task.any it becomes undefined
+
         const winner = yield context.df.Task.any([context.df.Task.all([gate1, gate2]), timeoutTask]);
         const outputs = [];
-     
+
         if (winner === timeoutTask) {
             // timeout case
             outputs.push("timeout");
-        }
-        else
-        {    
-            // success case     
+        } else {
+            // success case
             const okaction = yield context.df.callActivity("Hello", "Tokyo");
             timeoutTask.cancel();
             outputs.push(okaction);
         }
-        return outputs;     
+        return outputs;
     });
 
     public static CallActivityNoInput: any = df.orchestrator(function*(context: any) {

--- a/test/testobjects/TestOrchestrations.ts
+++ b/test/testobjects/TestOrchestrations.ts
@@ -45,6 +45,33 @@ export class TestOrchestrations {
         return output.result;
     });
 
+    public static AnyWithTaskSet: any = df.orchestrator(function*(context: any) {
+        const now = new Date(context.df.currentUtcDateTime).getTime();
+        const deadline = new Date(now + 300000);
+        const timeoutTask = context.df.createTimer(deadline);
+     
+        const gate1 = context.df.waitForExternalEvent("A");
+        const gate2 = context.df.waitForExternalEvent("B");
+       
+        //this line below will not work because Task.all returns a taskset instead of a task, so 
+        //in Task.any it becomes undefined
+        const winner = yield context.df.Task.any([context.df.Task.all([gate1, gate2]), timeoutTask]);
+        const outputs = [];
+     
+        if (winner === timeoutTask) {
+            // timeout case
+            outputs.push("timeout");
+        }
+        else
+        {    
+            // success case     
+            const okaction = yield context.df.callActivity("Hello", "tokyo");
+            timeoutTask.cancel();
+            outputs.push(okaction);
+        }
+        return outputs;     
+    });
+
     public static CallActivityNoInput: any = df.orchestrator(function*(context: any) {
        const returnValue = yield context.df.callActivity("ReturnsFour");
        return returnValue;

--- a/test/testobjects/TestOrchestrations.ts
+++ b/test/testobjects/TestOrchestrations.ts
@@ -50,10 +50,12 @@ export class TestOrchestrations {
         const deadline = new Date(now + 300000);
         const timeoutTask = context.df.createTimer(deadline);
 
-        const gate1 = context.df.waitForExternalEvent("A");
-        const gate2 = context.df.waitForExternalEvent("B");
+        const firstRequiredTask = context.df.waitForExternalEvent("firstRequiredEvent");
+        const secondRequiredTask = context.df.waitForExternalEvent("secondRequiredEvent");
 
-        const winner = yield context.df.Task.any([context.df.Task.all([gate1, gate2]), timeoutTask]);
+        const allRequiredEvents = context.df.Task.all([firstRequiredTask, secondRequiredTask]);
+
+        const winner = yield context.df.Task.any([allRequiredEvents, timeoutTask]);
         const outputs = [];
 
         if (winner === timeoutTask) {

--- a/test/testobjects/TestOrchestrations.ts
+++ b/test/testobjects/TestOrchestrations.ts
@@ -65,7 +65,7 @@ export class TestOrchestrations {
         else
         {    
             // success case     
-            const okaction = yield context.df.callActivity("Hello", "tokyo");
+            const okaction = yield context.df.callActivity("Hello", "Tokyo");
             timeoutTask.cancel();
             outputs.push(okaction);
         }

--- a/test/testobjects/testhistories.ts
+++ b/test/testobjects/testhistories.ts
@@ -280,14 +280,21 @@ export class TestHistories {
                 eventId: -1,
                 timestamp: firstIteration.add(2, "s").toDate(),
                 isPlayed: false,
-                name: "A",
+                name: "firstRequiredEvent",
             }));
             if (eventsBeatTimer) {
                 history.push(new EventRaisedEvent({
                     eventId: -1,
                     timestamp: firstIteration.add(2, "s").toDate(),
                     isPlayed: false,
-                    name: "B",
+                    name: "secondRequiredEvent",
+                }));
+                history.push(new TimerFiredEvent({
+                    eventId: -1,
+                    timestamp: firstTimestamp,
+                    fireAt,
+                    isPlayed: false,
+                    timerId: 0,
                 }));
             } else {
                 history.push(new TimerFiredEvent({
@@ -296,6 +303,12 @@ export class TestHistories {
                     fireAt,
                     isPlayed: false,
                     timerId: 0,
+                }));
+                history.push(new EventRaisedEvent({
+                    eventId: -1,
+                    timestamp: firstIteration.add(3, "s").toDate(),
+                    isPlayed: false,
+                    name: "secondRequiredEvent",
                 }));
             }
         }
@@ -588,7 +601,7 @@ export class TestHistories {
             new OrchestratorStartedEvent(
                 {
                     eventId: -1,
-                    timestamp: firstMoment.add(3, "s").toDate(),
+                    timestamp: firstMoment.add(4, "s").toDate(),
                     isPlayed: false,
                 },
             ),
@@ -601,27 +614,15 @@ export class TestHistories {
                     taskScheduledId: 1,
                 },
             ),
-            new TaskCompletedEvent(
+            new TaskFailedEvent(
                 {
                     eventId: -1,
                     timestamp: firstMoment.add(3, "s").toDate(),
                     isPlayed: false,
                     result: JSON.stringify(2),
                     taskScheduledId: 2,
-                },
-            ),
-            new OrchestratorCompletedEvent(
-                {
-                    eventId: -1,
-                    timestamp: firstTimestamp,
-                    isPlayed: false,
-                },
-            ),
-            new OrchestratorStartedEvent(
-                {
-                    eventId: -1,
-                    timestamp: firstMoment.add(4, "s").toDate(),
-                    isPlayed: false,
+                    reason: `Activity function 'GetFileSize' failed: Could not find file ${files[1]}`,
+                    details: "Serialized System.Exception here",
                 },
             ),
             new TaskFailedEvent(
@@ -630,7 +631,7 @@ export class TestHistories {
                     timestamp: firstMoment.add(4, "s").toDate(),
                     isPlayed: false,
                     taskScheduledId: 3,
-                    reason: "Activity function 'GetFileSize' failed: Could not find file.",
+                    reason: `Activity function 'GetFileSize' failed: Could not find file ${files[2]}`,
                     details: "Serialized System.Exception here",
                 },
             ),

--- a/test/testobjects/testhistories.ts
+++ b/test/testobjects/testhistories.ts
@@ -179,7 +179,7 @@ export class TestHistories {
 
         return history;
     }
-    
+
     public static GetTimerActivityRaceTimerWinsHistory(firstTimestamp: Date, iteration: number): HistoryEvent[] {
         const firstIteration = moment(firstTimestamp);
         const fireAt = firstIteration.add(1, "s").toDate();
@@ -267,12 +267,9 @@ export class TestHistories {
         }
 
         if (iteration >= 2) {
-            let secondIteration : Date;
-            if (eventsBeatTimer) {
-                secondIteration = firstIteration.add(2500, "ms").toDate();
-            } else {
-                secondIteration = firstIteration.add(31500, "ms").toDate();
-            }
+            const secondIteration: Date = eventsBeatTimer
+                ? firstIteration.add(2500, "ms").toDate()
+                : firstIteration.add(31500, "ms").toDate();
 
             history.push(new OrchestratorStartedEvent({
                 eventId: -1,
@@ -291,7 +288,7 @@ export class TestHistories {
                     timestamp: firstIteration.add(2, "s").toDate(),
                     isPlayed: false,
                     name: "B",
-                }))
+                }));
             } else {
                 history.push(new TimerFiredEvent({
                     eventId: -1,

--- a/test/testobjects/testhistories.ts
+++ b/test/testobjects/testhistories.ts
@@ -179,7 +179,7 @@ export class TestHistories {
 
         return history;
     }
-
+    
     public static GetTimerActivityRaceTimerWinsHistory(firstTimestamp: Date, iteration: number): HistoryEvent[] {
         const firstIteration = moment(firstTimestamp);
         const fireAt = firstIteration.add(1, "s").toDate();
@@ -230,6 +230,77 @@ export class TestHistories {
                 isPlayed: iteration > 2,
                 timerId: 0,
             }));
+        }
+
+        return history;
+    }
+
+    public static GetAnyWithTaskSet(firstTimestamp: Date, iteration: number, eventsBeatTimer: boolean): HistoryEvent[] {
+        const firstIteration = moment(firstTimestamp);
+        const fireAt = firstIteration.add(300, "s").toDate();
+
+        const history = [];
+
+        if (iteration >= 1) {
+            history.push(new OrchestratorStartedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: false,
+            }));
+            history.push(new ExecutionStartedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: true,
+                name: "AnyWithTaskSet",
+            }));
+            history.push(new TimerCreatedEvent({
+                eventId: 0,
+                timestamp: firstTimestamp,
+                isPlayed: false,
+                fireAt,
+            }));
+            history.push(new OrchestratorCompletedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: iteration > 1,
+            }));
+        }
+
+        if (iteration >= 2) {
+            let secondIteration : Date;
+            if (eventsBeatTimer) {
+                secondIteration = firstIteration.add(2500, "ms").toDate();
+            } else {
+                secondIteration = firstIteration.add(31500, "ms").toDate();
+            }
+
+            history.push(new OrchestratorStartedEvent({
+                eventId: -1,
+                timestamp: secondIteration,
+                isPlayed: iteration > 2,
+            }));
+            history.push(new EventRaisedEvent({
+                eventId: -1,
+                timestamp: firstIteration.add(2, "s").toDate(),
+                isPlayed: false,
+                name: "A",
+            }));
+            if (eventsBeatTimer) {
+                history.push(new EventRaisedEvent({
+                    eventId: -1,
+                    timestamp: firstIteration.add(2, "s").toDate(),
+                    isPlayed: false,
+                    name: "B",
+                }))
+            } else {
+                history.push(new TimerFiredEvent({
+                    eventId: -1,
+                    timestamp: firstTimestamp,
+                    fireAt,
+                    isPlayed: false,
+                    timerId: 0,
+                }));
+            }
         }
 
         return history;


### PR DESCRIPTION
Unify the idea of `Task` and `TaskSet` so that `df.task.any()` and `df.task.all()` can work on the tasksets they generate themselves.

This cleaning of the two concepts also simplifies the code as well.