### PR TITLE
Add `npm pack` step to CI/CD pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,6 +79,14 @@ jobs:
             displayName: "npm build"
           - script: npm prune --production
             displayName: "npm prune --production" # so that only production dependencies are included in SBOM
+          - script: npm pack
+            displayName: "pack npm package"
+          - task: CopyFiles@2
+            displayName: 'Copy types package to staging'
+            inputs:
+                SourceFolder: $(System.DefaultWorkingDirectory)
+                Contents: '*.tgz'
+                TargetFolder: $(Build.ArtifactStagingDirectory)
           - task: ManifestGeneratorTask@0
             displayName: "SBOM Generation Task"
             inputs:


### PR DESCRIPTION
Follow-up to https://github.com/Azure/azure-functions-durable-js/pull/298

This add an `npm pack` step to our azure-pipelines CI so that the packages published to our local feed actually contain the .tar.gz containing this node package.