### PR TITLE
Use 1ES-hosted VM during build and release

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -6,12 +6,13 @@ resources:
         - pipeline: DurableJSCI
           project: "Azure Functions"
           source: azure-functions-durable-js
-          branch: main
+          branch: dev
 
 jobs:
     - job: Release
       pool:
-          vmImage: "ubuntu-latest"
+          name: "1ES-Hosted-AzFunc"
+          vmImage: "MMSUbuntu20.04TLS"
       steps:
           - task: NodeTool@0
             displayName: "Install Node.js"
@@ -27,5 +28,5 @@ jobs:
                 command: custom
                 workingDir: "$(Pipeline.Workspace)/DurableJSCI/drop"
                 verbose: true
-                customCommand: "publish package.tgz"
+                customCommand: "publish package.tgz --dry-run"
                 publishEndpoint: "NPM Durable Functions JS Publish"

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -6,7 +6,7 @@ resources:
         - pipeline: DurableJSCI
           project: "Azure Functions"
           source: azure-functions-durable-js
-          branch: dev
+          branch: main
 
 jobs:
     - job: Release
@@ -28,5 +28,5 @@ jobs:
                 command: custom
                 workingDir: "$(Pipeline.Workspace)/DurableJSCI/drop"
                 verbose: true
-                customCommand: "publish package.tgz --dry-run"
+                customCommand: "publish package.tgz"
                 publishEndpoint: "NPM Durable Functions JS Publish"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,7 +67,8 @@ jobs:
             displayName: "npm build and test (no linting)"
     - job: BuildArtifacts
       pool:
-          vmImage: "vs2017-win2016"
+          name: "1ES-Hosted-AzFunc"
+          vmImage: "MMSUbuntu20.04TLS"
       steps:
           - task: NodeTool@0
             inputs:
@@ -82,10 +83,10 @@ jobs:
           - script: npm pack
             displayName: "pack npm package"
           - task: CopyFiles@2
-            displayName: 'Copy types package to staging'
+            displayName: "Copy types package to staging"
             inputs:
                 SourceFolder: $(System.DefaultWorkingDirectory)
-                Contents: '*.tgz'
+                Contents: "*.tgz"
                 TargetFolder: $(Build.ArtifactStagingDirectory)
           - task: ManifestGeneratorTask@0
             displayName: "SBOM Generation Task"


### PR DESCRIPTION
Modeled after: https://github.com/Azure/azure-functions-nodejs-worker/pull/494

This PR changes our vmImage when publishing and releasing durable-JS artifacts to use a 1ES hosted Ubuntu VM