### PR TITLE
Stringify'ing all inputs to avoid precision loss

### DIFF
--- a/src/actions/callactivityaction.ts
+++ b/src/actions/callactivityaction.ts
@@ -6,14 +6,7 @@ export class CallActivityAction implements IAction {
     public readonly input: unknown;
 
     constructor(public readonly functionName: string, input?: unknown) {
-        // If we fail to stringify inputs, they may get deserialized incorrectly.
-        // For instance: "13131" might get interpreted as a number.
-        // Somehow this doesn't appear to occur with other datatypes, but we should
-        // investigate that further.
-        if (typeof input === "string") {
-            input = JSON.stringify(input);
-        }
-        this.input = input;
+        this.input = Utils.processInput(input);
         Utils.throwIfEmpty(functionName, "functionName");
     }
 }

--- a/src/actions/callactivityaction.ts
+++ b/src/actions/callactivityaction.ts
@@ -10,7 +10,7 @@ export class CallActivityAction implements IAction {
         // For instance: "13131" might get interpreted as a number.
         // Somehow this doesn't appear to occur with other datatypes, but we should
         // investigate that further.
-        if (input instanceof String) {
+        if (typeof input === "string") {
             input = JSON.stringify(input);
         }
         this.input = input;

--- a/src/actions/callactivityaction.ts
+++ b/src/actions/callactivityaction.ts
@@ -6,7 +6,14 @@ export class CallActivityAction implements IAction {
     public readonly input: unknown;
 
     constructor(public readonly functionName: string, input?: unknown) {
-        this.input = JSON.stringify(input);
+        // If we fail to stringify inputs, they may get deserialized incorrectly.
+        // For instance: "13131" might get interpreted as a number.
+        // Somehow this doesn't appear to occur with other datatypes, but we should
+        // investigate that further.
+        if (input instanceof String) {
+            input = JSON.stringify(input);
+        }
+        this.input = input;
         Utils.throwIfEmpty(functionName, "functionName");
     }
 }

--- a/src/actions/callactivityaction.ts
+++ b/src/actions/callactivityaction.ts
@@ -3,8 +3,10 @@ import { ActionType, IAction, Utils } from "../classes";
 /** @hidden */
 export class CallActivityAction implements IAction {
     public readonly actionType: ActionType = ActionType.CallActivity;
+    public readonly input: unknown;
 
-    constructor(public readonly functionName: string, public readonly input?: unknown) {
+    constructor(public readonly functionName: string, input?: unknown) {
+        this.input = JSON.stringify(input);
         Utils.throwIfEmpty(functionName, "functionName");
     }
 }

--- a/src/actions/callactivitywithretryaction.ts
+++ b/src/actions/callactivitywithretryaction.ts
@@ -3,12 +3,14 @@ import { ActionType, IAction, RetryOptions, Utils } from "../classes";
 /** @hidden */
 export class CallActivityWithRetryAction implements IAction {
     public readonly actionType: ActionType = ActionType.CallActivityWithRetry;
+    public readonly input: unknown;
 
     constructor(
         public readonly functionName: string,
         public readonly retryOptions: RetryOptions,
-        public readonly input?: unknown
+        input?: unknown
     ) {
+        this.input = JSON.stringify(input);
         Utils.throwIfEmpty(functionName, "functionName");
 
         Utils.throwIfNotInstanceOf<RetryOptions>(

--- a/src/actions/callactivitywithretryaction.ts
+++ b/src/actions/callactivitywithretryaction.ts
@@ -10,7 +10,14 @@ export class CallActivityWithRetryAction implements IAction {
         public readonly retryOptions: RetryOptions,
         input?: unknown
     ) {
-        this.input = JSON.stringify(input);
+        // If we fail to stringify inputs, they may get deserialized incorrectly.
+        // For instance: "13131" might get interpreted as a number.
+        // Somehow this doesn't appear to occur with other datatypes, but we should
+        // investigate that further.
+        if (input instanceof String) {
+            input = JSON.stringify(input);
+        }
+        this.input = input;
         Utils.throwIfEmpty(functionName, "functionName");
 
         Utils.throwIfNotInstanceOf<RetryOptions>(

--- a/src/actions/callactivitywithretryaction.ts
+++ b/src/actions/callactivitywithretryaction.ts
@@ -14,7 +14,7 @@ export class CallActivityWithRetryAction implements IAction {
         // For instance: "13131" might get interpreted as a number.
         // Somehow this doesn't appear to occur with other datatypes, but we should
         // investigate that further.
-        if (input instanceof String) {
+        if (typeof input === "string") {
             input = JSON.stringify(input);
         }
         this.input = input;

--- a/src/actions/callactivitywithretryaction.ts
+++ b/src/actions/callactivitywithretryaction.ts
@@ -10,14 +10,7 @@ export class CallActivityWithRetryAction implements IAction {
         public readonly retryOptions: RetryOptions,
         input?: unknown
     ) {
-        // If we fail to stringify inputs, they may get deserialized incorrectly.
-        // For instance: "13131" might get interpreted as a number.
-        // Somehow this doesn't appear to occur with other datatypes, but we should
-        // investigate that further.
-        if (typeof input === "string") {
-            input = JSON.stringify(input);
-        }
-        this.input = input;
+        this.input = Utils.processInput(input);
         Utils.throwIfEmpty(functionName, "functionName");
 
         Utils.throwIfNotInstanceOf<RetryOptions>(

--- a/src/actions/callentityaction.ts
+++ b/src/actions/callentityaction.ts
@@ -4,15 +4,13 @@ import { ActionType, EntityId, IAction, Utils } from "../classes";
 export class CallEntityAction implements IAction {
     public readonly actionType: ActionType = ActionType.CallEntity;
     public readonly instanceId: string;
+    public readonly input: unknown;
 
-    constructor(
-        entityId: EntityId,
-        public readonly operation: string,
-        public readonly input?: unknown
-    ) {
+    constructor(entityId: EntityId, public readonly operation: string, input?: unknown) {
         if (!entityId) {
             throw new Error("Must provide EntityId to CallEntityAction constructor");
         }
+        this.input = JSON.stringify(input);
         Utils.throwIfEmpty(operation, "operation");
         this.instanceId = EntityId.getSchedulerIdFromEntityId(entityId);
     }

--- a/src/actions/callentityaction.ts
+++ b/src/actions/callentityaction.ts
@@ -10,14 +10,7 @@ export class CallEntityAction implements IAction {
         if (!entityId) {
             throw new Error("Must provide EntityId to CallEntityAction constructor");
         }
-        // If we fail to stringify inputs, they may get deserialized incorrectly.
-        // For instance: "13131" might get interpreted as a number.
-        // Somehow this doesn't appear to occur with other datatypes, but we should
-        // investigate that further.
-        if (typeof input === "string") {
-            input = JSON.stringify(input);
-        }
-        this.input = input;
+        this.input = Utils.processInput(input);
         Utils.throwIfEmpty(operation, "operation");
         this.instanceId = EntityId.getSchedulerIdFromEntityId(entityId);
     }

--- a/src/actions/callentityaction.ts
+++ b/src/actions/callentityaction.ts
@@ -14,7 +14,7 @@ export class CallEntityAction implements IAction {
         // For instance: "13131" might get interpreted as a number.
         // Somehow this doesn't appear to occur with other datatypes, but we should
         // investigate that further.
-        if (input instanceof String) {
+        if (typeof input === "string") {
             input = JSON.stringify(input);
         }
         this.input = input;

--- a/src/actions/callentityaction.ts
+++ b/src/actions/callentityaction.ts
@@ -10,7 +10,14 @@ export class CallEntityAction implements IAction {
         if (!entityId) {
             throw new Error("Must provide EntityId to CallEntityAction constructor");
         }
-        this.input = JSON.stringify(input);
+        // If we fail to stringify inputs, they may get deserialized incorrectly.
+        // For instance: "13131" might get interpreted as a number.
+        // Somehow this doesn't appear to occur with other datatypes, but we should
+        // investigate that further.
+        if (input instanceof String) {
+            input = JSON.stringify(input);
+        }
+        this.input = input;
         Utils.throwIfEmpty(operation, "operation");
         this.instanceId = EntityId.getSchedulerIdFromEntityId(entityId);
     }

--- a/src/actions/callsuborchestratoraction.ts
+++ b/src/actions/callsuborchestratoraction.ts
@@ -10,7 +10,14 @@ export class CallSubOrchestratorAction implements IAction {
         public readonly instanceId?: string,
         input?: unknown
     ) {
-        this.input = JSON.stringify(input);
+        // If we fail to stringify inputs, they may get deserialized incorrectly.
+        // For instance: "13131" might get interpreted as a number.
+        // Somehow this doesn't appear to occur with other datatypes, but we should
+        // investigate that further.
+        if (input instanceof String) {
+            input = JSON.stringify(input);
+        }
+        this.input = input;
         Utils.throwIfEmpty(functionName, "functionName");
 
         if (instanceId) {

--- a/src/actions/callsuborchestratoraction.ts
+++ b/src/actions/callsuborchestratoraction.ts
@@ -3,12 +3,14 @@ import { ActionType, IAction, Utils } from "../classes";
 /** @hidden */
 export class CallSubOrchestratorAction implements IAction {
     public readonly actionType: ActionType = ActionType.CallSubOrchestrator;
+    public readonly input: unknown;
 
     constructor(
         public readonly functionName: string,
         public readonly instanceId?: string,
-        public readonly input?: unknown
+        input?: unknown
     ) {
+        this.input = JSON.stringify(input);
         Utils.throwIfEmpty(functionName, "functionName");
 
         if (instanceId) {

--- a/src/actions/callsuborchestratoraction.ts
+++ b/src/actions/callsuborchestratoraction.ts
@@ -10,14 +10,7 @@ export class CallSubOrchestratorAction implements IAction {
         public readonly instanceId?: string,
         input?: unknown
     ) {
-        // If we fail to stringify inputs, they may get deserialized incorrectly.
-        // For instance: "13131" might get interpreted as a number.
-        // Somehow this doesn't appear to occur with other datatypes, but we should
-        // investigate that further.
-        if (typeof input === "string") {
-            input = JSON.stringify(input);
-        }
-        this.input = input;
+        this.input = Utils.processInput(input);
         Utils.throwIfEmpty(functionName, "functionName");
 
         if (instanceId) {

--- a/src/actions/callsuborchestratoraction.ts
+++ b/src/actions/callsuborchestratoraction.ts
@@ -14,7 +14,7 @@ export class CallSubOrchestratorAction implements IAction {
         // For instance: "13131" might get interpreted as a number.
         // Somehow this doesn't appear to occur with other datatypes, but we should
         // investigate that further.
-        if (input instanceof String) {
+        if (typeof input === "string") {
             input = JSON.stringify(input);
         }
         this.input = input;

--- a/src/actions/callsuborchestratorwithretryaction.ts
+++ b/src/actions/callsuborchestratorwithretryaction.ts
@@ -3,13 +3,15 @@ import { ActionType, IAction, RetryOptions, Utils } from "../classes";
 /** @hidden */
 export class CallSubOrchestratorWithRetryAction implements IAction {
     public readonly actionType: ActionType = ActionType.CallSubOrchestratorWithRetry;
+    public readonly input: unknown;
 
     constructor(
         public readonly functionName: string,
         public readonly retryOptions: RetryOptions,
-        public readonly input?: unknown,
+        input?: unknown,
         public readonly instanceId?: string
     ) {
+        this.input = JSON.stringify(input);
         Utils.throwIfEmpty(functionName, "functionName");
 
         Utils.throwIfNotInstanceOf<RetryOptions>(

--- a/src/actions/callsuborchestratorwithretryaction.ts
+++ b/src/actions/callsuborchestratorwithretryaction.ts
@@ -11,14 +11,7 @@ export class CallSubOrchestratorWithRetryAction implements IAction {
         input?: unknown,
         public readonly instanceId?: string
     ) {
-        // If we fail to stringify inputs, they may get deserialized incorrectly.
-        // For instance: "13131" might get interpreted as a number.
-        // Somehow this doesn't appear to occur with other datatypes, but we should
-        // investigate that further.
-        if (typeof input === "string") {
-            input = JSON.stringify(input);
-        }
-        this.input = input;
+        this.input = Utils.processInput(input);
         Utils.throwIfEmpty(functionName, "functionName");
 
         Utils.throwIfNotInstanceOf<RetryOptions>(

--- a/src/actions/callsuborchestratorwithretryaction.ts
+++ b/src/actions/callsuborchestratorwithretryaction.ts
@@ -15,7 +15,7 @@ export class CallSubOrchestratorWithRetryAction implements IAction {
         // For instance: "13131" might get interpreted as a number.
         // Somehow this doesn't appear to occur with other datatypes, but we should
         // investigate that further.
-        if (input instanceof String) {
+        if (typeof input === "string") {
             input = JSON.stringify(input);
         }
         this.input = input;

--- a/src/actions/callsuborchestratorwithretryaction.ts
+++ b/src/actions/callsuborchestratorwithretryaction.ts
@@ -11,7 +11,14 @@ export class CallSubOrchestratorWithRetryAction implements IAction {
         input?: unknown,
         public readonly instanceId?: string
     ) {
-        this.input = JSON.stringify(input);
+        // If we fail to stringify inputs, they may get deserialized incorrectly.
+        // For instance: "13131" might get interpreted as a number.
+        // Somehow this doesn't appear to occur with other datatypes, but we should
+        // investigate that further.
+        if (input instanceof String) {
+            input = JSON.stringify(input);
+        }
+        this.input = input;
         Utils.throwIfEmpty(functionName, "functionName");
 
         Utils.throwIfNotInstanceOf<RetryOptions>(

--- a/src/actions/continueasnewaction.ts
+++ b/src/actions/continueasnewaction.ts
@@ -6,6 +6,14 @@ export class ContinueAsNewAction implements IAction {
     public readonly input: unknown;
 
     constructor(input: unknown) {
-        this.input = JSON.stringify(input);
+        // If we fail to stringify inputs, they may get deserialized incorrectly.
+        // For instance: "13131" might get interpreted as a number.
+        // Somehow this doesn't appear to occur with other datatypes, but we should
+        // investigate that further.
+
+        if (input instanceof String) {
+            input = JSON.stringify(input);
+        }
+        this.input = input;
     }
 }

--- a/src/actions/continueasnewaction.ts
+++ b/src/actions/continueasnewaction.ts
@@ -3,6 +3,9 @@ import { ActionType, IAction } from "../classes";
 /** @hidden */
 export class ContinueAsNewAction implements IAction {
     public readonly actionType: ActionType = ActionType.ContinueAsNew;
+    public readonly input: unknown;
 
-    constructor(public readonly input: unknown) {}
+    constructor(input: unknown) {
+        this.input = JSON.stringify(input);
+    }
 }

--- a/src/actions/continueasnewaction.ts
+++ b/src/actions/continueasnewaction.ts
@@ -10,8 +10,7 @@ export class ContinueAsNewAction implements IAction {
         // For instance: "13131" might get interpreted as a number.
         // Somehow this doesn't appear to occur with other datatypes, but we should
         // investigate that further.
-
-        if (input instanceof String) {
+        if (typeof input === "string") {
             input = JSON.stringify(input);
         }
         this.input = input;

--- a/src/actions/continueasnewaction.ts
+++ b/src/actions/continueasnewaction.ts
@@ -1,4 +1,4 @@
-import { ActionType, IAction } from "../classes";
+import { ActionType, IAction, Utils } from "../classes";
 
 /** @hidden */
 export class ContinueAsNewAction implements IAction {
@@ -6,13 +6,6 @@ export class ContinueAsNewAction implements IAction {
     public readonly input: unknown;
 
     constructor(input: unknown) {
-        // If we fail to stringify inputs, they may get deserialized incorrectly.
-        // For instance: "13131" might get interpreted as a number.
-        // Somehow this doesn't appear to occur with other datatypes, but we should
-        // investigate that further.
-        if (typeof input === "string") {
-            input = JSON.stringify(input);
-        }
-        this.input = input;
+        this.input = Utils.processInput(input);
     }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,15 @@
 /** @hidden */
 export class Utils {
+    public static processInput<T>(input: string | T): string | T {
+        // If we fail to stringify inputs, they may get deserialized incorrectly.
+        // For instance: "13131" might get interpreted as a number.
+        // Somehow this doesn't appear to occur with other datatypes, but we should
+        // investigate that further.
+        if (typeof input === "string") {
+            input = JSON.stringify(input);
+        }
+        return input;
+    }
     public static getInstancesOf<T>(
         collection: { [index: string]: unknown },
         typeInstance: T


### PR DESCRIPTION
**WIP** : _Do not merge, work in progress...._

**Related issues:** https://github.com/Azure/azure-functions-durable-extension/issues/1476, https://github.com/Azure/azure-functions-durable-js/issues/215  

**Problem:** We have encountered a handful of tickets where values are somehow interpreted, and changed, in the pipeline between orchestrator-activity and trigger-activity. A classic example of this is `Date` serialization, where interpreting a Date mid-pipeline could change its encoding. Something similar would occur with `BigInt`s, where interpreting it mid-pipeline could introduce precision problems. These are the cases described in the two related issues above respectively.

**Insight:** 

In Durable Python,  the `Input` field of an `Action` object is serialized before the serializing the `Action` object itself. This means that, in order to interpret an `Input` field as anything other than a string, you have to decode the `Input` field after decoding the `Action` object itself. 

The effect of this is that out-of-proc input data flowing through `durable-extension` is interpreted as string, and left alone. We can see an example of this eager input serialization in python [here](https://github.com/Azure/azure-functions-durable-python/blob/65188f28fc2f6951a91293435bd6d51cef6a193a/azure/durable_functions/models/actions/CallActivityAction.py#L19) and [here](https://github.com/Azure/azure-functions-durable-python/blob/65188f28fc2f6951a91293435bd6d51cef6a193a/azure/durable_functions/models/actions/CallSubOrchestratorAction.py#L16). Note, the `dumps` method there means "dump to a JSON-string". Observe how that occurs at the level of object construction, so when the object itself gets serialized later, the `Input` gets "doubly" serialized.

However, we do not do this in JS. I think this is because JS can natively emit JSON objects, so we the extension can readily accept its data. That being said, it runs the risk of C# and others interpreting JSON-native datatypes like integers and dates, and changing their precision. 

**This PR:**

This PR introduces the same eager-serialization of `Input` fields in `Action` objects that we see in Python. This is quite the invasive change, and somehow none of our tests complained, so we are going to require some serious testing, and adding extra tests, before merging.

