### PR TITLE
Support Long Timers ⏳📈🚀🚀🚀

### DIFF
--- a/src/actions/createlongtimeraction.ts
+++ b/src/actions/createlongtimeraction.ts
@@ -1,0 +1,6 @@
+import { ActionType } from "./actiontype";
+import { IAction } from "./iaction";
+
+export class CreateLongTimerAction implements IAction {
+    public readonly actionType: ActionType;
+}

--- a/src/actions/createlongtimeraction.ts
+++ b/src/actions/createlongtimeraction.ts
@@ -1,6 +1,0 @@
-import { ActionType } from "./actiontype";
-import { IAction } from "./iaction";
-
-export class CreateLongTimerAction implements IAction {
-    public readonly actionType: ActionType;
-}

--- a/src/actions/createtimeraction.ts
+++ b/src/actions/createtimeraction.ts
@@ -5,7 +5,7 @@ import { ActionType, IAction } from "../classes";
 export class CreateTimerAction implements IAction {
     public readonly actionType: ActionType = ActionType.CreateTimer;
 
-    constructor(public readonly fireAt: Date, public isCancelled: boolean = false) {
+    constructor(public readonly fireAt: Date, public isCanceled: boolean = false) {
         if (!isDate(fireAt)) {
             throw new TypeError(`fireAt: Expected valid Date object but got ${fireAt}`);
         }

--- a/src/durableorchestrationbindinginfo.ts
+++ b/src/durableorchestrationbindinginfo.ts
@@ -11,6 +11,8 @@ export class DurableOrchestrationBindingInfo {
         public readonly instanceId: string = "",
         public readonly isReplaying: boolean = false,
         public readonly parentInstanceId?: string,
+        public readonly maximumDelayTime?: string,
+        public readonly longRunningTimerIntervalLength?: string,
         upperSchemaVersion = 0 // TODO: Implement entity locking // public readonly contextLocks?: EntityId[],
     ) {
         // It is assumed that the extension supports all schemas in range [0, upperSchemaVersion].

--- a/src/durableorchestrationbindinginfo.ts
+++ b/src/durableorchestrationbindinginfo.ts
@@ -11,8 +11,8 @@ export class DurableOrchestrationBindingInfo {
         public readonly instanceId: string = "",
         public readonly isReplaying: boolean = false,
         public readonly parentInstanceId?: string,
-        public readonly maximumDelayTime?: string,
-        public readonly longRunningTimerIntervalLength?: string,
+        public readonly maximumShortTimerDuration?: string,
+        public readonly longRunningTimerIntervalDuration?: string,
         upperSchemaVersion = 0 // TODO: Implement entity locking // public readonly contextLocks?: EntityId[],
     ) {
         // It is assumed that the extension supports all schemas in range [0, upperSchemaVersion].

--- a/src/durableorchestrationcontext.ts
+++ b/src/durableorchestrationcontext.ts
@@ -339,7 +339,8 @@ export class DurableOrchestrationContext {
         if (this.schemaVersion >= ReplaySchema.V3) {
             if (!this.maximumShortTimerDuration || !this.longRunningTimerIntervalDuration) {
                 throw Error(
-                    "Replay schema version >= V3 is being used, but one or more of the properties `maximumShortTimerDuration` and `longRunningTimerIntervalDuration` are not defined. This is likely an issue with the Extension."
+                    "A framework-internal error was detected: replay schema version >= V3 is being used, but one or more of the properties `maximumShortTimerDuration` and `longRunningTimerIntervalDuration` are not defined. This is likely an issue with the Durable Functions Extension. Please report this bug here: https://github.com/Azure/azure-functions-durable-js/issues "
+
                 );
             }
 

--- a/src/durableorchestrationcontext.ts
+++ b/src/durableorchestrationcontext.ts
@@ -339,8 +339,12 @@ export class DurableOrchestrationContext {
         if (this.schemaVersion >= ReplaySchema.V3) {
             if (!this.maximumShortTimerDuration || !this.longRunningTimerIntervalDuration) {
                 throw Error(
-                    "A framework-internal error was detected: replay schema version >= V3 is being used, but one or more of the properties `maximumShortTimerDuration` and `longRunningTimerIntervalDuration` are not defined. This is likely an issue with the Durable Functions Extension. Please report this bug here: https://github.com/Azure/azure-functions-durable-js/issues "
-
+                    "A framework-internal error was detected: replay schema version >= V3 is being used, " +
+                        "but one or more of the properties `maximumShortTimerDuration` and `longRunningTimerIntervalDuration` are not defined. " +
+                        "This is likely an issue with the Durable Functions Extension. " +
+                        "Please report this bug here: https://github.com/Azure/azure-functions-durable-js/issues\n" +
+                        `maximumShortTimerDuration: ${this.maximumShortTimerDuration}\n` +
+                        `longRunningTimerIntervalDuration: ${this.longRunningTimerIntervalDuration}`
                 );
             }
 

--- a/src/durableorchestrationcontext.ts
+++ b/src/durableorchestrationcontext.ts
@@ -43,8 +43,8 @@ export class DurableOrchestrationContext {
         currentUtcDateTime: Date,
         isReplaying: boolean,
         parentInstanceId: string | undefined,
-        longRunningTimerIntervalLength: string | undefined,
-        maximumDelayTime: string | undefined,
+        longRunningTimerIntervalDuration: string | undefined,
+        maximumShortTimerDuration: string | undefined,
         input: unknown,
         private taskOrchestratorExecutor: TaskOrchestrationExecutor
     ) {
@@ -53,8 +53,8 @@ export class DurableOrchestrationContext {
         this.isReplaying = isReplaying;
         this.currentUtcDateTime = currentUtcDateTime;
         this.parentInstanceId = parentInstanceId;
-        this.longRunningTimerIntervalLength = moment.duration(longRunningTimerIntervalLength);
-        this.maximumDelayTime = moment.duration(maximumDelayTime);
+        this.longRunningTimerIntervalDuration = moment.duration(longRunningTimerIntervalDuration);
+        this.maximumShortTimerDuration = moment.duration(maximumShortTimerDuration);
         this.input = input;
         this.newGuidCounter = 0;
     }
@@ -107,9 +107,9 @@ export class DurableOrchestrationContext {
      */
     public currentUtcDateTime: Date;
 
-    public longRunningTimerIntervalLength: moment.Duration;
+    public longRunningTimerIntervalDuration: moment.Duration;
 
-    public maximumDelayTime: moment.Duration;
+    public maximumShortTimerDuration: moment.Duration;
 
     /**
      * @hidden
@@ -307,14 +307,14 @@ export class DurableOrchestrationContext {
         let task: TimerTask;
         if (
             moment.duration(moment(fireAt).diff(moment(this.currentUtcDateTime))) >
-            this.maximumDelayTime
+            this.maximumShortTimerDuration
         ) {
             task = new LongTimerTask(
                 false,
                 newAction,
-                this.currentUtcDateTime,
-                this.maximumDelayTime,
-                this.longRunningTimerIntervalLength
+                this,
+                this.maximumShortTimerDuration,
+                this.longRunningTimerIntervalDuration
             );
         } else {
             task = new DFTimerTask(false, newAction);

--- a/src/durableorchestrationcontext.ts
+++ b/src/durableorchestrationcontext.ts
@@ -31,6 +31,7 @@ import {
     LongTimerTask,
 } from "./task";
 import moment = require("moment");
+import { ReplaySchema } from "./replaySchema";
 
 /**
  * Parameter data for orchestration bindings that can be used to schedule
@@ -45,6 +46,7 @@ export class DurableOrchestrationContext {
         parentInstanceId: string | undefined,
         longRunningTimerIntervalDuration: string | undefined,
         maximumShortTimerDuration: string | undefined,
+        schemaVersion: ReplaySchema,
         input: unknown,
         private taskOrchestratorExecutor: TaskOrchestrationExecutor
     ) {
@@ -55,6 +57,7 @@ export class DurableOrchestrationContext {
         this.parentInstanceId = parentInstanceId;
         this.longRunningTimerIntervalDuration = moment.duration(longRunningTimerIntervalDuration);
         this.maximumShortTimerDuration = moment.duration(maximumShortTimerDuration);
+        this.schemaVersion = schemaVersion;
         this.input = input;
         this.newGuidCounter = 0;
     }
@@ -110,6 +113,8 @@ export class DurableOrchestrationContext {
     public longRunningTimerIntervalDuration: moment.Duration;
 
     public maximumShortTimerDuration: moment.Duration;
+
+    public schemaVersion: ReplaySchema;
 
     /**
      * @hidden
@@ -306,8 +311,9 @@ export class DurableOrchestrationContext {
         const newAction = new CreateTimerAction(fireAt);
         let task: TimerTask;
         if (
+            this.schemaVersion >= ReplaySchema.V3 &&
             moment.duration(moment(fireAt).diff(moment(this.currentUtcDateTime))) >
-            this.maximumShortTimerDuration
+                this.maximumShortTimerDuration
         ) {
             task = new LongTimerTask(
                 false,

--- a/src/durableorchestrationcontext.ts
+++ b/src/durableorchestrationcontext.ts
@@ -313,6 +313,7 @@ export class DurableOrchestrationContext {
                 false,
                 newAction,
                 this,
+                this.taskOrchestratorExecutor,
                 this.maximumShortTimerDuration,
                 this.longRunningTimerIntervalDuration
             );

--- a/src/durableorchestrationcontext.ts
+++ b/src/durableorchestrationcontext.ts
@@ -335,7 +335,6 @@ export class DurableOrchestrationContext {
      */
     public createTimer(fireAt: Date): TimerTask {
         const timerAction = new CreateTimerAction(fireAt);
-        let task: TimerTask;
         const durationUntilFire = moment.duration(moment(fireAt).diff(this.currentUtcDateTime));
         if (
             this.schemaVersion >= ReplaySchema.V3 &&
@@ -343,7 +342,7 @@ export class DurableOrchestrationContext {
             this.longRunningTimerIntervalDuration &&
             durationUntilFire > this.maximumShortTimerDuration
         ) {
-            task = new LongTimerTask(
+            return new LongTimerTask(
                 false,
                 timerAction,
                 this,
@@ -351,10 +350,9 @@ export class DurableOrchestrationContext {
                 this.maximumShortTimerDuration,
                 this.longRunningTimerIntervalDuration
             );
-        } else {
-            task = new DFTimerTask(false, timerAction);
         }
-        return task;
+
+        return new DFTimerTask(false, timerAction);
     }
 
     /**

--- a/src/durableorchestrationcontext.ts
+++ b/src/durableorchestrationcontext.ts
@@ -121,7 +121,7 @@ export class DurableOrchestrationContext {
      * This duration property is determined by the underlying storage
      * solution and passed to the SDK from the extension.
      */
-    public maximumShortTimerDuration: moment.Duration | undefined;
+    private readonly maximumShortTimerDuration: moment.Duration | undefined;
 
     /**
      * A duration property which defines the duration of smaller
@@ -131,7 +131,7 @@ export class DurableOrchestrationContext {
      * This duration property is determined by the underlying
      * storage solution and passed to the SDK from the extension.
      */
-    public longRunningTimerIntervalDuration: moment.Duration | undefined;
+    private readonly longRunningTimerIntervalDuration: moment.Duration | undefined;
 
     /**
      * Gets the current schema version that this execution is
@@ -140,7 +140,7 @@ export class DurableOrchestrationContext {
      * Different schema versions can allow different behavior.
      * For example, long timers are only supported in schema version >=3
      */
-    public schemaVersion: ReplaySchema;
+    private readonly schemaVersion: ReplaySchema;
 
     /**
      * @hidden

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -61,6 +61,8 @@ export class Orchestrator {
                 this.currentUtcDateTime,
                 orchestrationBinding.isReplaying,
                 orchestrationBinding.parentInstanceId,
+                orchestrationBinding.longRunningTimerIntervalLength,
+                orchestrationBinding.maximumDelayTime,
                 input,
                 this.taskOrchestrationExecutor
             );

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -61,8 +61,8 @@ export class Orchestrator {
                 this.currentUtcDateTime,
                 orchestrationBinding.isReplaying,
                 orchestrationBinding.parentInstanceId,
-                orchestrationBinding.longRunningTimerIntervalLength,
-                orchestrationBinding.maximumDelayTime,
+                orchestrationBinding.longRunningTimerIntervalDuration,
+                orchestrationBinding.maximumShortTimerDuration,
                 input,
                 this.taskOrchestrationExecutor
             );

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -63,6 +63,7 @@ export class Orchestrator {
                 orchestrationBinding.parentInstanceId,
                 orchestrationBinding.longRunningTimerIntervalDuration,
                 orchestrationBinding.maximumShortTimerDuration,
+                upperSchemaVersion,
                 input,
                 this.taskOrchestrationExecutor
             );

--- a/src/replaySchema.ts
+++ b/src/replaySchema.ts
@@ -8,4 +8,4 @@ export enum ReplaySchema {
     V3 = 2,
 }
 
-export const LatestReplaySchema: ReplaySchema = ReplaySchema.V2;
+export const LatestReplaySchema: ReplaySchema = ReplaySchema.V3;

--- a/src/replaySchema.ts
+++ b/src/replaySchema.ts
@@ -5,6 +5,7 @@
 export enum ReplaySchema {
     V1 = 0,
     V2 = 1,
+    V3 = 2,
 }
 
 export const LatestReplaySchema: ReplaySchema = ReplaySchema.V2;

--- a/src/task.ts
+++ b/src/task.ts
@@ -96,7 +96,7 @@ export interface TimerTask extends Task {
     /**
      * @returns Whether or not the timer has been canceled.
      */
-    isCancelled: boolean;
+    isCanceled: boolean;
     /**
      * Indicates the timer should be canceled. This request will execute on the
      * next `yield` or `return` statement.
@@ -293,8 +293,8 @@ export class DFTimerTask extends AtomicTask implements TimerTask {
     }
 
     /** Whether this timer task is cancelled */
-    get isCancelled(): boolean {
-        return this.action.isCancelled;
+    get isCanceled(): boolean {
+        return this.action.isCanceled;
     }
 
     /**
@@ -306,7 +306,7 @@ export class DFTimerTask extends AtomicTask implements TimerTask {
         if (this.hasResult) {
             throw Error("Cannot cancel a completed task.");
         }
-        this.action.isCancelled = true; // TODO: fix typo
+        this.action.isCanceled = true;
     }
 }
 
@@ -429,8 +429,8 @@ export class LongTimerTask extends WhenAllTask implements TimerTask {
         this.longRunningTimerIntervalDuration = longRunningTimerIntervalDuration;
     }
 
-    get isCancelled(): boolean {
-        return this.action.isCancelled;
+    get isCanceled(): boolean {
+        return this.action.isCanceled;
     }
 
     /**
@@ -442,7 +442,7 @@ export class LongTimerTask extends WhenAllTask implements TimerTask {
         if (this.hasResult) {
             throw Error("Cannot cancel a completed task.");
         }
-        this.action.isCancelled = true; // TODO: fix typo
+        this.action.isCanceled = true;
     }
 
     /**

--- a/src/task.ts
+++ b/src/task.ts
@@ -411,7 +411,6 @@ export class LongTimerTask extends WhenAllTask implements TimerTask {
                 new DFTimerTask(false, new CreateTimerAction(currentFireAtTime.toDate()))
             );
         }
-        childrenTimers.push(new DFTimerTask(false, new CreateTimerAction(lastFireAtTime.toDate())));
         super(childrenTimers, action);
         this.id = id;
         this.action = action;

--- a/src/task.ts
+++ b/src/task.ts
@@ -408,10 +408,10 @@ export class LongTimerTask extends WhenAllTask implements TimerTask {
     ) {
         const currentTime = moment(orchestrationContext.currentUtcDateTime);
         const finalFireTime = moment(action.fireAt);
-        const durationTillFire = moment.duration(finalFireTime.diff(currentTime));
+        const durationUntilFire = moment.duration(finalFireTime.diff(currentTime));
 
         let nextFireTime: Date;
-        if (durationTillFire > maximumTimerLength) {
+        if (durationUntilFire > maximumTimerLength) {
             nextFireTime = currentTime.add(longRunningTimerIntervalDuration).toDate();
         } else {
             nextFireTime = finalFireTime.toDate();
@@ -463,9 +463,9 @@ export class LongTimerTask extends WhenAllTask implements TimerTask {
     }
 
     private getNextTimerTask(finalFireTime: Date, currentTime: Date): DFTimerTask {
-        const durationTillFire = moment.duration(moment(finalFireTime).diff(currentTime));
+        const durationUntilFire = moment.duration(moment(finalFireTime).diff(currentTime));
         let nextFireTime: Date;
-        if (durationTillFire > this.maximumTimerLength) {
+        if (durationUntilFire > this.maximumTimerLength) {
             nextFireTime = moment(currentTime).add(this.longRunningTimerIntervalDuration).toDate();
         } else {
             nextFireTime = finalFireTime;

--- a/src/task.ts
+++ b/src/task.ts
@@ -292,7 +292,7 @@ export class DFTimerTask extends AtomicTask implements TimerTask {
         super(id, action);
     }
 
-    /** Whether this timer task is cancelled */
+    /** Whether this timer task is canceled */
     get isCanceled(): boolean {
         return this.action.isCanceled;
     }

--- a/src/task.ts
+++ b/src/task.ts
@@ -400,8 +400,13 @@ export class LongTimerTask extends WhenAllTask implements TimerTask {
         const currentTime = moment(currentUtcTime);
         const lastFireAtTime = moment(action.fireAt);
         const currentFireAtTime = currentTime;
-        while (moment.duration(lastFireAtTime.diff(currentFireAtTime)) > maximumTimerLength) {
-            currentFireAtTime.add(longRunningTimerIntervalLength);
+        while (currentFireAtTime != lastFireAtTime) {
+            const diffDuration = moment.duration(lastFireAtTime.diff(currentFireAtTime));
+            if (diffDuration > maximumTimerLength) {
+                currentFireAtTime.add(longRunningTimerIntervalLength);
+            } else {
+                currentFireAtTime.add(diffDuration);
+            }
             childrenTimers.push(
                 new DFTimerTask(false, new CreateTimerAction(currentFireAtTime.toDate()))
             );

--- a/src/task.ts
+++ b/src/task.ts
@@ -388,8 +388,12 @@ export class WhenAnyTask extends CompoundTask {
 export class LongTimerTask extends WhenAllTask implements TimerTask {
     public constructor(
         public action: CreateTimerAction,
-        public longRunningTimerIntervalLength: moment.timer
+        public readonly currentUtcTime: Date,
+        public readonly longRunningTimerIntervalLength: string
     ) {
+        const intervalDuration = moment.duration(longRunningTimerIntervalLength);
+        const currentTime = moment(currentUtcTime);
+        const fireAtTime = moment(action.fireAt);
         const childrenTimers: DFTimerTask[] = [];
         super(childrenTimers, action);
     }

--- a/src/task.ts
+++ b/src/task.ts
@@ -406,15 +406,15 @@ export class LongTimerTask extends WhenAllTask implements TimerTask {
         maximumTimerLength: moment.Duration,
         longRunningTimerIntervalDuration: moment.Duration
     ) {
-        const currentTime = moment(orchestrationContext.currentUtcDateTime);
-        const finalFireTime = moment(action.fireAt);
-        const durationUntilFire = moment.duration(finalFireTime.diff(currentTime));
+        const currentTime = orchestrationContext.currentUtcDateTime;
+        const finalFireTime = action.fireAt;
+        const durationUntilFire = moment.duration(moment(finalFireTime).diff(currentTime));
 
         let nextFireTime: Date;
         if (durationUntilFire > maximumTimerLength) {
-            nextFireTime = currentTime.add(longRunningTimerIntervalDuration).toDate();
+            nextFireTime = moment(currentTime).add(longRunningTimerIntervalDuration).toDate();
         } else {
-            nextFireTime = finalFireTime.toDate();
+            nextFireTime = finalFireTime;
         }
 
         const nextTimerAction = new CreateTimerAction(nextFireTime);

--- a/src/task.ts
+++ b/src/task.ts
@@ -410,12 +410,10 @@ export class LongTimerTask extends WhenAllTask implements TimerTask {
         const finalFireTime = action.fireAt;
         const durationUntilFire = moment.duration(moment(finalFireTime).diff(currentTime));
 
-        let nextFireTime: Date;
-        if (durationUntilFire > maximumTimerLength) {
-            nextFireTime = moment(currentTime).add(longRunningTimerIntervalDuration).toDate();
-        } else {
-            nextFireTime = finalFireTime;
-        }
+        const nextFireTime: Date =
+            durationUntilFire > maximumTimerLength
+                ? moment(currentTime).add(longRunningTimerIntervalDuration).toDate()
+                : finalFireTime;
 
         const nextTimerAction = new CreateTimerAction(nextFireTime);
         const nextTimerTask = new DFTimerTask(false, nextTimerAction);
@@ -464,12 +462,10 @@ export class LongTimerTask extends WhenAllTask implements TimerTask {
 
     private getNextTimerTask(finalFireTime: Date, currentTime: Date): DFTimerTask {
         const durationUntilFire = moment.duration(moment(finalFireTime).diff(currentTime));
-        let nextFireTime: Date;
-        if (durationUntilFire > this.maximumTimerLength) {
-            nextFireTime = moment(currentTime).add(this.longRunningTimerIntervalDuration).toDate();
-        } else {
-            nextFireTime = finalFireTime;
-        }
+        const nextFireTime: Date =
+            durationUntilFire > this.maximumTimerLength
+                ? moment(currentTime).add(this.longRunningTimerIntervalDuration).toDate()
+                : finalFireTime;
         return new DFTimerTask(false, new CreateTimerAction(nextFireTime));
     }
 

--- a/src/testingUtils.ts
+++ b/src/testingUtils.ts
@@ -16,6 +16,7 @@ import {
     OrchestratorStartedEvent,
 } from "./classes";
 import { IOrchestrationFunctionContext } from "./iorchestrationfunctioncontext";
+import { ReplaySchema } from "./replaySchema";
 import { TaskOrchestrationExecutor } from "./taskorchestrationexecutor";
 
 /**
@@ -35,6 +36,7 @@ export class DummyOrchestrationContext implements IOrchestrationFunctionContext 
      * @param isReplaying Whether the orchestration is to be marked as isReplaying the its first event
      * @param maximumDelayTime
      * @param longRunningTimerIntervalLength
+     * @param schemaVersion
      * @param parentInstanceId The instanceId of the orchestration's parent, if this is a sub-orchestration
      */
     constructor(
@@ -44,6 +46,7 @@ export class DummyOrchestrationContext implements IOrchestrationFunctionContext 
         currentUtcDateTime: Date = new Date(),
         maximumDelayTime: string,
         longRunningTimerIntervalLength: string,
+        schemaVersion: ReplaySchema,
         isReplaying = false,
         parentInstanceId = ""
     ) {
@@ -60,6 +63,7 @@ export class DummyOrchestrationContext implements IOrchestrationFunctionContext 
             parentInstanceId,
             longRunningTimerIntervalLength,
             maximumDelayTime,
+            schemaVersion,
             input,
             new TaskOrchestrationExecutor()
         );

--- a/src/testingUtils.ts
+++ b/src/testingUtils.ts
@@ -33,6 +33,8 @@ export class DummyOrchestrationContext implements IOrchestrationFunctionContext 
      * @param input The input to the orchestration
      * @param currentUtcDateTime The deterministic date at the beginning of orchestration replay
      * @param isReplaying Whether the orchestration is to be marked as isReplaying the its first event
+     * @param maximumDelayTime
+     * @param longRunningTimerIntervalLength
      * @param parentInstanceId The instanceId of the orchestration's parent, if this is a sub-orchestration
      */
     constructor(
@@ -40,6 +42,8 @@ export class DummyOrchestrationContext implements IOrchestrationFunctionContext 
         history: HistoryEvent[] | undefined = undefined,
         input: any = undefined,
         currentUtcDateTime: Date = new Date(),
+        maximumDelayTime: string,
+        longRunningTimerIntervalLength: string,
         isReplaying = false,
         parentInstanceId = ""
     ) {
@@ -54,6 +58,8 @@ export class DummyOrchestrationContext implements IOrchestrationFunctionContext 
             currentUtcDateTime,
             isReplaying,
             parentInstanceId,
+            longRunningTimerIntervalLength,
+            maximumDelayTime,
             input,
             new TaskOrchestrationExecutor()
         );

--- a/src/testingUtils.ts
+++ b/src/testingUtils.ts
@@ -34,9 +34,9 @@ export class DummyOrchestrationContext implements IOrchestrationFunctionContext 
      * @param input The input to the orchestration
      * @param currentUtcDateTime The deterministic date at the beginning of orchestration replay
      * @param isReplaying Whether the orchestration is to be marked as isReplaying the its first event
-     * @param maximumDelayTime
-     * @param longRunningTimerIntervalLength
-     * @param schemaVersion
+     * @param longRunningTimerIntervalDuration The duration to break smaller timers into if a long timer exceeds the maximum allowed duration
+     * @param maximumShortTimerDuration The maximum duration for a timer allowed by the underlying storage infrastructure
+     * @param schemaVersion The schema version currently used after being negotiated with the extension
      * @param parentInstanceId The instanceId of the orchestration's parent, if this is a sub-orchestration
      */
     constructor(
@@ -44,8 +44,8 @@ export class DummyOrchestrationContext implements IOrchestrationFunctionContext 
         history: HistoryEvent[] | undefined = undefined,
         input: any = undefined,
         currentUtcDateTime: Date = new Date(),
-        maximumDelayTime: string,
-        longRunningTimerIntervalLength: string,
+        longRunningTimerIntervalDuration: string,
+        maximumShortTimerDuration: string,
         schemaVersion: ReplaySchema,
         isReplaying = false,
         parentInstanceId = ""
@@ -61,8 +61,8 @@ export class DummyOrchestrationContext implements IOrchestrationFunctionContext 
             currentUtcDateTime,
             isReplaying,
             parentInstanceId,
-            longRunningTimerIntervalLength,
-            maximumDelayTime,
+            longRunningTimerIntervalDuration,
+            maximumShortTimerDuration,
             schemaVersion,
             input,
             new TaskOrchestrationExecutor()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,11 +14,14 @@ export class Utils {
         collection: { [index: string]: unknown },
         typeInstance: T
     ): T[] {
-        return collection && typeInstance
-            ? (Object.keys(collection)
-                  .filter((key: string) => this.hasAllPropertiesOf(collection[key], typeInstance))
-                  .map((key: string) => this.parseTimestampsAsDates(collection[key])) as T[])
-            : [];
+        if (collection && typeInstance) {
+            const candidateObjects = Object.values(collection).filter((value) =>
+                this.hasAllPropertiesOf(value, typeInstance)
+            );
+            this.parseTimestampsAsDates(candidateObjects);
+            return candidateObjects as T[];
+        }
+        return [];
     }
 
     public static getHrMilliseconds(times: number[]): number {
@@ -46,16 +49,15 @@ export class Utils {
         return obj.hasOwnProperty(prop);
     }
 
-    public static parseTimestampsAsDates(obj: unknown): unknown {
-        if (
-            typeof obj === "object" &&
-            obj !== null &&
-            this.hasOwnProperty(obj, "Timestamp") &&
-            typeof obj.Timestamp === "string"
-        ) {
-            obj.Timestamp = new Date(obj.Timestamp);
+    public static parseTimestampsAsDates(obj: unknown): void {
+        if (typeof obj === "object" && obj != null) {
+            if (this.hasOwnProperty(obj, "Timestamp") && typeof obj.Timestamp === "string") {
+                obj.Timestamp = new Date(obj.Timestamp);
+            }
+            Object.values(obj).map((value) => {
+                this.parseTimestampsAsDates(value);
+            });
         }
-        return obj;
     }
 
     public static hasAllPropertiesOf<T>(obj: unknown, refInstance: T): boolean {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,9 +19,6 @@ export class Utils {
                 this.hasAllPropertiesOf(value, typeInstance)
             );
 
-            // This recursive step ensures _all_ Timestamp properties are converted properly
-            // For example, a payload can contain the history as a property, so if we want to
-            // parse each HistoryEvent's Timestamp, we need to traverse the payload recursively
             this.parseTimestampsAsDates(candidateObjects);
 
             return candidateObjects as T[];
@@ -60,6 +57,9 @@ export class Utils {
                 obj.Timestamp = new Date(obj.Timestamp);
             }
             Object.values(obj).map((value) => {
+                // This recursive step ensures _all_ Timestamp properties are converted properly
+                // For example, a payload can contain the history as a property, so if we want to
+                // parse each HistoryEvent's Timestamp, we need to traverse the payload recursively
                 this.parseTimestampsAsDates(value);
             });
         }

--- a/test/integration/orchestrator-spec.ts
+++ b/test/integration/orchestrator-spec.ts
@@ -1572,7 +1572,13 @@ describe("Orchestrator", () => {
                 const mockContext = new MockContext({
                     context: new DurableOrchestrationBindingInfo(
                         TestHistories.GetOrchestratorStart("WaitOnTimer", startTime),
-                        fireAt
+                        fireAt,
+                        "",
+                        false,
+                        undefined,
+                        "P6D",
+                        "P3D",
+                        ReplaySchema.V3
                     ),
                 });
 
@@ -1584,7 +1590,7 @@ describe("Orchestrator", () => {
                             isDone: false,
                             output: undefined,
                             actions: [[new CreateTimerAction(fireAt)]],
-                            schemaVersion: ReplaySchema.V1,
+                            schemaVersion: ReplaySchema.V3,
                         },
                         true
                     )
@@ -1599,7 +1605,13 @@ describe("Orchestrator", () => {
                 const mockContext = new MockContext({
                     context: new DurableOrchestrationBindingInfo(
                         TestHistories.GetWaitOnLongTimerHalfway(startTime, fireAt),
-                        fireAt
+                        fireAt,
+                        "",
+                        false,
+                        undefined,
+                        "P6D",
+                        "P3D",
+                        ReplaySchema.V3
                     ),
                 });
 
@@ -1611,7 +1623,7 @@ describe("Orchestrator", () => {
                             isDone: false,
                             output: undefined,
                             actions: [[new CreateTimerAction(fireAt)]],
-                            schemaVersion: ReplaySchema.V1,
+                            schemaVersion: ReplaySchema.V3,
                         },
                         true
                     )
@@ -1626,7 +1638,13 @@ describe("Orchestrator", () => {
                 const mockContext = new MockContext({
                     context: new DurableOrchestrationBindingInfo(
                         TestHistories.GetWaitOnTimerFired(startTimestamp, fireAt),
-                        fireAt
+                        fireAt,
+                        "",
+                        false,
+                        undefined,
+                        "P6D",
+                        "P3D",
+                        ReplaySchema.V3
                     ),
                 });
 
@@ -1638,7 +1656,7 @@ describe("Orchestrator", () => {
                             isDone: true,
                             actions: [[new CreateTimerAction(fireAt)]],
                             output: "Timer fired!",
-                            schemaVersion: ReplaySchema.V1,
+                            schemaVersion: ReplaySchema.V3,
                         },
                         true
                     )

--- a/test/integration/orchestrator-spec.ts
+++ b/test/integration/orchestrator-spec.ts
@@ -1566,12 +1566,12 @@ describe("Orchestrator", () => {
         describe("long timers", () => {
             it("schedules long timers", () => {
                 const orchestrator = TestOrchestrations.WaitOnTimer;
-                const startMoment = moment.utc();
-                const fireAt = startMoment.add(10, "d").toDate();
+                const startTime = moment.utc().toDate();
+                const fireAt = moment(startTime).add(10, "d").toDate();
 
                 const mockContext = new MockContext({
                     context: new DurableOrchestrationBindingInfo(
-                        TestHistories.GetOrchestratorStart("WaitOnTimer", startMoment.toDate()),
+                        TestHistories.GetOrchestratorStart("WaitOnTimer", startTime),
                         fireAt
                     ),
                 });

--- a/test/integration/orchestrator-spec.ts
+++ b/test/integration/orchestrator-spec.ts
@@ -1576,8 +1576,8 @@ describe("Orchestrator", () => {
                         "",
                         false,
                         undefined,
-                        "P6D",
-                        "P3D",
+                        "6.00:00:00",
+                        "3.00:00:00",
                         ReplaySchema.V3
                     ),
                 });
@@ -1609,8 +1609,8 @@ describe("Orchestrator", () => {
                         "",
                         false,
                         undefined,
-                        "P6D",
-                        "P3D",
+                        "6.00:00:00",
+                        "3.00:00:00",
                         ReplaySchema.V3
                     ),
                 });
@@ -1642,8 +1642,8 @@ describe("Orchestrator", () => {
                         "",
                         false,
                         undefined,
-                        "P6D",
-                        "P3D",
+                        "6.00:00:00",
+                        "3.00:00:00",
                         ReplaySchema.V3
                     ),
                 });

--- a/test/integration/orchestrator-spec.ts
+++ b/test/integration/orchestrator-spec.ts
@@ -3,6 +3,7 @@ import { TraceContext } from "@azure/functions";
 import { expect } from "chai";
 import "mocha";
 import * as moment from "moment";
+import { start } from "repl";
 import * as uuidv1 from "uuid/v1";
 import { ManagedIdentityTokenSource } from "../../src";
 import {
@@ -83,32 +84,6 @@ describe("Orchestrator", () => {
             )
         );
     });
-
-    /*
-    it("handles a simple orchestration function (no activity functions), with yield of non-Task object", async () => {
-        const orchestrator = TestOrchestrations.SayHelloInlineInproperYield;
-        const name = "World";
-        const mockContext = new MockContext({
-            context: new DurableOrchestrationBindingInfo(
-                TestHistories.GetOrchestratorStart(
-                    "SayHelloInlineInproperYield",
-                    moment.utc().toDate(),
-                    name
-                ),
-                name
-            ),
-        });
-        orchestrator(mockContext);
-
-        expect(mockContext.doneValue).to.be.deep.equal(
-            new OrchestratorState({
-                isDone: true,
-                actions: [],
-                output: `Hello, ${name}!`,
-            })
-        );
-    });
-    */
 
     describe("handle falsy values", () => {
         for (const falsyValue of falsyValues) {
@@ -1586,6 +1561,89 @@ describe("Orchestrator", () => {
                     true
                 )
             );
+        });
+
+        describe("long timers", () => {
+            it("schedules long timers", () => {
+                const orchestrator = TestOrchestrations.WaitOnTimer;
+                const startMoment = moment.utc();
+                const fireAt = startMoment.add(10, "d").toDate();
+
+                const mockContext = new MockContext({
+                    context: new DurableOrchestrationBindingInfo(
+                        TestHistories.GetOrchestratorStart("WaitOnTimer", startMoment.toDate()),
+                        fireAt
+                    ),
+                });
+
+                orchestrator(mockContext);
+
+                expect(mockContext.doneValue).to.be.deep.equal(
+                    new OrchestratorState(
+                        {
+                            isDone: false,
+                            output: undefined,
+                            actions: [[new CreateTimerAction(fireAt)]],
+                            schemaVersion: ReplaySchema.V1,
+                        },
+                        true
+                    )
+                );
+            });
+
+            it("waits for sub-timers of long timer", () => {
+                const orchestrator = TestOrchestrations.WaitOnTimer;
+                const startTime = moment.utc().toDate();
+                const fireAt = moment(startTime).add(10, "days").toDate();
+
+                const mockContext = new MockContext({
+                    context: new DurableOrchestrationBindingInfo(
+                        TestHistories.GetWaitOnLongTimerHalfway(startTime, fireAt),
+                        fireAt
+                    ),
+                });
+
+                orchestrator(mockContext);
+
+                expect(mockContext.doneValue).to.be.deep.equal(
+                    new OrchestratorState(
+                        {
+                            isDone: false,
+                            output: undefined,
+                            actions: [[new CreateTimerAction(fireAt)]],
+                            schemaVersion: ReplaySchema.V1,
+                        },
+                        true
+                    )
+                );
+            });
+
+            it("proceeds after long timer fires", () => {
+                const orchestrator = TestOrchestrations.WaitOnTimer;
+                const startTimestamp = moment.utc().toDate();
+                const fireAt = moment(startTimestamp).add(10, "d").toDate();
+
+                const mockContext = new MockContext({
+                    context: new DurableOrchestrationBindingInfo(
+                        TestHistories.GetWaitOnTimerFired(startTimestamp, fireAt),
+                        fireAt
+                    ),
+                });
+
+                orchestrator(mockContext);
+
+                expect(mockContext.doneValue).to.deep.equal(
+                    new OrchestratorState(
+                        {
+                            isDone: true,
+                            actions: [[new CreateTimerAction(fireAt)]],
+                            output: "Timer fired!",
+                            schemaVersion: ReplaySchema.V1,
+                        },
+                        true
+                    )
+                );
+            });
         });
     });
 

--- a/test/testobjects/testhistories.ts
+++ b/test/testobjects/testhistories.ts
@@ -2303,7 +2303,7 @@ export class TestHistories {
         ];
     }
 
-    private static TimerCreated(timestamp: Date, fireAt: Date): HistoryEvent[] {
+    private static TimerCreated(timestamp: Date, fireAt: Date, timerId: number): HistoryEvent[] {
         return [
             new OrchestratorStartedEvent({
                 eventId: -1,
@@ -2311,7 +2311,7 @@ export class TestHistories {
                 isPlayed: false,
             }),
             new TimerCreatedEvent({
-                eventId: 0,
+                eventId: timerId,
                 timestamp,
                 isPlayed: false,
                 fireAt,
@@ -2324,7 +2324,7 @@ export class TestHistories {
         ];
     }
 
-    private static TimerFired(fireAt: Date): HistoryEvent[] {
+    private static TimerFired(fireAt: Date, timerId: number): HistoryEvent[] {
         return [
             new OrchestratorStartedEvent({
                 eventId: -1,
@@ -2336,7 +2336,7 @@ export class TestHistories {
                 timestamp: fireAt,
                 isPlayed: false,
                 fireAt,
-                timerId: 0,
+                timerId,
             }),
             new OrchestratorCompletedEvent({
                 eventId: -1,
@@ -2364,17 +2364,22 @@ export class TestHistories {
 
         let previousTimestamp = firstTimestamp;
         let nextFireAt;
+        let timerId = 0;
         while (
             moment.duration(moment(fireAt).diff(previousTimestamp)) > maximumShortTimerDuration
         ) {
             nextFireAt = moment(previousTimestamp).add(longRunningTimerIntervalDuration).toDate();
             history.push(
-                ...this.TimerCreated(previousTimestamp, nextFireAt),
-                ...this.TimerFired(nextFireAt)
+                ...this.TimerCreated(previousTimestamp, nextFireAt, timerId),
+                ...this.TimerFired(nextFireAt, timerId)
             );
             previousTimestamp = nextFireAt;
+            timerId++;
         }
-        history.push(...this.TimerCreated(previousTimestamp, fireAt), ...this.TimerFired(fireAt));
+        history.push(
+            ...this.TimerCreated(previousTimestamp, fireAt, timerId),
+            ...this.TimerFired(fireAt, timerId)
+        );
         return history;
     }
 
@@ -2399,8 +2404,8 @@ export class TestHistories {
         ];
 
         const nextFireAt = moment(firstTimestamp).add(longRunningTimerIntervalDuration).toDate();
-        history.push(...this.TimerCreated(firstTimestamp, nextFireAt));
-        history.push(...this.TimerFired(nextFireAt));
+        history.push(...this.TimerCreated(firstTimestamp, nextFireAt, 0));
+        history.push(...this.TimerFired(nextFireAt, 0));
         return history;
     }
 }

--- a/test/unit/timertask-spec.ts
+++ b/test/unit/timertask-spec.ts
@@ -5,9 +5,9 @@ import { DFTimerTask } from "../../src/task";
 
 describe("TimerTask", () => {
     it("throws cannot cancel a completed task", async () => {
-        const isCancelled = false;
+        const isCanceled = false;
         const date = new Date();
-        const action = new CreateTimerAction(date, isCancelled);
+        const action = new CreateTimerAction(date, isCanceled);
         const task = new DFTimerTask(0, action);
         task.setValue(false, undefined); // set value to complete task
 
@@ -17,21 +17,21 @@ describe("TimerTask", () => {
     });
 
     it("cancels an incomplete task", async () => {
-        const isCancelled = false;
+        const isCanceled = false;
         const date = new Date();
-        const action = new CreateTimerAction(date, isCancelled);
+        const action = new CreateTimerAction(date, isCanceled);
         const task = new DFTimerTask(0, action);
 
         task.cancel();
-        expect(task.isCancelled).to.equal(true);
+        expect(task.isCanceled).to.equal(true);
     });
 
     it("is canceled when its action is canceled", async () => {
-        const isCancelled = true;
+        const isCanceled = true;
         const date = new Date();
-        const action = new CreateTimerAction(date, isCancelled);
+        const action = new CreateTimerAction(date, isCanceled);
         const task = new DFTimerTask(0, action);
 
-        expect(task.isCancelled).to.equal(true);
+        expect(task.isCanceled).to.equal(true);
     });
 });


### PR DESCRIPTION
Resolves #325. This PR leverages these changes in the extension: https://github.com/Azure/azure-functions-durable-extension/pull/2134 to allow JS orchestrators to have timers longer than 6 days. Internally, when user code calls `CreateTimer`, if it is more than 6 days, a `LongTimerTask`, which is essentially a `WhenAll` task of several small sub-timers, is created instead of an atomic `DFTimerTask`. 

Now, the JS SDK will become the first OOProc SDK to support long timers 🥳 This also unblocks #284 