### PR TITLE
Revamp retry logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -602,6 +602,12 @@
         "graceful-readlink": ">= 1.0.0"
       }
     },
+    "common-tags": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -668,6 +674,12 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true
     },
     "doctrine": {
@@ -1247,6 +1259,12 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -1553,6 +1571,12 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
     "log-symbols": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
@@ -1582,6 +1606,22 @@
             "supports-color": "^5.3.0"
           }
         }
+      }
+    },
+    "loglevel": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.8.tgz",
+      "integrity": "sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA==",
+      "dev": true
+    },
+    "loglevel-colored-level-prefix": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/loglevel-colored-level-prefix/-/loglevel-colored-level-prefix-1.0.0.tgz",
+      "integrity": "sha1-akAhj9x64V/HbD0PPmdsRlOIYD4=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "loglevel": "^1.4.1"
       }
     },
     "lolex": {
@@ -1982,6 +2022,117 @@
       "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
       "dev": true
     },
+    "prettier-eslint": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-11.0.0.tgz",
+      "integrity": "sha512-ACjL7T8m10HCO7DwYdXwhNWuZzQv86JkZAhVpzFV9brTMWi3i6LhqoELFaXf6RetDngujz89tnbDmGyvDl+rzA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/parser": "^3.0.0",
+        "common-tags": "^1.4.0",
+        "dlv": "^1.1.0",
+        "eslint": "^6.8.0",
+        "indent-string": "^4.0.0",
+        "lodash.merge": "^4.6.0",
+        "loglevel-colored-level-prefix": "^1.0.0",
+        "prettier": "^2.0.0",
+        "pretty-format": "^23.0.1",
+        "require-relative": "^0.8.7",
+        "typescript": "^3.9.3",
+        "vue-eslint-parser": "~7.1.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.3.0.tgz",
+          "integrity": "sha512-d4pGIAbu/tYsrPrdHCQ5xfadJGvlkUxbeBB56nO/VGmEDi/sKmfa5fGty5t5veL1OyJBrUmSiRn1R1qfVDydrg==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.3",
+            "@typescript-eslint/typescript-estree": "3.3.0",
+            "eslint-scope": "^5.0.0",
+            "eslint-utils": "^2.0.0"
+          }
+        },
+        "@typescript-eslint/parser": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.3.0.tgz",
+          "integrity": "sha512-a7S0Sqn/+RpOOWTcaLw6RD4obsharzxmgMfdK24l364VxuBODXjuJM7ImCkSXEN7oz52aiZbXSbc76+2EsE91w==",
+          "dev": true,
+          "requires": {
+            "@types/eslint-visitor-keys": "^1.0.0",
+            "@typescript-eslint/experimental-utils": "3.3.0",
+            "@typescript-eslint/typescript-estree": "3.3.0",
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.3.0.tgz",
+          "integrity": "sha512-3SqxylENltEvJsjjMSDCUx/edZNSC7wAqifUU1Ywp//0OWEZwMZJfecJud9XxJ/40rAKEbJMKBOQzeOjrLJFzQ==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "eslint-visitor-keys": "^1.1.0",
+            "glob": "^7.1.6",
+            "is-glob": "^4.0.1",
+            "lodash": "^4.17.15",
+            "semver": "^7.3.2",
+            "tsutils": "^3.17.1"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "eslint-utils": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        },
+        "typescript": {
+          "version": "3.9.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
+          "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
+          "dev": true
+        }
+      }
+    },
     "prettier-linter-helpers": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
@@ -1989,6 +2140,33 @@
       "dev": true,
       "requires": {
         "fast-diff": "^1.1.2"
+      }
+    },
+    "pretty-format": {
+      "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
+      "integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0",
+        "ansi-styles": "^3.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        }
       }
     },
     "progress": {
@@ -2047,6 +2225,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
+    "require-relative": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
+      "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
       "dev": true
     },
     "resolve": {
@@ -2547,6 +2731,48 @@
       "version": "10.8.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-10.8.0.tgz",
       "integrity": "sha512-mXqMxfCh5NLsVgYVKl9WvnHNDPCcbNppHSPPowu0VjtSsGWVY+z8hJF44edLR1nbLNzi3jYoYsIl8KZpioIk6g=="
+    },
+    "vue-eslint-parser": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.1.0.tgz",
+      "integrity": "sha512-Kr21uPfthDc63nDl27AGQEhtt9VrZ9nkYk/NTftJ2ws9XiJwzJJCnCr3AITQ2jpRMA0XPGDECxYH8E027qMK9Q==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "eslint-scope": "^5.0.0",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.2.1",
+        "esquery": "^1.0.1",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "espree": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+          "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+          "dev": true,
+          "requires": {
+            "acorn": "^7.1.1",
+            "acorn-jsx": "^5.2.0",
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "clean": "rimraf lib",
     "lint": "eslint \"src/**/*.ts\"",
     "lint:test": "eslint \"test/**/*.ts\"",
+    "lint:srcfix": "eslint --fix \"src/**/*.ts\"",
+    "lint:testfix": "eslint --fix \"test/**/*.ts\"",
     "build": "npm run clean && npm run lint && npm run lint:test && npm run stripInternalDocs && echo Done",
     "build:nolint": "npm run clean && npm run stripInternalDocs && echo Done",
     "stripInternalDocs": "tsc --pretty -p tsconfig.nocomments",
@@ -67,6 +69,7 @@
     "moment": "~2.22.2",
     "nock": "^10.0.6",
     "prettier": "^2.0.5",
+    "prettier-eslint": "11.0.0",
     "sinon": "~7.1.1",
     "ts-node": "~1.0.0",
     "typescript": "^3.8.3"

--- a/test/integration/orchestrator-spec.ts
+++ b/test/integration/orchestrator-spec.ts
@@ -691,6 +691,44 @@ describe("Orchestrator", () => {
                 })
             );
         });
+
+        it("works with fan-out/fan-in", async () => {
+            const orchestrator = TestOrchestrations.SayHelloWithActivityRetryFanout;
+            const retryOptions = new RetryOptions(100, 5);
+            const mockContext = new MockContext({
+                context: new DurableOrchestrationBindingInfo(
+                    TestHistories.GetSayHelloWithActivityRetryFanout(
+                        moment.utc().toDate(),
+                        retryOptions.firstRetryIntervalInMilliseconds,
+                        4
+                    ),
+                    undefined
+                ),
+            });
+
+            orchestrator(mockContext);
+
+            expect(mockContext.doneValue).to.be.deep.equal(
+                new OrchestratorState({
+                    isDone: true,
+                    actions: [
+                        [
+                            new CallActivityWithRetryAction(
+                                "Hello",
+                                new RetryOptions(100, 5),
+                                "Tokyo"
+                            ),
+                            new CallActivityWithRetryAction(
+                                "Hello",
+                                new RetryOptions(100, 5),
+                                "Seattle"
+                            ),
+                        ],
+                    ],
+                    output: ["Hello, Tokyo!", "Hello, Seattle!"],
+                })
+            );
+        });
     });
 
     describe("callHttp()", () => {
@@ -1333,6 +1371,44 @@ describe("Orchestrator", () => {
                         ],
                     ],
                     output: `Hello, ${name}!`,
+                })
+            );
+        });
+
+        it("handles fan-out/fan-in", async () => {
+            const orchestrator = TestOrchestrations.SayHelloWithSubOrchestratorRetryFanout;
+            const retryOptions = new RetryOptions(100, 5);
+            const mockContext = new MockContext({
+                context: new DurableOrchestrationBindingInfo(
+                    TestHistories.GetSayHelloWithSuborchestratorRetryFanout(
+                        moment.utc().toDate(),
+                        retryOptions.firstRetryIntervalInMilliseconds,
+                        4
+                    ),
+                    undefined
+                ),
+            });
+
+            orchestrator(mockContext);
+
+            expect(mockContext.doneValue).to.be.deep.equal(
+                new OrchestratorState({
+                    isDone: true,
+                    actions: [
+                        [
+                            new CallSubOrchestratorWithRetryAction(
+                                "SayHelloInline",
+                                new RetryOptions(100, 5),
+                                "Tokyo"
+                            ),
+                            new CallSubOrchestratorWithRetryAction(
+                                "SayHelloInline",
+                                new RetryOptions(100, 5),
+                                "Seattle"
+                            ),
+                        ],
+                    ],
+                    output: ["Hello, Tokyo!", "Hello, Seattle!"],
                 })
             );
         });

--- a/test/testobjects/TestOrchestrations.ts
+++ b/test/testobjects/TestOrchestrations.ts
@@ -181,6 +181,14 @@ export class TestOrchestrations {
         return output;
     });
 
+    public static SayHelloWithActivityRetryFanout: any = df.orchestrator(function* (context: any) {
+        const tasks = [];
+        const retryOptions = new df.RetryOptions(100, 5);
+        tasks.push(context.df.callActivityWithRetry("Hello", retryOptions, "Tokyo"));
+        tasks.push(context.df.callActivityWithRetry("Hello", retryOptions, "Seattle"));
+        return yield context.df.Task.all(tasks);
+    });
+
     public static SayHelloWithActivityRetryNoOptions: any = df.orchestrator(function* (
         context: any
     ) {
@@ -238,6 +246,20 @@ export class TestOrchestrations {
             childId
         );
         return output;
+    });
+
+    public static SayHelloWithSubOrchestratorRetryFanout: any = df.orchestrator(function* (
+        context: any
+    ) {
+        const retryOptions = new df.RetryOptions(100, 5);
+        const output = [];
+        output.push(
+            context.df.callSubOrchestratorWithRetry("SayHelloInline", retryOptions, "Tokyo")
+        );
+        output.push(
+            context.df.callSubOrchestratorWithRetry("SayHelloInline", retryOptions, "Seattle")
+        );
+        return yield context.df.Task.all(output);
     });
 
     public static SayHelloWithSubOrchestratorRetryNoOptions: any = df.orchestrator(function* (


### PR DESCRIPTION
The current retry logic had two flaws. First, since it restarted searching from the beginning on each attempt, it could grab the wrong scheduled activity/suborchestration on subsequent events. This could lead to incorrect results. Second, since each retry attempt started from the beginning of the state array, it was not very performant. The new approach only iterates through the state array once per call to callActivityWithRetry() or callSubOrchestrationWithRetry().