### PR TITLE
Merge dev to main for release 1.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "durable-functions",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "durable-functions",
-            "version": "1.5.1",
+            "version": "1.5.2",
             "license": "MIT",
             "dependencies": {
                 "@azure/functions": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "durable-functions",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "description": "Durable Functions library for Node.js Azure Functions",
     "license": "MIT",
     "repository": {


### PR DESCRIPTION
Follow-up to https://github.com/Azure/azure-functions-durable-js/pull/279.
Version metadata had not been updated in the first PR.