### PR TITLE
Add SBOM inside npm payload

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,11 +81,11 @@ jobs:
             displayName: "npm build"
           - script: npm prune --production
             displayName: "npm prune --production" # so that only production dependencies are included in SBOM
-          - task: ManifestGeneratorTask@0
-            displayName: "SBOM Generation Task"
-            inputs:
-                BuildDropPath: "$(System.DefaultWorkingDirectory)"
-                Verbosity: "Information"
+          #- task: ManifestGeneratorTask@0
+          #  displayName: "SBOM Generation Task"
+          #  inputs:
+          #      BuildDropPath: "$(System.DefaultWorkingDirectory)"
+          #      Verbosity: "Information"
           - script: npm pack
             displayName: "pack npm package"
           - task: CopyFiles@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,19 +81,19 @@ jobs:
             displayName: "npm build"
           - script: npm prune --production
             displayName: "npm prune --production" # so that only production dependencies are included in SBOM
-          - script: npm pack
-            displayName: "pack npm package"
-          - task: CopyFiles@2
-            displayName: "Copy types package to staging"
-            inputs:
-                SourceFolder: $(System.DefaultWorkingDirectory)
-                Contents: "*.tgz"
-                TargetFolder: $(Build.ArtifactStagingDirectory)
           - task: ManifestGeneratorTask@0
             displayName: "SBOM Generation Task"
             inputs:
                 BuildDropPath: "$(Build.ArtifactStagingDirectory)"
                 Verbosity: "Information"
+          - script: npm pack
+            displayName: "pack npm package"
+          - task: CopyFiles@2
+            displayName: "Copy package to staging"
+            inputs:
+                SourceFolder: $(System.DefaultWorkingDirectory)
+                Contents: "*.tgz"
+                TargetFolder: $(Build.ArtifactStagingDirectory)
           - task: PublishBuildArtifacts@1
             inputs:
                 PathtoPublish: "$(Build.ArtifactStagingDirectory)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,7 +84,7 @@ jobs:
           - task: ManifestGeneratorTask@0
             displayName: "SBOM Generation Task"
             inputs:
-                BuildDropPath: "$(Build.ArtifactStagingDirectory)"
+                BuildDropPath: "$(Build.SourcesDirectory)"
                 Verbosity: "Information"
           - script: npm pack
             displayName: "pack npm package"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,7 +84,7 @@ jobs:
           - task: ManifestGeneratorTask@0
             displayName: "SBOM Generation Task"
             inputs:
-                BuildDropPath: "$(Build.SourcesDirectory)"
+                BuildDropPath: "$(System.DefaultWorkingDirectory)"
                 Verbosity: "Information"
           - script: npm pack
             displayName: "pack npm package"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,8 +86,6 @@ jobs:
             inputs:
                 BuildDropPath: "$(System.DefaultWorkingDirectory)"
                 Verbosity: "Information"
-          - script: ls
-            displayName: "ls"
           - script: npm pack
             displayName: "pack npm package"
           - task: CopyFiles@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,6 +75,14 @@ jobs:
             inputs:
                 versionSpec: $(NODE_14)
             displayName: "Install Node.js"
+          #- task: CopyFiles@2
+          #  displayName: "Copy package to staging"
+          #  inputs:
+          #      SourceFolder: $(System.DefaultWorkingDirectory)
+          #      Contents: "*."
+          #      TargetFolder: $(Build.ArtifactStagingDirectory)
+          - script: ls
+            displayName: "ls" # see current dir
           - script: npm ci
             displayName: "npm ci"
           - script: npm build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,6 +94,8 @@ jobs:
           #  inputs:
           #      BuildDropPath: "$(System.DefaultWorkingDirectory)"
           #      Verbosity: "Information"
+          - script: ls
+            displayName: "ls" # see current dir again
           - script: npm pack
             displayName: "pack npm package"
           - task: CopyFiles@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,25 +75,19 @@ jobs:
             inputs:
                 versionSpec: $(NODE_14)
             displayName: "Install Node.js"
-          #- task: CopyFiles@2
-          #  displayName: "Copy package to staging"
-          #  inputs:
-          #      SourceFolder: $(System.DefaultWorkingDirectory)
-          #      Contents: "*."
-          #      TargetFolder: $(Build.ArtifactStagingDirectory)
-          - script: ls
-            displayName: "ls" # see current dir
           - script: npm ci
             displayName: "npm ci"
           - script: npm run-script build
             displayName: "npm run-script build"
           - script: npm prune --production
             displayName: "npm prune --production" # so that only production dependencies are included in SBOM
-          #- task: ManifestGeneratorTask@0
-          #  displayName: "SBOM Generation Task"
-          #  inputs:
-          #      BuildDropPath: "$(System.DefaultWorkingDirectory)"
-          #      Verbosity: "Information"
+          - task: ManifestGeneratorTask@0
+            displayName: "SBOM Generation Task"
+            inputs:
+                BuildDropPath: "$(System.DefaultWorkingDirectory)"
+                Verbosity: "Information"
+          - script: ls
+            displayName: "ls"
           - script: npm pack
             displayName: "pack npm package"
           - task: CopyFiles@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,8 +85,8 @@ jobs:
             displayName: "ls" # see current dir
           - script: npm ci
             displayName: "npm ci"
-          - script: npm build
-            displayName: "npm build"
+          - script: npm run-script build
+            displayName: "npm run-script build"
           - script: npm prune --production
             displayName: "npm prune --production" # so that only production dependencies are included in SBOM
           #- task: ManifestGeneratorTask@0
@@ -94,8 +94,6 @@ jobs:
           #  inputs:
           #      BuildDropPath: "$(System.DefaultWorkingDirectory)"
           #      Verbosity: "Information"
-          - script: ls
-            displayName: "ls" # see current dir again
           - script: npm pack
             displayName: "pack npm package"
           - task: CopyFiles@2

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "azure-functions"
     ],
     "files": [
-        "lib/src"
+        "lib/src",
+        "_manifest"
     ],
     "main": "lib/src/index.js",
     "typings": "lib/src/index.d.ts",


### PR DESCRIPTION
This PR adds the SBOM payload, inside the `_manifest` folder, to our `npm` package.

I'm attaching a picture of how the `durable-functions` directory inside of `node_modules` would look like moving forward, notice the `_manifest` directory.

![npm_payload](https://user-images.githubusercontent.com/9623336/154170440-e5841eb4-2e75-4621-8cf2-9c50117856f8.PNG)
