### PR TITLE
Update various dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -514,14 +514,6 @@
                 "follow-redirects": "^1.14.0"
             }
         },
-        "node_modules/backbone": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
-            "integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
-            "dependencies": {
-                "underscore": ">=1.8.3"
-            }
-        },
         "node_modules/balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -1374,8 +1366,7 @@
         "node_modules/function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-            "dev": true
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
         "node_modules/functional-red-black-tree": {
             "version": "1.0.1",
@@ -1493,7 +1484,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dev": true,
             "dependencies": {
                 "function-bind": "^1.1.1"
             },
@@ -1541,9 +1531,9 @@
             }
         },
         "node_modules/highlight.js": {
-            "version": "9.18.5",
-            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.5.tgz",
-            "integrity": "sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==",
+            "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+            "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
             "engines": {
                 "node": "*"
             }
@@ -1639,9 +1629,9 @@
             }
         },
         "node_modules/inquirer/node_modules/ansi-regex": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "engines": {
                 "node": ">=8"
@@ -1766,9 +1756,9 @@
             }
         },
         "node_modules/interpret": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-            "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
             "engines": {
                 "node": ">= 0.10"
             }
@@ -1801,6 +1791,17 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/is-core-module": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
+            "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
+            "dependencies": {
+                "has": "^1.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-date-object": {
@@ -1892,11 +1893,6 @@
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
             "dev": true
-        },
-        "node_modules/jquery": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
-            "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
         },
         "node_modules/js-yaml": {
             "version": "3.13.1",
@@ -2050,9 +2046,9 @@
             "dev": true
         },
         "node_modules/lunr": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.8.tgz",
-            "integrity": "sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg=="
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+            "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
         },
         "node_modules/make-error": {
             "version": "1.3.6",
@@ -2061,9 +2057,9 @@
             "dev": true
         },
         "node_modules/marked": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.1.tgz",
-            "integrity": "sha512-tZfJS8uE0zpo7xpTffwFwYRfW9AzNcdo04Qcjs+C9+oCy8MSRD2reD5iDVtYx8mtLaqsGughw/YLlcwNxAHA1g==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-1.0.0.tgz",
+            "integrity": "sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng==",
             "bin": {
                 "marked": "bin/marked"
             },
@@ -2109,9 +2105,9 @@
             }
         },
         "node_modules/mocha": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.1.tgz",
-            "integrity": "sha512-3qQsu3ijNS3GkWcccT5Zw0hf/rWvu1fTN9sPvEd81hlwsr30GX2GcDSSoBxo24IR8FelmrAydGC6/1J5QQP4WA==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.2.tgz",
+            "integrity": "sha512-o96kdRKMKI3E8U0bjnfqW4QMk12MwZ4mhdBTf+B5a1q9+aq2HRnj+3ZdJu0B/ZhJeK78MgYuv6L8d/rA5AeBJA==",
             "dev": true,
             "dependencies": {
                 "ansi-colors": "3.2.3",
@@ -2127,7 +2123,7 @@
                 "js-yaml": "3.13.1",
                 "log-symbols": "3.0.0",
                 "minimatch": "3.0.4",
-                "mkdirp": "0.5.3",
+                "mkdirp": "0.5.5",
                 "ms": "2.1.1",
                 "node-environment-flags": "1.0.6",
                 "object.assign": "4.1.0",
@@ -2144,7 +2140,11 @@
                 "mocha": "bin/mocha"
             },
             "engines": {
-                "node": ">= 8.0.0"
+                "node": ">= 8.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mochajs"
             }
         },
         "node_modules/mocha/node_modules/debug": {
@@ -2154,18 +2154,6 @@
             "dev": true,
             "dependencies": {
                 "ms": "^2.1.1"
-            }
-        },
-        "node_modules/mocha/node_modules/mkdirp": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-            "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
-            "dev": true,
-            "dependencies": {
-                "minimist": "^1.2.5"
-            },
-            "bin": {
-                "mkdirp": "bin/cmd.js"
             }
         },
         "node_modules/mocha/node_modules/ms": {
@@ -2466,9 +2454,9 @@
             }
         },
         "node_modules/path-parse": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
         },
         "node_modules/path-to-regexp": {
             "version": "1.7.0",
@@ -2790,11 +2778,15 @@
             "dev": true
         },
         "node_modules/resolve": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-            "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+            "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
             "dependencies": {
-                "path-parse": "^1.0.5"
+                "is-core-module": "^2.2.0",
+                "path-parse": "^1.0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/resolve-from": {
@@ -2885,9 +2877,9 @@
             }
         },
         "node_modules/shelljs": {
-            "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
-            "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+            "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+            "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
             "dependencies": {
                 "glob": "^7.0.0",
                 "interpret": "^1.0.0",
@@ -3278,36 +3270,37 @@
             }
         },
         "node_modules/typedoc": {
-            "version": "0.17.1",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.1.tgz",
-            "integrity": "sha512-1AckBdQNvBm0jgR7eko9t3FMPfjoxiKEpQx8ePCsyfTQDPwLVpFIFzn5pXA+smDGTWf2BT7FQrKU6BDzSdgMng==",
+            "version": "0.17.8",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.8.tgz",
+            "integrity": "sha512-/OyrHCJ8jtzu+QZ+771YaxQ9s4g5Z3XsQE3Ma7q+BL392xxBn4UMvvCdVnqKC2T/dz03/VXSLVKOP3lHmDdc/w==",
             "dependencies": {
                 "fs-extra": "^8.1.0",
-                "handlebars": "^4.7.3",
-                "highlight.js": "^9.18.1",
+                "handlebars": "^4.7.6",
+                "highlight.js": "^10.0.0",
                 "lodash": "^4.17.15",
-                "marked": "^0.8.0",
+                "lunr": "^2.3.8",
+                "marked": "1.0.0",
                 "minimatch": "^3.0.0",
                 "progress": "^2.0.3",
-                "shelljs": "^0.8.3",
-                "typedoc-default-themes": "^0.8.0"
+                "shelljs": "^0.8.4",
+                "typedoc-default-themes": "^0.10.2"
             },
             "bin": {
                 "typedoc": "bin/typedoc"
             },
             "engines": {
                 "node": ">= 8.0.0"
+            },
+            "peerDependencies": {
+                "typescript": ">=3.8.3"
             }
         },
         "node_modules/typedoc-default-themes": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.8.0.tgz",
-            "integrity": "sha512-0bzAjVEX6ClhE3jLRdU7vR8Fsfbt4ZcPa+gkqyAVgTlQ1fLo/7AkCbTP+hC5XAiByDfRfsAGqj9y6FNjJh0p4A==",
+            "version": "0.10.2",
+            "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.10.2.tgz",
+            "integrity": "sha512-zo09yRj+xwLFE3hyhJeVHWRSPuKEIAsFK5r2u47KL/HBKqpwdUSanoaz5L34IKiSATFrjG5ywmIu98hPVMfxZg==",
             "dependencies": {
-                "backbone": "^1.4.0",
-                "jquery": "^3.4.1",
-                "lunr": "^2.3.8",
-                "underscore": "^1.9.2"
+                "lunr": "^2.3.8"
             },
             "engines": {
                 "node": ">= 8"
@@ -3317,7 +3310,6 @@
             "version": "3.8.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
             "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
-            "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -3346,11 +3338,6 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "optional": true
-        },
-        "node_modules/underscore": {
-            "version": "1.13.1",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-            "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
         },
         "node_modules/universalify": {
             "version": "0.1.2",
@@ -4064,14 +4051,6 @@
                 "follow-redirects": "^1.14.0"
             }
         },
-        "backbone": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
-            "integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
-            "requires": {
-                "underscore": ">=1.8.3"
-            }
-        },
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -4753,8 +4732,7 @@
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-            "dev": true
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
         "functional-red-black-tree": {
             "version": "1.0.1",
@@ -4843,7 +4821,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dev": true,
             "requires": {
                 "function-bind": "^1.1.1"
             }
@@ -4876,9 +4853,9 @@
             "dev": true
         },
         "highlight.js": {
-            "version": "9.18.5",
-            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.5.tgz",
-            "integrity": "sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA=="
+            "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+            "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
         },
         "iconv-lite": {
             "version": "0.4.24",
@@ -4953,9 +4930,9 @@
             },
             "dependencies": {
                 "ansi-regex": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
                     "dev": true
                 },
                 "ansi-styles": {
@@ -5052,9 +5029,9 @@
             }
         },
         "interpret": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-            "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
         },
         "is-binary-path": {
             "version": "2.1.0",
@@ -5076,6 +5053,14 @@
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
             "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
             "dev": true
+        },
+        "is-core-module": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
+            "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
+            "requires": {
+                "has": "^1.0.3"
+            }
         },
         "is-date-object": {
             "version": "1.0.2",
@@ -5145,11 +5130,6 @@
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
             "dev": true
-        },
-        "jquery": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
-            "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
         },
         "js-yaml": {
             "version": "3.13.1",
@@ -5284,9 +5264,9 @@
             "dev": true
         },
         "lunr": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.8.tgz",
-            "integrity": "sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg=="
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+            "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
         },
         "make-error": {
             "version": "1.3.6",
@@ -5295,9 +5275,9 @@
             "dev": true
         },
         "marked": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.1.tgz",
-            "integrity": "sha512-tZfJS8uE0zpo7xpTffwFwYRfW9AzNcdo04Qcjs+C9+oCy8MSRD2reD5iDVtYx8mtLaqsGughw/YLlcwNxAHA1g=="
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-1.0.0.tgz",
+            "integrity": "sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng=="
         },
         "mimic-fn": {
             "version": "2.1.0",
@@ -5328,9 +5308,9 @@
             }
         },
         "mocha": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.1.tgz",
-            "integrity": "sha512-3qQsu3ijNS3GkWcccT5Zw0hf/rWvu1fTN9sPvEd81hlwsr30GX2GcDSSoBxo24IR8FelmrAydGC6/1J5QQP4WA==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.2.tgz",
+            "integrity": "sha512-o96kdRKMKI3E8U0bjnfqW4QMk12MwZ4mhdBTf+B5a1q9+aq2HRnj+3ZdJu0B/ZhJeK78MgYuv6L8d/rA5AeBJA==",
             "dev": true,
             "requires": {
                 "ansi-colors": "3.2.3",
@@ -5346,7 +5326,7 @@
                 "js-yaml": "3.13.1",
                 "log-symbols": "3.0.0",
                 "minimatch": "3.0.4",
-                "mkdirp": "0.5.3",
+                "mkdirp": "0.5.5",
                 "ms": "2.1.1",
                 "node-environment-flags": "1.0.6",
                 "object.assign": "4.1.0",
@@ -5366,15 +5346,6 @@
                     "dev": true,
                     "requires": {
                         "ms": "^2.1.1"
-                    }
-                },
-                "mkdirp": {
-                    "version": "0.5.3",
-                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-                    "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
-                    "dev": true,
-                    "requires": {
-                        "minimist": "^1.2.5"
                     }
                 },
                 "ms": {
@@ -5629,9 +5600,9 @@
             "dev": true
         },
         "path-parse": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
         },
         "path-to-regexp": {
             "version": "1.7.0",
@@ -5878,11 +5849,12 @@
             "dev": true
         },
         "resolve": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-            "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+            "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
             "requires": {
-                "path-parse": "^1.0.5"
+                "is-core-module": "^2.2.0",
+                "path-parse": "^1.0.6"
             }
         },
         "resolve-from": {
@@ -5952,9 +5924,9 @@
             "dev": true
         },
         "shelljs": {
-            "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
-            "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+            "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+            "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
             "requires": {
                 "glob": "^7.0.0",
                 "interpret": "^1.0.0",
@@ -6270,37 +6242,34 @@
             "dev": true
         },
         "typedoc": {
-            "version": "0.17.1",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.1.tgz",
-            "integrity": "sha512-1AckBdQNvBm0jgR7eko9t3FMPfjoxiKEpQx8ePCsyfTQDPwLVpFIFzn5pXA+smDGTWf2BT7FQrKU6BDzSdgMng==",
+            "version": "0.17.8",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.8.tgz",
+            "integrity": "sha512-/OyrHCJ8jtzu+QZ+771YaxQ9s4g5Z3XsQE3Ma7q+BL392xxBn4UMvvCdVnqKC2T/dz03/VXSLVKOP3lHmDdc/w==",
             "requires": {
                 "fs-extra": "^8.1.0",
-                "handlebars": "^4.7.3",
-                "highlight.js": "^9.18.1",
+                "handlebars": "^4.7.6",
+                "highlight.js": "^10.0.0",
                 "lodash": "^4.17.15",
-                "marked": "^0.8.0",
+                "lunr": "^2.3.8",
+                "marked": "1.0.0",
                 "minimatch": "^3.0.0",
                 "progress": "^2.0.3",
-                "shelljs": "^0.8.3",
-                "typedoc-default-themes": "^0.8.0"
+                "shelljs": "^0.8.4",
+                "typedoc-default-themes": "^0.10.2"
             }
         },
         "typedoc-default-themes": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.8.0.tgz",
-            "integrity": "sha512-0bzAjVEX6ClhE3jLRdU7vR8Fsfbt4ZcPa+gkqyAVgTlQ1fLo/7AkCbTP+hC5XAiByDfRfsAGqj9y6FNjJh0p4A==",
+            "version": "0.10.2",
+            "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.10.2.tgz",
+            "integrity": "sha512-zo09yRj+xwLFE3hyhJeVHWRSPuKEIAsFK5r2u47KL/HBKqpwdUSanoaz5L34IKiSATFrjG5ywmIu98hPVMfxZg==",
             "requires": {
-                "backbone": "^1.4.0",
-                "jquery": "^3.4.1",
-                "lunr": "^2.3.8",
-                "underscore": "^1.9.2"
+                "lunr": "^2.3.8"
             }
         },
         "typescript": {
             "version": "3.8.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-            "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
-            "dev": true
+            "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w=="
         },
         "uglify-js": {
             "version": "3.9.0",
@@ -6318,11 +6287,6 @@
                     "optional": true
                 }
             }
-        },
-        "underscore": {
-            "version": "1.13.1",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-            "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
         },
         "universalify": {
             "version": "0.1.2",


### PR DESCRIPTION
The node package manager provides very helpful utilities that warn package maintainers of when they should be upgrading various dependencies for performance, security, and correctness reasons. One such tool is `npm audit` which performs an audit of dependencies and raises warnings when those are due for an update.

Running `npm audit fix` automatically updates dependencies that do not introduce breaking changes. This PR is the result of running `npm audit fix`.