### PR TITLE
Update dependencies as per `npm audit`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1228,19 +1228,9 @@
             "dev": true
         },
         "follow-redirects": {
-            "version": "1.14.5",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
-            "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
-        },
-        "fs-extra": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-            "requires": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
-            }
+            "version": "1.14.7",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+            "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
         },
         "fs.realpath": {
             "version": "1.0.0",
@@ -1253,11 +1243,6 @@
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
             "dev": true,
             "optional": true
-        },
-        "function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
         "functional-red-black-tree": {
             "version": "1.0.1",
@@ -1336,11 +1321,6 @@
                 }
             }
         },
-        "graceful-fs": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-            "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
-        },
         "graceful-readlink": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
@@ -1351,26 +1331,6 @@
             "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
             "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
             "dev": true
-        },
-        "handlebars": {
-            "version": "4.7.7",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-            "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
-            "requires": {
-                "minimist": "^1.2.5",
-                "neo-async": "^2.6.0",
-                "source-map": "^0.6.1",
-                "uglify-js": "^3.1.4",
-                "wordwrap": "^1.0.0"
-            }
-        },
-        "has": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "requires": {
-                "function-bind": "^1.1.1"
-            }
         },
         "has-flag": {
             "version": "3.0.0",
@@ -1383,11 +1343,6 @@
             "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
             "dev": true
-        },
-        "highlight.js": {
-            "version": "10.7.3",
-            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-            "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
         },
         "ignore": {
             "version": "4.0.6",
@@ -1425,11 +1380,6 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
-        "interpret": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
-        },
         "is-binary-path": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -1437,14 +1387,6 @@
             "dev": true,
             "requires": {
                 "binary-extensions": "^2.0.0"
-            }
-        },
-        "is-core-module": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
-            "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
-            "requires": {
-                "has": "^1.0.3"
             }
         },
         "is-extglob": {
@@ -1531,13 +1473,11 @@
             "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
             "dev": true
         },
-        "jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-            "requires": {
-                "graceful-fs": "^4.1.6"
-            }
+        "jsonc-parser": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+            "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+            "dev": true
         },
         "just-extend": {
             "version": "4.0.2",
@@ -1615,7 +1555,8 @@
         "lunr": {
             "version": "2.3.9",
             "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
-            "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
+            "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+            "dev": true
         },
         "make-error": {
             "version": "1.3.6",
@@ -1624,9 +1565,10 @@
             "dev": true
         },
         "marked": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-1.0.0.tgz",
-            "integrity": "sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng=="
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
+            "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==",
+            "dev": true
         },
         "merge2": {
             "version": "1.4.1",
@@ -1655,7 +1597,8 @@
         "minimist": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "dev": true
         },
         "mkdirp": {
             "version": "0.5.5",
@@ -1751,11 +1694,6 @@
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
             "dev": true
-        },
-        "neo-async": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-            "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
         },
         "nise": {
             "version": "1.4.8",
@@ -1884,11 +1822,6 @@
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "dev": true
         },
-        "path-parse": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-        },
         "path-to-regexp": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
@@ -1940,7 +1873,8 @@
         "progress": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
+            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+            "dev": true
         },
         "propagate": {
             "version": "1.0.0",
@@ -1984,14 +1918,6 @@
                 "picomatch": "^2.2.1"
             }
         },
-        "rechoir": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-            "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-            "requires": {
-                "resolve": "^1.1.6"
-            }
-        },
         "regexpp": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -2009,15 +1935,6 @@
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
             "dev": true
-        },
-        "resolve": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-            "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-            "requires": {
-                "is-core-module": "^2.2.0",
-                "path-parse": "^1.0.6"
-            }
         },
         "resolve-from": {
             "version": "4.0.0",
@@ -2084,14 +2001,15 @@
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true
         },
-        "shelljs": {
-            "version": "0.8.4",
-            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-            "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+        "shiki": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.0.tgz",
+            "integrity": "sha512-iczxaIYeBFHTFrQPb9DVy2SKgYxC4Wo7Iucm7C17cCh2Ge/refnvHscUOxM85u57MfLoNOtjoEFUWt9gBexblA==",
+            "dev": true,
             "requires": {
-                "glob": "^7.0.0",
-                "interpret": "^1.0.0",
-                "rechoir": "^0.6.2"
+                "jsonc-parser": "^3.0.0",
+                "vscode-oniguruma": "^1.6.1",
+                "vscode-textmate": "5.2.0"
             }
         },
         "sinon": {
@@ -2142,7 +2060,8 @@
         "source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true
         },
         "source-map-support": {
             "version": "0.5.19",
@@ -2320,28 +2239,32 @@
             "dev": true
         },
         "typedoc": {
-            "version": "0.17.8",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.8.tgz",
-            "integrity": "sha512-/OyrHCJ8jtzu+QZ+771YaxQ9s4g5Z3XsQE3Ma7q+BL392xxBn4UMvvCdVnqKC2T/dz03/VXSLVKOP3lHmDdc/w==",
+            "version": "0.22.11",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.11.tgz",
+            "integrity": "sha512-pVr3hh6dkS3lPPaZz1fNpvcrqLdtEvXmXayN55czlamSgvEjh+57GUqfhAI1Xsuu/hNHUT1KNSx8LH2wBP/7SA==",
+            "dev": true,
             "requires": {
-                "fs-extra": "^8.1.0",
-                "handlebars": "^4.7.6",
-                "highlight.js": "^10.0.0",
-                "lodash": "^4.17.15",
-                "lunr": "^2.3.8",
-                "marked": "1.0.0",
-                "minimatch": "^3.0.0",
-                "progress": "^2.0.3",
-                "shelljs": "^0.8.4",
-                "typedoc-default-themes": "^0.10.2"
-            }
-        },
-        "typedoc-default-themes": {
-            "version": "0.10.2",
-            "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.10.2.tgz",
-            "integrity": "sha512-zo09yRj+xwLFE3hyhJeVHWRSPuKEIAsFK5r2u47KL/HBKqpwdUSanoaz5L34IKiSATFrjG5ywmIu98hPVMfxZg==",
-            "requires": {
-                "lunr": "^2.3.8"
+                "glob": "^7.2.0",
+                "lunr": "^2.3.9",
+                "marked": "^4.0.10",
+                "minimatch": "^3.0.4",
+                "shiki": "^0.10.0"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+                    "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                }
             }
         },
         "typescript": {
@@ -2349,28 +2272,6 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
             "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
             "dev": true
-        },
-        "uglify-js": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.0.tgz",
-            "integrity": "sha512-j5wNQBWaql8gr06dOUrfaohHlscboQZ9B8sNsoK5o4sBjm7Ht9dxSbrMXyktQpA16Acaij8AcoozteaPYZON0g==",
-            "optional": true,
-            "requires": {
-                "commander": "~2.20.3"
-            },
-            "dependencies": {
-                "commander": {
-                    "version": "2.20.3",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-                    "optional": true
-                }
-            }
-        },
-        "universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
         },
         "uri-js": {
             "version": "4.4.1",
@@ -2397,6 +2298,18 @@
             "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
             "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
         },
+        "vscode-oniguruma": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.1.tgz",
+            "integrity": "sha512-vc4WhSIaVpgJ0jJIejjYxPvURJavX6QG41vu0mGhqywMkQqulezEqEQ3cO3gc8GvcOpX6ycmKGqRoROEMBNXTQ==",
+            "dev": true
+        },
+        "vscode-textmate": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+            "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+            "dev": true
+        },
         "which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2411,11 +2324,6 @@
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
             "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
             "dev": true
-        },
-        "wordwrap": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
         },
         "workerpool": {
             "version": "6.1.5",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
         "debug": "~2.6.9",
         "lodash": "^4.17.15",
         "rimraf": "~2.5.4",
-        "typedoc": "^0.17.1",
         "uuid": "~3.3.2",
         "validator": "~13.7.0"
     },
@@ -76,6 +75,7 @@
         "prettier": "^2.0.5",
         "sinon": "~7.1.1",
         "ts-node": "^10.0.0",
+        "typedoc": "^0.22.11",
         "typescript": "^3.8.3"
     },
     "engines": {


### PR DESCRIPTION
This PR runs `npm audit fix` on our dependencies, for security purposes. Most of the diff here occurs in the `package-lock` dependencies.

It also updates `typedoc` (intellisense API docs generator) from being a dependency, to being ` dev-dependency`. As per - https://github.com/Azure/azure-functions-durable-js/issues/261