### PR TITLE
Properly Convert all Timestamps from Srings to Date Types

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,7 +18,12 @@ export class Utils {
             const candidateObjects = Object.values(collection).filter((value) =>
                 this.hasAllPropertiesOf(value, typeInstance)
             );
+
+            // this recursive step ensures _all_ Timestamp properties are converted propertly
+            // For example, a payload can contain the history as a property, so if we want to
+            // parse each HistoryEvent's Timestamp, we need to traverse the payload recursively
             this.parseTimestampsAsDates(candidateObjects);
+
             return candidateObjects as T[];
         }
         return [];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,7 +19,8 @@ export class Utils {
                 this.hasAllPropertiesOf(value, typeInstance)
             );
 
-            // this recursive step ensures _all_ Timestamp properties are converted propertly
+            // this recursive step ensures _all_ Timestamp properties are converted properly
+
             // For example, a payload can contain the history as a property, so if we want to
             // parse each HistoryEvent's Timestamp, we need to traverse the payload recursively
             this.parseTimestampsAsDates(candidateObjects);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,11 +14,14 @@ export class Utils {
         collection: { [index: string]: unknown },
         typeInstance: T
     ): T[] {
-        return collection && typeInstance
-            ? (Object.keys(collection)
-                  .filter((key: string) => this.hasAllPropertiesOf(collection[key], typeInstance))
-                  .map((key: string) => this.parseTimestampsAsDates(collection[key])) as T[])
-            : [];
+        if (collection && typeInstance) {
+            const candidateObjects = Object.values(collection).filter((value) =>
+                this.hasAllPropertiesOf(value, typeInstance)
+            );
+            this.parseTimestampsAsDates(candidateObjects);
+            return candidateObjects as T[];
+        }
+        return [];
     }
 
     public static getHrMilliseconds(times: number[]): number {
@@ -46,16 +49,15 @@ export class Utils {
         return obj.hasOwnProperty(prop);
     }
 
-    public static parseTimestampsAsDates(obj: unknown): unknown {
-        if (
-            typeof obj === "object" &&
-            obj !== null &&
-            this.hasOwnProperty(obj, "Timestamp") &&
-            typeof obj.Timestamp === "string"
-        ) {
-            obj.Timestamp = new Date(obj.Timestamp);
+    public static parseTimestampsAsDates(obj: unknown): void {
+        if (typeof obj === "object" && obj != null) {
+            if (this.hasOwnProperty(obj, "Timestamp") && typeof obj.Timestamp === "string") {
+                obj.Timestamp = new Date(obj.Timestamp);
+            }
+            Object.values(obj).map((value) => {
+                this.parseTimestampsAsDates(value);
+            });
         }
-        return obj;
     }
 
     public static hasAllPropertiesOf<T>(obj: unknown, refInstance: T): boolean {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,8 +19,7 @@ export class Utils {
                 this.hasAllPropertiesOf(value, typeInstance)
             );
 
-            // this recursive step ensures _all_ Timestamp properties are converted properly
-
+            // This recursive step ensures _all_ Timestamp properties are converted properly
             // For example, a payload can contain the history as a property, so if we want to
             // parse each HistoryEvent's Timestamp, we need to traverse the payload recursively
             this.parseTimestampsAsDates(candidateObjects);


### PR DESCRIPTION
The function `getInstancesOf` is used by the `Orchestrator` to get the `DurableOrchestrationBindingInfo` instance on initialization, which includes the list of `HistoryEvent`s. The old implementation of `getInstanceOf` included a function, `parseTimestampsAsDates` to convert the `Timestamp` properties of the desired object from a `string` type to a `Date` type. However, this function was only converting the first level of properties. Since the `Timestamp` properties of `HistoryEvent`s live inside the `history` property of the `DurableOrchestrationBindingInfo` object, this function actually did not convert those `Timestamp` properties, and those remained as strings. This introduced a bug in which the `durableOrchestrationContext.currentUtcDateTime` was never being advanced, because [this line](https://github.com/Azure/azure-functions-durable-js/blob/f337aff952dcb683709b8158b76d24d3ea2aca62/src/taskorchestrationexecutor.ts#L176) in the `TaskOrchestrationExecutor` was comparing a `string` to a `Date`.

This PR updates the `parseTimestampsAsDates` function to a recursive implementation that converts all `Timestamp` properties of the object and its children objects as well. It also cleans up the `getInstancesOf` method a bit to make it slightly easier to understand :) 