### PR TITLE
"Demand" 1ES VM in pipelines

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -12,7 +12,8 @@ jobs:
     - job: Release
       pool:
           name: "1ES-Hosted-AzFunc"
-          vmImage: "MMSUbuntu20.04TLS"
+          demands:
+              - ImageOverride -equals MMSUbuntu20.04TLS
       steps:
           - task: NodeTool@0
             displayName: "Install Node.js"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,7 +68,8 @@ jobs:
     - job: BuildArtifacts
       pool:
           name: "1ES-Hosted-AzFunc"
-          vmImage: "MMSUbuntu20.04TLS"
+          demands:
+              - ImageOverride -equals MMSUbuntu20.04TLS
       steps:
           - task: NodeTool@0
             inputs:


### PR DESCRIPTION
Modeled after: https://github.com/Azure/azure-functions-kafka-extension/commit/814394735e52d339b8e2afb7cfa9376c02a85858

This PR looks to ensure that our Azure pipelines use the 1ES VMs when building artifacts.