### PR TITLE
Removes synchronous calls when starting a new durableorchestrator

### DIFF
--- a/src/durableorchestrationclient.ts
+++ b/src/durableorchestrationclient.ts
@@ -603,7 +603,7 @@ export class DurableOrchestrationClient {
                 .replace(this.instanceIdPlaceholder, (instanceId ? `/${instanceId}` : ""));
         }
 
-        const response = await this.axiosInstance.post(requestUrl, input !== undefined ? JSON.stringify(input) : "");
+        const response = await this.axiosInstance.post(requestUrl, JSON.stringify(input));
         if (response.data && response.status <= 202) {
             return (response.data as HttpManagementPayload).id;
         } else  {


### PR DESCRIPTION
When undefined is passed as input to _startNew_ to start a new orchestrator function in Azure Functions 3.X an InvalidOperationException is thrown due to a call to a synchronous call to a Read method since synchronous calls have been disabled by default in this version of the SDK. #175 