### PR TITLE
Add missing NodeJS types to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
         "rimraf": "~2.5.4",
         "typedoc": "^0.17.1",
         "uuid": "~3.3.2",
-        "validator": "~10.8.0"
+        "validator": "~10.8.0",
+        "@types/node": "10.14.2"
     },
     "devDependencies": {
         "@azure/functions": "^1.2.3",
@@ -56,7 +57,6 @@
         "@types/debug": "0.0.29",
         "@types/mocha": "~7.0.2",
         "@types/nock": "^9.3.0",
-        "@types/node": "~6.14.7",
         "@types/rimraf": "0.0.28",
         "@types/sinon": "~5.0.5",
         "@typescript-eslint/eslint-plugin": "^2.21.0",


### PR DESCRIPTION
Resolves: https://github.com/Azure/azure-functions-durable-js/issues/167

This PR adds missing typing dependencies to our TypeScript package. This should allow our TypeScript users to be able to compile their projects without needing to do an extra installation step via: `npm install @types/node`.