### PR TITLE
Add more exported types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,21 @@
 import { DurableHttpRequest, DurableHttpResponse, EntityId, EntityStateResponse,
-    OrchestrationRuntimeStatus, RetryOptions } from "./classes";
-import { getClient } from "./durableorchestrationclient";
+    IOrchestrationFunctionContext, OrchestrationRuntimeStatus, RetryOptions, Task } from "./classes";
+import { DurableOrchestrationClient, getClient } from "./durableorchestrationclient";
 import { entity, orchestrator } from "./shim";
 import { ManagedIdentityTokenSource } from "./tokensource";
 
 export {
     DurableHttpRequest,
     DurableHttpResponse,
+    DurableOrchestrationClient,
     entity,
     EntityId,
     EntityStateResponse,
     getClient,
+    IOrchestrationFunctionContext,
     ManagedIdentityTokenSource,
     orchestrator,
     OrchestrationRuntimeStatus,
     RetryOptions,
+    Task,
 };


### PR DESCRIPTION
Current types exported via index.ts have some missing types if you want to strongly type everything in the code using durable functions to benefit from intellisense. I have added what has been missing from my point of view (I have manually imported that types from src directory in my current solution).

Example typing (df was not visible by intellisense previously):
```TypeScript
const orchestratorTrigger: (ctx: IOrchestrationFunctionContext) => void =
  orchestrator(function* f(ctx: IOrchestrationFunctionContext): IterableIterator<unknown> {
    const message: ICommandMessage = ctx.df.getInput() as ICommandMessage;
}
```