### PR TITLE
Update CI refs to track main, not master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 |Branch|Status|
 |---|---|
-|master|[![Build Status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/Azure.azure-functions-durable-js?branchName=master)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=13&branchName=master)|
+|main|[![Build Status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/Azure.azure-functions-durable-js?branchName=main)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=13&branchName=main)|
 |dev|[![Build Status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/Azure.azure-functions-durable-js?branchName=dev)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=13&branchName=dev)|
 
 # Durable Functions for Node.js

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ variables: {
 name: $(MODULE_VERSION)-$(Date:yyyyMMdd)$(Rev:.r)
 
 trigger:
-- master
+- main
 - dev
 
 jobs:


### PR DESCRIPTION
As in title, part of: Azure/azure-functions-durable-extension#1606

This PR updates our CI config file to track `main` instead of `master`.