### PR TITLE
Fix updating isReplaying flag between activity calls

### DIFF
--- a/src/durableorchestrationcontext.ts
+++ b/src/durableorchestrationcontext.ts
@@ -16,6 +16,17 @@ export class DurableOrchestrationContext {
     public readonly instanceId: string;
 
     /**
+     * The ID of the parent orchestration of the current sub-orchestration
+     * instance. The value will be available only in sub-orchestrations.
+     *
+     * The parent instance ID is generated and fixed when the parent
+     * orchestrator function is scheduled. It can be either auto-generated, in
+     * which case it is formatted as a GUID, or it can be user-specified with
+     * any format.
+     */
+    public readonly parentInstanceId: string | undefined;
+
+    /**
      * Gets a value indicating whether the orchestrator function is currently
      * replaying itself.
      *
@@ -26,18 +37,7 @@ export class DurableOrchestrationContext {
      * whether the function is being replayed and then issue the log statements
      * when this value is `false`.
      */
-    public readonly isReplaying: boolean;
-
-    /**
-     * The ID of the parent orchestration of the current sub-orchestration
-     * instance. The value will be available only in sub-orchestrations.
-     *
-     * The parent instance ID is generated and fixed when the parent
-     * orchestrator function is scheduled. It can be either auto-generated, in
-     * which case it is formatted as a GUID, or it can be user-specified with
-     * any format.
-     */
-    public readonly parentInstanceId: string | undefined;
+    public isReplaying: boolean;
 
     /**
      * Gets the current date/time in a way that is safe for use by orchestrator

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -177,6 +177,10 @@ export class Orchestrator {
                 decisionStartedEvent = newDecisionStartedEvent || decisionStartedEvent;
                 context.df.currentUtcDateTime = this.currentUtcDateTime = new Date(decisionStartedEvent.Timestamp);
 
+                if (state[partialResult.completionIndex] !== undefined) {
+                  context.df.isReplaying = state[partialResult.completionIndex].IsPlayed;
+                }
+
                 g = gen.next(partialResult.result);
             }
         } catch (error) {
@@ -544,9 +548,9 @@ export class Orchestrator {
     }
 
     private all(state: HistoryEvent[], tasks: TaskBase[]): TaskSet {
-        let maxCompletionIndex: number | undefined = undefined;
+        let maxCompletionIndex: number | undefined;
         const errors: Error[] = [];
-        const results: unknown[] = [];
+        const results: Array<unknown> = [];
         for (let index = 0; index < tasks.length; index++) {
             const task = tasks[index];
             if (!TaskFilter.isCompletedTask(task)) {
@@ -582,7 +586,7 @@ export class Orchestrator {
             throw new Error("At least one yieldable task must be provided to wait for.");
         }
 
-        let firstCompleted: CompletedTask | undefined = undefined;
+        let firstCompleted: CompletedTask | undefined;
         for (let index = 0; index < tasks.length; index++) {
             const task = tasks[index];
             if (TaskFilter.isCompletedTask(task)) {

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -177,6 +177,9 @@ export class Orchestrator {
                 decisionStartedEvent = newDecisionStartedEvent || decisionStartedEvent;
                 context.df.currentUtcDateTime = this.currentUtcDateTime = new Date(decisionStartedEvent.Timestamp);
 
+                // The first time a task is marked as complete, the history event that finally marked the task as completed
+                // should not yet have been played by the Durable Task framework, resulting in isReplaying being false.
+                // On replays, the event will have already been processed by the framework, and IsPlayed will be marked as true.
                 if (state[partialResult.completionIndex] !== undefined) {
                   context.df.isReplaying = state[partialResult.completionIndex].IsPlayed;
                 }


### PR DESCRIPTION
According to this [document](https://docs.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-diagnostics#javascript-functions-20-only-1), if we want to only log on non-replay execution, we can write a conditional expression to log only if IsReplaying is false. But now it's not working.
This PR fixes updating the _IsReplaying_ flag between activity calls. 

Resolve #47 