### PR TITLE
Support V2 replay protocol

### DIFF
--- a/src/actions/actiontype.ts
+++ b/src/actions/actiontype.ts
@@ -17,4 +17,6 @@ export enum ActionType {
     WaitForExternalEvent = 6,
     CallEntity = 7,
     CallHttp = 8,
+    WhenAny = 11,
+    WhenAll = 12,
 }

--- a/src/actions/compositeaction.ts
+++ b/src/actions/compositeaction.ts
@@ -1,0 +1,8 @@
+import { ActionType, IAction } from "../classes";
+
+/** @hidden */
+export abstract class CompositeAction implements IAction {
+    public readonly actionType: ActionType;
+
+    constructor(public readonly compoundActions: IAction[]) {}
+}

--- a/src/actions/whenallaction.ts
+++ b/src/actions/whenallaction.ts
@@ -1,0 +1,7 @@
+import { ActionType } from "../classes";
+import { CompositeAction } from "./compositeaction";
+
+/** @hidden */
+export class WhenAllAction extends CompositeAction {
+    public readonly actionType: ActionType = ActionType.WhenAll;
+}

--- a/src/actions/whenanyaction.ts
+++ b/src/actions/whenanyaction.ts
@@ -1,0 +1,7 @@
+import { ActionType } from "../classes";
+import { CompositeAction } from "./compositeaction";
+
+/** @hidden */
+export class WhenAnyAction extends CompositeAction {
+    public readonly actionType: ActionType = ActionType.WhenAny;
+}

--- a/src/durableorchestrationbindinginfo.ts
+++ b/src/durableorchestrationbindinginfo.ts
@@ -1,12 +1,22 @@
+import { UpperSchemaVersion } from "./upperSchemaVersion";
 import { HistoryEvent } from "./classes";
+import { VariableConverter } from "typedoc/dist/lib/converter/nodes";
 
 /** @hidden */
 export class DurableOrchestrationBindingInfo {
+    public readonly upperSchemaVersion: UpperSchemaVersion;
     constructor(
         public readonly history: HistoryEvent[] = [],
         public readonly input?: unknown,
         public readonly instanceId: string = "",
         public readonly isReplaying: boolean = false,
-        public readonly parentInstanceId?: string // TODO: Implement entity locking // public readonly contextLocks?: EntityId[],
-    ) {}
+        public readonly parentInstanceId?: string,
+        upperSchemaVersion = 0 // TODO: Implement entity locking // public readonly contextLocks?: EntityId[],
+    ) {
+        if (Object.values(UpperSchemaVersion).includes(upperSchemaVersion)) {
+            this.upperSchemaVersion = upperSchemaVersion;
+        } else {
+            this.upperSchemaVersion = UpperSchemaVersion.V1;
+        }
+    }
 }

--- a/src/iorchestratorstate.ts
+++ b/src/iorchestratorstate.ts
@@ -1,4 +1,5 @@
 import { IAction } from "./classes";
+import { UpperSchemaVersion } from "./upperSchemaVersion";
 
 /** @hidden */
 export interface IOrchestratorState {
@@ -7,4 +8,5 @@ export interface IOrchestratorState {
     output: unknown;
     error?: string;
     customStatus?: unknown;
+    schemaVersion: UpperSchemaVersion;
 }

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -15,6 +15,7 @@ import {
 import { DurableOrchestrationContext } from "./durableorchestrationcontext";
 import { OrchestrationFailureError } from "./orchestrationfailureerror";
 import { TaskBase } from "./tasks/taskinterfaces";
+import { UpperSchemaVersion } from "./upperSchemaVersion";
 
 /** @hidden */
 const log = debug("orchestrator");
@@ -42,6 +43,10 @@ export class Orchestrator {
         const state: HistoryEvent[] = orchestrationBinding.history;
         const input = orchestrationBinding.input;
         const instanceId: string = orchestrationBinding.instanceId;
+
+        // The upper schema version corresponds to the maximum OOProc protocol version supported by the extension,
+        // we use it to determine the format of the SDK's output
+        const upperSchemaVersion: UpperSchemaVersion = orchestrationBinding.upperSchemaVersion;
         // const contextLocks: EntityId[] = orchestrationBinding.contextLocks;
 
         // Initialize currentUtcDateTime
@@ -61,7 +66,8 @@ export class Orchestrator {
                 this.currentUtcDateTime,
                 orchestrationBinding.isReplaying,
                 orchestrationBinding.parentInstanceId,
-                input
+                input,
+                upperSchemaVersion
             );
         }
 
@@ -91,6 +97,7 @@ export class Orchestrator {
                                 output: g.value,
                                 actions,
                                 customStatus: context.df.customStatus,
+                                schemaVersion: upperSchemaVersion,
                             })
                         );
                         return;
@@ -115,6 +122,7 @@ export class Orchestrator {
                             output: undefined,
                             actions,
                             customStatus: context.df.customStatus,
+                            schemaVersion: upperSchemaVersion,
                         })
                     );
                     return;
@@ -128,6 +136,7 @@ export class Orchestrator {
                             output: undefined,
                             actions,
                             customStatus: context.df.customStatus,
+                            schemaVersion: upperSchemaVersion,
                         })
                     );
                     return;
@@ -154,6 +163,7 @@ export class Orchestrator {
                             actions,
                             output: partialResult.result,
                             customStatus: context.df.customStatus,
+                            schemaVersion: upperSchemaVersion,
                         })
                     );
                     return;
@@ -207,6 +217,7 @@ export class Orchestrator {
                 actions,
                 error: error.message,
                 customStatus: context.df.customStatus,
+                schemaVersion: upperSchemaVersion,
             });
             context.done(new OrchestrationFailureError(error, errorState), undefined);
             return;

--- a/src/orchestratorstate.ts
+++ b/src/orchestratorstate.ts
@@ -1,17 +1,20 @@
 import { IAction, IOrchestratorState } from "./classes";
+import { UpperSchemaVersion } from "./upperSchemaVersion";
 
 /** @hidden */
 export class OrchestratorState implements IOrchestratorState {
     public readonly isDone: boolean;
-    public readonly actions: IAction[][];
+    public actions: IAction[][];
     public readonly output: unknown;
     public readonly error?: string;
     public readonly customStatus?: unknown;
+    public readonly schemaVersion: UpperSchemaVersion;
 
     constructor(options: IOrchestratorState) {
         this.isDone = options.isDone;
         this.actions = options.actions;
         this.output = options.output;
+        this.schemaVersion = options.schemaVersion;
 
         if (options.error) {
             this.error = options.error;
@@ -19,6 +22,12 @@ export class OrchestratorState implements IOrchestratorState {
 
         if (options.customStatus) {
             this.customStatus = options.customStatus;
+        }
+
+        // Under replay protocol V2, the actions array is flattened and then, for backwards compatibility reasons, nested within another array
+        if (options.schemaVersion === UpperSchemaVersion.V2) {
+            const flatActions: IAction[] = this.actions.reduce((arr, next) => arr.concat(next), []);
+            this.actions = [flatActions];
         }
     }
 }

--- a/src/tasks/taskfactory.ts
+++ b/src/tasks/taskfactory.ts
@@ -1,7 +1,8 @@
 import { CreateTimerAction, IAction } from "../classes";
+import { UpperSchemaVersion } from "../upperSchemaVersion";
 import { Task } from "./task";
 import { TaskBase } from "./taskinterfaces";
-import { TaskSet } from "./taskset";
+import { compoundActionType, TaskSet } from "./taskset";
 import { TimerTask } from "./timertask";
 
 /** @hidden */
@@ -65,20 +66,55 @@ export class TaskFactory {
     public static SuccessfulTaskSet(
         tasks: TaskBase[],
         completionIndex: number,
-        result: unknown
+        result: unknown,
+        compoundActionType: compoundActionType,
+        upperSchemaVersion: UpperSchemaVersion
     ): TaskSet {
-        return new TaskSet(true, false, tasks, completionIndex, result, undefined);
+        return new TaskSet(
+            true,
+            false,
+            tasks,
+            compoundActionType,
+            completionIndex,
+            result,
+            undefined,
+            upperSchemaVersion
+        );
     }
 
     public static FailedTaskSet(
         tasks: TaskBase[],
         completionIndex: number,
-        exception: Error
+        exception: Error,
+        compoundActionType: compoundActionType,
+        upperSchemaVersion: UpperSchemaVersion
     ): TaskSet {
-        return new TaskSet(true, true, tasks, completionIndex, undefined, exception);
+        return new TaskSet(
+            true,
+            true,
+            tasks,
+            compoundActionType,
+            completionIndex,
+            undefined,
+            exception,
+            upperSchemaVersion
+        );
     }
 
-    public static UncompletedTaskSet(tasks: TaskBase[]): TaskSet {
-        return new TaskSet(false, false, tasks, undefined, undefined, undefined);
+    public static UncompletedTaskSet(
+        tasks: TaskBase[],
+        compoundActionType: compoundActionType,
+        upperSchemaVersion: UpperSchemaVersion
+    ): TaskSet {
+        return new TaskSet(
+            false,
+            false,
+            tasks,
+            compoundActionType,
+            undefined,
+            undefined,
+            undefined,
+            upperSchemaVersion
+        );
     }
 }

--- a/src/tasks/taskset.ts
+++ b/src/tasks/taskset.ts
@@ -1,5 +1,10 @@
+import { WhenAllAction } from "../actions/whenallaction";
+import { WhenAnyAction } from "../actions/whenanyaction";
 import { IAction } from "../classes";
+import { UpperSchemaVersion } from "../upperSchemaVersion";
 import { TaskBase } from "./taskinterfaces";
+
+export type compoundActionType = "WhenAll" | "WhenAny";
 
 /** @hidden */
 export class TaskSet implements TaskBase {
@@ -7,15 +12,30 @@ export class TaskSet implements TaskBase {
         public readonly isCompleted: boolean,
         public readonly isFaulted: boolean,
         private readonly tasks: TaskBase[],
+        private compoundActionType: compoundActionType,
         private readonly completionIndex?: number,
         public result?: unknown,
-        public exception?: Error
+        public exception?: Error,
+        private upperSchemaVersion: UpperSchemaVersion = UpperSchemaVersion.V1
     ) {}
 
     public yieldNewActions(): IAction[] {
         // Get all of the actions in subtasks and flatten into one array.
-        return this.tasks
+        const actions: IAction[] = this.tasks
             .map((task) => task.yieldNewActions())
             .reduce((actions, subTaskActions) => actions.concat(subTaskActions));
+        if (this.upperSchemaVersion == UpperSchemaVersion.V1) {
+            return actions;
+        }
+
+        // Under OOProc protocol V2, WhenAll and WhenAny actions are proper instead of
+        // being represented as a list of sub-tasks
+        let action: IAction;
+        if (this.compoundActionType === "WhenAll") {
+            action = new WhenAllAction(actions);
+        } else {
+            action = new WhenAnyAction(actions);
+        }
+        return [action];
     }
 }

--- a/src/upperSchemaVersion.ts
+++ b/src/upperSchemaVersion.ts
@@ -1,0 +1,8 @@
+/**
+ * @hidden
+ * Supported OOProc DF extension protocols
+ */
+export enum UpperSchemaVersion {
+    V1 = 0,
+    V2 = 1,
+}

--- a/test/integration/orchestrator-spec.ts
+++ b/test/integration/orchestrator-spec.ts
@@ -5,6 +5,8 @@ import "mocha";
 import * as moment from "moment";
 import * as uuidv1 from "uuid/v1";
 import { ManagedIdentityTokenSource } from "../../src";
+import { WhenAllAction } from "../../src/actions/whenallaction";
+import { WhenAnyAction } from "../../src/actions/whenanyaction";
 import {
     ActionType,
     CallActivityAction,
@@ -30,6 +32,7 @@ import {
     IOrchestrationFunctionContext,
 } from "../../src/classes";
 import { OrchestrationFailureError } from "../../src/orchestrationfailureerror";
+import { UpperSchemaVersion } from "../../src/upperSchemaVersion";
 import { TestHistories } from "../testobjects/testhistories";
 import { TestOrchestrations } from "../testobjects/TestOrchestrations";
 import { TestUtils } from "../testobjects/testutils";
@@ -53,6 +56,7 @@ describe("Orchestrator", () => {
                 isDone: true,
                 actions: [],
                 output: `Hello, ${name}!`,
+                schemaVersion: UpperSchemaVersion.V1,
             })
         );
     });
@@ -77,6 +81,7 @@ describe("Orchestrator", () => {
                 isDone: true,
                 actions: [],
                 output: `Hello, ${name}!`,
+                schemaVersion: UpperSchemaVersion.V1,
             })
         );
     });
@@ -103,6 +108,7 @@ describe("Orchestrator", () => {
                     isDone: true,
                     actions: [],
                     output: falsyValue,
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
             if (isNaN(falsyValue as number)) {
@@ -304,6 +310,7 @@ describe("Orchestrator", () => {
                         [new CallActivityAction("ThrowsErrorActivity")],
                         [new CallActivityAction("Hello", name)],
                     ],
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -331,6 +338,7 @@ describe("Orchestrator", () => {
                     isDone: false,
                     output: undefined,
                     actions: [[new CallActivityAction("Hello", name)]],
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -350,6 +358,7 @@ describe("Orchestrator", () => {
                     isDone: false,
                     output: undefined,
                     actions: [[new CallActivityAction("ReturnsFour")]],
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -376,6 +385,7 @@ describe("Orchestrator", () => {
                             isDone: false,
                             output: undefined,
                             actions: [[new CallActivityAction("Hello", falsyValue)]],
+                            schemaVersion: UpperSchemaVersion.V1,
                         })
                     );
                 });
@@ -400,6 +410,7 @@ describe("Orchestrator", () => {
                             isDone: true,
                             actions: [[new CallActivityAction("Hello", falsyValue)]],
                             output: `Hello, ${falsyValue}!`,
+                            schemaVersion: UpperSchemaVersion.V1,
                         })
                     );
                 });
@@ -427,6 +438,7 @@ describe("Orchestrator", () => {
                     isDone: true,
                     actions: [[new CallActivityAction("Hello", name)]],
                     output: `Hello, ${name}!`,
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -452,6 +464,7 @@ describe("Orchestrator", () => {
                     isDone: true,
                     output: `Hello, ${name}!`,
                     actions: [[new CallActivityAction("Hello", name)]],
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -477,6 +490,7 @@ describe("Orchestrator", () => {
                     isDone: true,
                     actions: [[new CallActivityAction("Hello", name)]],
                     output: `Hello, ${name}!`,
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -503,6 +517,7 @@ describe("Orchestrator", () => {
                         [new CallActivityAction("Hello", "London")],
                     ],
                     output: ["Hello, Tokyo!", "Hello, Seattle!", "Hello, London!"],
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -568,6 +583,7 @@ describe("Orchestrator", () => {
                             ),
                         ],
                     ],
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -594,6 +610,7 @@ describe("Orchestrator", () => {
                     isDone: false,
                     output: undefined,
                     actions: [[new CallActivityWithRetryAction("Hello", retryOptions, name)]],
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -623,6 +640,7 @@ describe("Orchestrator", () => {
                             ),
                         ],
                     ],
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -656,6 +674,7 @@ describe("Orchestrator", () => {
                 .that.deep.include({
                     isDone: false,
                     actions: [[new CallActivityWithRetryAction("Hello", retryOptions, name)]],
+                    schemaVersion: UpperSchemaVersion.V1,
                 });
             expect(orchestrationState.error).to.include(expectedErr);
         });
@@ -689,6 +708,7 @@ describe("Orchestrator", () => {
                         ],
                     ],
                     output: `Hello, ${name}!`,
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -727,6 +747,7 @@ describe("Orchestrator", () => {
                         ],
                     ],
                     output: ["Hello, Tokyo!", "Hello, Seattle!"],
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -755,6 +776,7 @@ describe("Orchestrator", () => {
                     isDone: true,
                     actions: [[new CallActivityWithRetryAction("Hello", retryOptions, "World")]],
                     output: [startingTime, moment(startingTime).add(1, "m").add(30, "s").toDate()],
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -782,6 +804,7 @@ describe("Orchestrator", () => {
                     isDone: false,
                     output: undefined,
                     actions: [[new CallHttpAction(req)]],
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -829,6 +852,7 @@ describe("Orchestrator", () => {
                         },
                     ],
                 ],
+                schemaVersion: UpperSchemaVersion.V1,
             });
         });
 
@@ -858,6 +882,7 @@ describe("Orchestrator", () => {
                     isDone: true,
                     actions: [[new CallHttpAction(req)]],
                     output: res,
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -883,6 +908,7 @@ describe("Orchestrator", () => {
                     isDone: false,
                     output: undefined,
                     actions: [[new CallEntityAction(expectedEntity, "set", "testString")]],
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -907,6 +933,7 @@ describe("Orchestrator", () => {
                     isDone: true,
                     actions: [[new CallEntityAction(expectedEntity, "set", "testString")]],
                     output: "OK",
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -938,6 +965,7 @@ describe("Orchestrator", () => {
                     actions: [
                         [new CallSubOrchestratorAction("SayHelloWithActivity", childId, name)],
                     ],
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -966,6 +994,7 @@ describe("Orchestrator", () => {
                     actions: [
                         [new CallSubOrchestratorAction("SayHelloWithActivity", undefined, name)],
                     ],
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -1027,6 +1056,7 @@ describe("Orchestrator", () => {
                             ),
                         ],
                     ],
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -1128,6 +1158,7 @@ describe("Orchestrator", () => {
                         [new CallSubOrchestratorAction("SayHelloWithActivity", childId, name)],
                     ],
                     output: "Hello, World!",
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -1238,6 +1269,7 @@ describe("Orchestrator", () => {
                             ),
                         ],
                     ],
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -1277,6 +1309,7 @@ describe("Orchestrator", () => {
                             ),
                         ],
                     ],
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -1314,6 +1347,7 @@ describe("Orchestrator", () => {
                             ),
                         ],
                     ],
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -1400,6 +1434,7 @@ describe("Orchestrator", () => {
                         ],
                     ],
                     output: `Hello, ${name}!`,
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -1438,6 +1473,7 @@ describe("Orchestrator", () => {
                         ],
                     ],
                     output: ["Hello, Tokyo!", "Hello, Seattle!"],
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -1464,6 +1500,7 @@ describe("Orchestrator", () => {
                     isDone: true,
                     output: undefined,
                     actions: [[new ContinueAsNewAction({ value: 6 })]],
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -1489,6 +1526,7 @@ describe("Orchestrator", () => {
                     isDone: false,
                     output: undefined,
                     actions: [[new CreateTimerAction(fireAt)]],
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -1512,6 +1550,7 @@ describe("Orchestrator", () => {
                     isDone: true,
                     actions: [[new CreateTimerAction(fireAt)]],
                     output: "Timer fired!",
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -1566,6 +1605,7 @@ describe("Orchestrator", () => {
                     isDone: true,
                     actions: [],
                     output: expectedLockState,
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -1630,6 +1670,7 @@ describe("Orchestrator", () => {
                         [new CallActivityAction("Hello", "Seattle")],
                     ],
                     customStatus: "Tokyo",
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -1657,6 +1698,7 @@ describe("Orchestrator", () => {
                     actions: [
                         [new WaitForExternalEventAction("start", ExternalEventType.ExternalEvent)],
                     ],
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -1685,6 +1727,7 @@ describe("Orchestrator", () => {
                         [new WaitForExternalEventAction("start", ExternalEventType.ExternalEvent)],
                         [new CallActivityAction("Hello", name)],
                     ],
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -1712,6 +1755,7 @@ describe("Orchestrator", () => {
                     actions: [
                         [new WaitForExternalEventAction("start", ExternalEventType.ExternalEvent)],
                     ],
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -1741,6 +1785,44 @@ describe("Orchestrator", () => {
                         [new CallActivityAction("GetFileList", "C:\\Dev")],
                         filePaths.map((file) => new CallActivityAction("GetFileSize", file)),
                     ],
+                    schemaVersion: UpperSchemaVersion.V1,
+                })
+            );
+        });
+
+        it("Task.all adheres to V2 replay protocol", async () => {
+            // same test as above, but tests for V2 protocol output
+            const orchestrator = TestOrchestrations.FanOutFanInDiskUsage;
+            const filePaths = ["file1.txt", "file2.png", "file3.csx"];
+            const mockContext = new MockContext({
+                context: new DurableOrchestrationBindingInfo(
+                    TestHistories.GetFanOutFanInDiskUsageReplayOne(
+                        moment.utc().toDate(),
+                        filePaths
+                    ),
+                    "C:\\Dev",
+                    undefined,
+                    undefined,
+                    undefined,
+                    UpperSchemaVersion.V2
+                ),
+            });
+
+            orchestrator(mockContext);
+
+            expect(mockContext.doneValue).to.be.deep.equal(
+                new OrchestratorState({
+                    isDone: false,
+                    output: undefined,
+                    actions: [
+                        [
+                            new CallActivityAction("GetFileList", "C:\\Dev"),
+                            new WhenAllAction(
+                                filePaths.map((file) => new CallActivityAction("GetFileSize", file))
+                            ),
+                        ],
+                    ],
+                    schemaVersion: UpperSchemaVersion.V2,
                 })
             );
         });
@@ -1768,6 +1850,7 @@ describe("Orchestrator", () => {
                         [new CallActivityAction("GetFileList", "C:\\Dev")],
                         filePaths.map((file) => new CallActivityAction("GetFileSize", file)),
                     ],
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -1792,6 +1875,7 @@ describe("Orchestrator", () => {
                         filePaths.map((file) => new CallActivityAction("GetFileSize", file)),
                     ],
                     output: 6,
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -1853,6 +1937,41 @@ describe("Orchestrator", () => {
                         ],
                     ],
                     output: "A",
+                    schemaVersion: UpperSchemaVersion.V1,
+                })
+            );
+        });
+
+        it("Task.any adheres to V2 protocol", async () => {
+            // same test as above, but checks for V2 protocol output
+            const orchestrator = TestOrchestrations.AnyAOrB;
+            const completeInOrder = true;
+            const mockContext = new MockContext({
+                context: new DurableOrchestrationBindingInfo(
+                    TestHistories.GetAnyAOrB(moment.utc().toDate(), completeInOrder),
+                    completeInOrder,
+                    undefined,
+                    undefined,
+                    undefined,
+                    UpperSchemaVersion.V2
+                ),
+            });
+
+            orchestrator(mockContext);
+
+            expect(mockContext.doneValue).to.be.deep.equal(
+                new OrchestratorState({
+                    isDone: true,
+                    actions: [
+                        [
+                            new WhenAnyAction([
+                                new CallActivityAction("TaskA", true),
+                                new CallActivityAction("TaskB", true),
+                            ]),
+                        ],
+                    ],
+                    output: "A",
+                    schemaVersion: UpperSchemaVersion.V2,
                 })
             );
         });
@@ -1879,6 +1998,7 @@ describe("Orchestrator", () => {
                         ],
                     ],
                     output: "B",
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -1905,6 +2025,7 @@ describe("Orchestrator", () => {
                         ],
                     ],
                     output: "A",
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -1932,6 +2053,7 @@ describe("Orchestrator", () => {
                         ],
                     ],
                     output: undefined,
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
 
@@ -1955,6 +2077,7 @@ describe("Orchestrator", () => {
                         [new CallActivityAction("Hello", "Tokyo")],
                     ],
                     output: undefined,
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -1982,6 +2105,7 @@ describe("Orchestrator", () => {
                         ],
                     ],
                     output: undefined,
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
 
@@ -2004,6 +2128,7 @@ describe("Orchestrator", () => {
                         ],
                     ],
                     output: ["timeout"],
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -2030,6 +2155,7 @@ describe("Orchestrator", () => {
                         ],
                     ],
                     output: "A",
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -2058,6 +2184,7 @@ describe("Orchestrator", () => {
                         ],
                     ],
                     output: undefined,
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
 
@@ -2082,6 +2209,7 @@ describe("Orchestrator", () => {
                         [new CallActivityAction("TaskB")],
                     ],
                     output: undefined,
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
 
@@ -2106,6 +2234,7 @@ describe("Orchestrator", () => {
                         [new CallActivityAction("TaskB")],
                     ],
                     output: undefined,
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
 
@@ -2130,6 +2259,7 @@ describe("Orchestrator", () => {
                         [new CallActivityAction("TaskB")],
                     ],
                     output: {},
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });
@@ -2158,6 +2288,7 @@ describe("Orchestrator", () => {
                         ],
                     ],
                     output: undefined,
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
 
@@ -2181,6 +2312,7 @@ describe("Orchestrator", () => {
                         ],
                     ],
                     output: "Timer finished",
+                    schemaVersion: UpperSchemaVersion.V1,
                 })
             );
         });


### PR DESCRIPTION
This PR adds support for the V2 replay protocol in the DF extension. This protocol adds improved reliability and correctness by representing WhenAll and WhenAny tasks as proper Actions within the extension.

To do this, we need to parse the "upperSchemaVersion" field from the extension's input payload, which tells us the maximum protocol version supported by the extension. At time of writing, only 2 protocols exist: V1 and V2.

For V2, we simply change the representation of compound tasks (tasks of tasks) such that WhenAny and WhenAll tasks are not a list of action, but instead a list of tasks within a WhenAny or WhenAll action depending on the API invoked.

Finally, while these PR changes a lot of files, the change is pretty simple: we're just propagating the protocol version throughout various methods to determine the shape of our "Actions" output. 

Should partially address: https://github.com/Azure/azure-functions-durable-js/issues/291