### PR TITLE
Update Azure DevOps pipeline

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
     "tabWidth": 4,
     "true": false,
     "singleQuote": false,
-    "printWidth": 100
+    "printWidth": 100,
+    "endOfLine": "auto"
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,6 +73,8 @@ jobs:
             displayName: "npm ci"
           - script: npm build
             displayName: "npm build"
+          - script: npm prune --production
+            displayName: "npm prune --production" # so that only production dependencies are included in SBOM
           - task: ManifestGeneratorTask@0
             displayName: "SBOM Generation Task"
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,8 +3,10 @@ variables:
 name: $(MODULE_VERSION)-$(Date:yyyyMMdd)$(Rev:.r)
 
 trigger:
-    - main
-    - dev
+    branches:
+        include:
+            - main
+            - dev
 
 jobs:
     - job: UnitTests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,11 +2,15 @@ variables:
     { MODULE_VERSION: "1.2.2", NODE_10: "10.x", NODE_12: "12.x", NODE_14: "14.x", NODE_16: "16.x" }
 name: $(MODULE_VERSION)-$(Date:yyyyMMdd)$(Rev:.r)
 
-trigger:
+pr:
     branches:
         include:
             - main
             - dev
+
+trigger:
+    - main
+    - dev
 
 jobs:
     - job: UnitTests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,9 +10,6 @@ jobs:
     - job: UnitTests
       strategy:
           matrix:
-              WINDOWS_NODE8:
-                  IMAGE_TYPE: "vs2017-win2016"
-                  NODE_VERSION: $(NODE_8)
               WINDOWS_NODE10:
                   IMAGE_TYPE: "vs2017-win2016"
                   NODE_VERSION: $(NODE_10)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,9 @@ jobs:
               UBUNTU_NODE10:
                   IMAGE_TYPE: "ubuntu-latest"
                   NODE_VERSION: $(NODE_10)
+              UBUNTU_NODE12:
+                  IMAGE_TYPE: "ubuntu-latest"
+                  NODE_VERSION: $(NODE_12)
               UBUNTU_NODE14:
                   IMAGE_TYPE: "ubuntu-latest"
                   NODE_VERSION: $(NODE_14)
@@ -24,6 +27,9 @@ jobs:
               WINDOWS_NODE10:
                   IMAGE_TYPE: "windows-latest"
                   NODE_VERSION: $(NODE_10)
+              WINDOWS_NODE12:
+                  IMAGE_TYPE: "windows-latest"
+                  NODE_VERSION: $(NODE_12)
               WINDOWS_NODE14:
                   IMAGE_TYPE: "windows-latest"
                   NODE_VERSION: $(NODE_14)
@@ -33,6 +39,9 @@ jobs:
               MAC_NODE10:
                   IMAGE_TYPE: "macOS-latest"
                   NODE_VERSION: $(NODE_10)
+              MAC_NODE12:
+                  IMAGE_TYPE: "macOS-latest"
+                  NODE_VERSION: $(NODE_12)
               MAC_NODE14:
                   IMAGE_TYPE: "macOS-latest"
                   NODE_VERSION: $(NODE_14)
@@ -45,9 +54,9 @@ jobs:
           - task: NodeTool@0
             inputs:
                 versionSpec: $(NODE_VERSION)
-            displayName: "Install Node.js"
-          - script: npm install
-            displayName: "npm install"
+            displayName: "Install Node dependencies"
+          - script: npm ci
+            displayName: "npm ci"
           - script: npm run test
             displayName: "npm build and test"
           - script: npm run test:nolint

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 variables:
-    { MODULE_VERSION: "1.2.2", NODE_8: "8.x", NODE_10: "10.x", NODE_12: "12.x", NODE_14: "14.x" }
+    { MODULE_VERSION: "1.2.2", NODE_10: "10.x", NODE_12: "12.x", NODE_14: "14.x", NODE_16: "16.x" }
 name: $(MODULE_VERSION)-$(Date:yyyyMMdd)$(Rev:.r)
 
 trigger:
@@ -10,15 +10,33 @@ jobs:
     - job: UnitTests
       strategy:
           matrix:
-              WINDOWS_NODE10:
-                  IMAGE_TYPE: "vs2017-win2016"
+              UBUNTU_NODE10:
+                  IMAGE_TYPE: "ubuntu-latest"
                   NODE_VERSION: $(NODE_10)
-              WINDOWS_NODE12:
-                  IMAGE_TYPE: "vs2017-win2016"
-                  NODE_VERSION: $(NODE_12)
-              WINDOWS_NODE14:
-                  IMAGE_TYPE: "vs2017-win2016"
+              UBUNTU_NODE14:
+                  IMAGE_TYPE: "ubuntu-latest"
                   NODE_VERSION: $(NODE_14)
+              UBUNTU_NODE16:
+                  IMAGE_TYPE: "ubuntu-latest"
+                  NODE_VERSION: $(NODE_16)
+              WINDOWS_NODE10:
+                  IMAGE_TYPE: "windows-latest"
+                  NODE_VERSION: $(NODE_10)
+              WINDOWS_NODE14:
+                  IMAGE_TYPE: "windows-latest"
+                  NODE_VERSION: $(NODE_14)
+              WINDOWS_NODE16:
+                  IMAGE_TYPE: "windows-latest"
+                  NODE_VERSION: $(NODE_16)
+              MAC_NODE10:
+                  IMAGE_TYPE: "macOS-latest"
+                  NODE_VERSION: $(NODE_10)
+              MAC_NODE14:
+                  IMAGE_TYPE: "macOS-latest"
+                  NODE_VERSION: $(NODE_14)
+              MAC_NODE16:
+                  IMAGE_TYPE: "macOS-latest"
+                  NODE_VERSION: $(NODE_16)
       pool:
           vmImage: $(IMAGE_TYPE)
       steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,12 +48,27 @@ jobs:
             displayName: "npm install"
           - script: npm run test
             displayName: "npm build and test"
-            condition: ne(variables['NODE_VERSION'], variables['NODE_8'])
           - script: npm run test:nolint
             displayName: "npm build and test (no linting)"
-            condition: eq(variables['NODE_VERSION'], variables['NODE_8'])
+    - job: BuildArtifacts
+      pool:
+          vmImage: "vs2017-win2016"
+      steps:
+          - task: NodeTool@0
+            inputs:
+                versionSpec: $(NODE_14)
+            displayName: "Install Node.js"
+          - script: npm ci
+            displayName: "npm ci"
+          - script: npm build
+            displayName: "npm build"
           - task: ManifestGeneratorTask@0
             displayName: "SBOM Generation Task"
             inputs:
                 BuildDropPath: "$(Build.ArtifactStagingDirectory)"
                 Verbosity: "Information"
+          - task: PublishBuildArtifacts@1
+            inputs:
+                PathtoPublish: "$(Build.ArtifactStagingDirectory)"
+                ArtifactName: "drop"
+                publishLocation: "Container"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,44 +1,44 @@
-variables: {
-  MODULE_VERSION: '1.2.2',
-  NODE_8: '8.x',
-  NODE_10: '10.x',
-  NODE_12: '12.x',
-  NODE_14: '14.x'
-}
+variables:
+    { MODULE_VERSION: "1.2.2", NODE_8: "8.x", NODE_10: "10.x", NODE_12: "12.x", NODE_14: "14.x" }
 name: $(MODULE_VERSION)-$(Date:yyyyMMdd)$(Rev:.r)
 
 trigger:
-- main
-- dev
+    - main
+    - dev
 
 jobs:
-- job: UnitTests
-  strategy:
-    matrix:
-      WINDOWS_NODE8:
-        IMAGE_TYPE: 'vs2017-win2016'
-        NODE_VERSION: $(NODE_8)
-      WINDOWS_NODE10:
-        IMAGE_TYPE: 'vs2017-win2016'
-        NODE_VERSION: $(NODE_10)
-      WINDOWS_NODE12:
-        IMAGE_TYPE: 'vs2017-win2016'
-        NODE_VERSION: $(NODE_12)
-      WINDOWS_NODE14:
-        IMAGE_TYPE: 'vs2017-win2016'
-        NODE_VERSION: $(NODE_14)
-  pool:
-    vmImage: $(IMAGE_TYPE)
-  steps:
-  - task: NodeTool@0
-    inputs:
-      versionSpec: $(NODE_VERSION)
-    displayName: 'Install Node.js'
-  - script: npm install
-    displayName: 'npm install'
-  - script: npm run test
-    displayName: 'npm build and test'
-    condition: ne(variables['NODE_VERSION'], variables['NODE_8'])
-  - script: npm run test:nolint
-    displayName: 'npm build and test (no linting)'
-    condition: eq(variables['NODE_VERSION'], variables['NODE_8'])
+    - job: UnitTests
+      strategy:
+          matrix:
+              WINDOWS_NODE8:
+                  IMAGE_TYPE: "vs2017-win2016"
+                  NODE_VERSION: $(NODE_8)
+              WINDOWS_NODE10:
+                  IMAGE_TYPE: "vs2017-win2016"
+                  NODE_VERSION: $(NODE_10)
+              WINDOWS_NODE12:
+                  IMAGE_TYPE: "vs2017-win2016"
+                  NODE_VERSION: $(NODE_12)
+              WINDOWS_NODE14:
+                  IMAGE_TYPE: "vs2017-win2016"
+                  NODE_VERSION: $(NODE_14)
+      pool:
+          vmImage: $(IMAGE_TYPE)
+      steps:
+          - task: NodeTool@0
+            inputs:
+                versionSpec: $(NODE_VERSION)
+            displayName: "Install Node.js"
+          - script: npm install
+            displayName: "npm install"
+          - script: npm run test
+            displayName: "npm build and test"
+            condition: ne(variables['NODE_VERSION'], variables['NODE_8'])
+          - script: npm run test:nolint
+            displayName: "npm build and test (no linting)"
+            condition: eq(variables['NODE_VERSION'], variables['NODE_8'])
+          - task: ManifestGeneratorTask@0
+            displayName: "SBOM Generation Task"
+            inputs:
+                BuildDropPath: "$(Build.ArtifactStagingDirectory)"
+                Verbosity: "Information"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "typings": "lib/src/index.d.ts",
     "scripts": {
         "clean": "rimraf lib",
-        "lint": "eslint --fix --ext .ts,.json src/",
+        "lint": "eslint --ext .ts,.json src/",
         "lint:test": "eslint --ext .ts,.json test/",
         "lint:samples": "eslint --ext .ts,.js samples/",
         "lint:srcfix": "eslint --ext .ts,.json src/ --fix",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "typings": "lib/src/index.d.ts",
     "scripts": {
         "clean": "rimraf lib",
-        "lint": "eslint --ext .ts,.json src/",
+        "lint": "eslint --fix --ext .ts,.json src/",
         "lint:test": "eslint --ext .ts,.json test/",
         "lint:samples": "eslint --ext .ts,.js samples/",
         "lint:srcfix": "eslint --ext .ts,.json src/ --fix",


### PR DESCRIPTION
This PR makes 3 updates to our azure-pipelines config.

1. Our test matrix now matches that of the NodeJS worker. This means adding NodeJS 16 to our tests and dropping tests on Node8.
2. Just like the NodeJS worker, we add an "Artifact publishing" job, which will come in handy when automating npm releases
3. In the artifact publishing job, we add an SBOM-building step, for auditing purposes. This was modeled after this NodeJS worker PR:  https://github.com/Azure/azure-functions-nodejs-worker/pull/489