### PR TITLE
Avoid using mutable `moment.add` method

### DIFF
--- a/test/integration/orchestrator-spec.ts
+++ b/test/integration/orchestrator-spec.ts
@@ -818,7 +818,10 @@ describe("Orchestrator", () => {
                         actions: [
                             [new CallActivityWithRetryAction("Hello", retryOptions, "World")],
                         ],
-                        output: [startingTime, moment(startingTime).add(1, "m").toDate()],
+                        output: [
+                            startingTime,
+                            moment(startingTime).add(1, "m").add(30, "s").toDate(),
+                        ],
                         schemaVersion: ReplaySchema.V1,
                     },
                     true

--- a/test/integration/orchestrator-spec.ts
+++ b/test/integration/orchestrator-spec.ts
@@ -818,10 +818,7 @@ describe("Orchestrator", () => {
                         actions: [
                             [new CallActivityWithRetryAction("Hello", retryOptions, "World")],
                         ],
-                        output: [
-                            startingTime,
-                            moment(startingTime).add(1, "m").add(30, "s").toDate(),
-                        ],
+                        output: [startingTime, moment(startingTime).add(1, "m").toDate()],
                         schemaVersion: ReplaySchema.V1,
                     },
                     true
@@ -1536,12 +1533,12 @@ describe("Orchestrator", () => {
     describe("createTimer()", () => {
         it("schedules a timer", async () => {
             const orchestrator = TestOrchestrations.WaitOnTimer;
-            const startMoment = moment.utc();
-            const fireAt = startMoment.add(5, "m").toDate();
+            const startTime = moment.utc().toDate();
+            const fireAt = moment(startTime).add(5, "m").toDate();
 
             const mockContext = new MockContext({
                 context: new DurableOrchestrationBindingInfo(
-                    TestHistories.GetOrchestratorStart("WaitOnTimer", startMoment.toDate()),
+                    TestHistories.GetOrchestratorStart("WaitOnTimer", startTime),
                     fireAt
                 ),
             });
@@ -2043,10 +2040,10 @@ describe("Orchestrator", () => {
         it("Task.any called with one TaskSet and one timer where TaskSet wins", async () => {
             const orchestrator = TestOrchestrations.AnyWithTaskSet;
             const eventsWin = true;
-            const initialTime = moment.utc();
+            const initialTime = moment.utc().toDate();
             let mockContext = new MockContext({
                 context: new DurableOrchestrationBindingInfo(
-                    TestHistories.GetAnyWithTaskSet(initialTime.toDate(), 1, eventsWin)
+                    TestHistories.GetAnyWithTaskSet(initialTime, 1, eventsWin)
                 ),
             });
 
@@ -2060,7 +2057,7 @@ describe("Orchestrator", () => {
                             [
                                 new WaitForExternalEventAction("firstRequiredEvent"),
                                 new WaitForExternalEventAction("secondRequiredEvent"),
-                                new CreateTimerAction(initialTime.add(300, "s").toDate()),
+                                new CreateTimerAction(moment(initialTime).add(300, "s").toDate()),
                             ],
                         ],
                         output: undefined,
@@ -2072,7 +2069,7 @@ describe("Orchestrator", () => {
 
             mockContext = new MockContext({
                 context: new DurableOrchestrationBindingInfo(
-                    TestHistories.GetAnyWithTaskSet(initialTime.toDate(), 2, eventsWin)
+                    TestHistories.GetAnyWithTaskSet(initialTime, 2, eventsWin)
                 ),
             });
 
@@ -2086,7 +2083,7 @@ describe("Orchestrator", () => {
                             [
                                 new WaitForExternalEventAction("firstRequiredEvent"),
                                 new WaitForExternalEventAction("secondRequiredEvent"),
-                                new CreateTimerAction(initialTime.add(300, "s").toDate()),
+                                new CreateTimerAction(moment(initialTime).add(300, "s").toDate()),
                             ],
                             [new CallActivityAction("Hello", "Tokyo")],
                         ],
@@ -2101,10 +2098,10 @@ describe("Orchestrator", () => {
         it("Task.any called with one TaskSet and one timer where timer wins", async () => {
             const orchestrator = TestOrchestrations.AnyWithTaskSet;
             const eventsWin = false;
-            const initialTime = moment.utc();
+            const initialTime = moment.utc().toDate();
             let mockContext = new MockContext({
                 context: new DurableOrchestrationBindingInfo(
-                    TestHistories.GetAnyWithTaskSet(initialTime.toDate(), 1, eventsWin)
+                    TestHistories.GetAnyWithTaskSet(initialTime, 1, eventsWin)
                 ),
             });
 
@@ -2118,7 +2115,7 @@ describe("Orchestrator", () => {
                             [
                                 new WaitForExternalEventAction("firstRequiredEvent"),
                                 new WaitForExternalEventAction("secondRequiredEvent"),
-                                new CreateTimerAction(initialTime.add(300, "s").toDate()),
+                                new CreateTimerAction(moment(initialTime).add(300, "s").toDate()),
                             ],
                         ],
                         output: undefined,
@@ -2130,7 +2127,7 @@ describe("Orchestrator", () => {
 
             mockContext = new MockContext({
                 context: new DurableOrchestrationBindingInfo(
-                    TestHistories.GetAnyWithTaskSet(initialTime.toDate(), 2, eventsWin)
+                    TestHistories.GetAnyWithTaskSet(initialTime, 2, eventsWin)
                 ),
             });
 
@@ -2144,7 +2141,7 @@ describe("Orchestrator", () => {
                             [
                                 new WaitForExternalEventAction("firstRequiredEvent"),
                                 new WaitForExternalEventAction("secondRequiredEvent"),
-                                new CreateTimerAction(initialTime.add(300, "s").toDate()),
+                                new CreateTimerAction(moment(initialTime).add(300, "s").toDate()),
                             ],
                         ],
                         output: ["timeout"],
@@ -2187,12 +2184,12 @@ describe("Orchestrator", () => {
 
         it("Timer in combination with Task.any() executes deterministically", async () => {
             const orchestrator = TestOrchestrations.TimerActivityRace;
-            const currentTime = moment.utc();
+            const currentTime = moment.utc().toDate();
 
             // first iteration
             let mockContext = new MockContext({
                 context: new DurableOrchestrationBindingInfo(
-                    TestHistories.GetTimerActivityRaceActivityWinsHistory(currentTime.toDate(), 1),
+                    TestHistories.GetTimerActivityRaceActivityWinsHistory(currentTime, 1),
                     undefined
                 ),
             });
@@ -2205,7 +2202,7 @@ describe("Orchestrator", () => {
                         isDone: false,
                         actions: [
                             [
-                                new CreateTimerAction(currentTime.add(1, "s").toDate()),
+                                new CreateTimerAction(moment(currentTime).add(1, "s").toDate()),
                                 new CallActivityAction("TaskA"),
                             ],
                         ],
@@ -2219,7 +2216,7 @@ describe("Orchestrator", () => {
             // second iteration
             mockContext = new MockContext({
                 context: new DurableOrchestrationBindingInfo(
-                    TestHistories.GetTimerActivityRaceActivityWinsHistory(currentTime.toDate(), 2),
+                    TestHistories.GetTimerActivityRaceActivityWinsHistory(currentTime, 2),
                     undefined
                 ),
             });
@@ -2232,7 +2229,7 @@ describe("Orchestrator", () => {
                         isDone: false,
                         actions: [
                             [
-                                new CreateTimerAction(currentTime.add(1, "s").toDate()),
+                                new CreateTimerAction(moment(currentTime).add(1, "s").toDate()),
                                 new CallActivityAction("TaskA"),
                             ],
                             [new CallActivityAction("TaskB")],
@@ -2247,7 +2244,7 @@ describe("Orchestrator", () => {
             // third iteration
             mockContext = new MockContext({
                 context: new DurableOrchestrationBindingInfo(
-                    TestHistories.GetTimerActivityRaceActivityWinsHistory(currentTime.toDate(), 3),
+                    TestHistories.GetTimerActivityRaceActivityWinsHistory(currentTime, 3),
                     undefined
                 ),
             });
@@ -2260,7 +2257,7 @@ describe("Orchestrator", () => {
                         isDone: false,
                         actions: [
                             [
-                                new CreateTimerAction(currentTime.add(1, "s").toDate()),
+                                new CreateTimerAction(moment(currentTime).add(1, "s").toDate()),
                                 new CallActivityAction("TaskA"),
                             ],
                             [new CallActivityAction("TaskB")],
@@ -2275,7 +2272,7 @@ describe("Orchestrator", () => {
             // final iteration
             mockContext = new MockContext({
                 context: new DurableOrchestrationBindingInfo(
-                    TestHistories.GetTimerActivityRaceActivityWinsHistory(currentTime.toDate(), 4),
+                    TestHistories.GetTimerActivityRaceActivityWinsHistory(currentTime, 4),
                     undefined
                 ),
             });
@@ -2288,7 +2285,7 @@ describe("Orchestrator", () => {
                         isDone: true,
                         actions: [
                             [
-                                new CreateTimerAction(currentTime.add(1, "s").toDate()),
+                                new CreateTimerAction(moment(currentTime).add(1, "s").toDate()),
                                 new CallActivityAction("TaskA"),
                             ],
                             [new CallActivityAction("TaskB")],
@@ -2303,12 +2300,12 @@ describe("Orchestrator", () => {
 
         it("Timer in combination with Task.any() timer wins", async () => {
             const orchestrator = TestOrchestrations.TimerActivityRace;
-            const currentTime = moment.utc();
+            const currentTime = moment.utc().toDate();
 
             // first iteration
             let mockContext = new MockContext({
                 context: new DurableOrchestrationBindingInfo(
-                    TestHistories.GetTimerActivityRaceTimerWinsHistory(currentTime.toDate(), 1),
+                    TestHistories.GetTimerActivityRaceTimerWinsHistory(currentTime, 1),
                     null
                 ),
             });
@@ -2321,7 +2318,7 @@ describe("Orchestrator", () => {
                         isDone: false,
                         actions: [
                             [
-                                new CreateTimerAction(currentTime.add(1, "s").toDate()),
+                                new CreateTimerAction(moment(currentTime).add(1, "s").toDate()),
                                 new CallActivityAction("TaskA"),
                             ],
                         ],
@@ -2335,7 +2332,7 @@ describe("Orchestrator", () => {
             // second iteration
             mockContext = new MockContext({
                 context: new DurableOrchestrationBindingInfo(
-                    TestHistories.GetTimerActivityRaceTimerWinsHistory(currentTime.toDate(), 2),
+                    TestHistories.GetTimerActivityRaceTimerWinsHistory(currentTime, 2),
                     null
                 ),
             });
@@ -2348,7 +2345,7 @@ describe("Orchestrator", () => {
                         isDone: true,
                         actions: [
                             [
-                                new CreateTimerAction(currentTime.add(1, "s").toDate()),
+                                new CreateTimerAction(moment(currentTime).add(1, "s").toDate()),
                                 new CallActivityAction("TaskA"),
                             ],
                         ],

--- a/test/testobjects/testhistories.ts
+++ b/test/testobjects/testhistories.ts
@@ -1352,6 +1352,8 @@ export class TestHistories {
             })
         );
 
+        // These artificial delays between fireAt and timestamp is because
+        // in reality, timers don't fire exactly at their fireAt time
         let fireAt = moment(timestamp).add(retryInterval, "ms").toDate();
         timestamp = moment(fireAt).add(10, "s").toDate();
 

--- a/test/testobjects/testhistories.ts
+++ b/test/testobjects/testhistories.ts
@@ -39,8 +39,6 @@ export class TestHistories {
     }
 
     public static GetAnyAOrB(firstTimestamp: Date, completeInOrder: boolean): HistoryEvent[] {
-        const firstMoment = moment(firstTimestamp);
-
         return [
             new OrchestratorStartedEvent({
                 eventId: -1,
@@ -75,12 +73,12 @@ export class TestHistories {
             }),
             new OrchestratorStartedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
             }),
             new TaskCompletedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
                 result: JSON.stringify(completeInOrder ? "A" : "B"),
                 taskScheduledId: completeInOrder ? 0 : 1,
@@ -92,11 +90,10 @@ export class TestHistories {
         firstTimestamp: Date,
         iteration: number
     ): HistoryEvent[] {
-        const firstIteration = moment(firstTimestamp);
-        const fireAt = firstIteration.add(1, "s").toDate();
-        const secondIteration = firstIteration.add(500, "ms").toDate();
-        const thirdIteration = firstIteration.add(1100, "ms").toDate();
-        const finalIteration = firstIteration.add(2, "s").toDate();
+        const fireAt = moment(firstTimestamp).add(1, "s").toDate();
+        const secondIteration = moment(firstTimestamp).add(500, "ms").toDate();
+        const thirdIteration = moment(firstTimestamp).add(1100, "ms").toDate();
+        const finalIteration = moment(firstTimestamp).add(2, "s").toDate();
 
         const history = [];
 
@@ -234,9 +231,8 @@ export class TestHistories {
         firstTimestamp: Date,
         iteration: number
     ): HistoryEvent[] {
-        const firstIteration = moment(firstTimestamp);
-        const fireAt = firstIteration.add(1, "s").toDate();
-        const secondIteration = firstIteration.add(1100, "ms").toDate();
+        const fireAt = moment(firstTimestamp).add(1, "s").toDate();
+        const secondIteration = moment(firstTimestamp).add(1100, "ms").toDate();
 
         const history = [];
         if (iteration >= 1) {
@@ -307,8 +303,7 @@ export class TestHistories {
         iteration: number,
         eventsBeatTimer: boolean
     ): HistoryEvent[] {
-        const firstIteration = moment(firstTimestamp);
-        const fireAt = firstIteration.add(300, "s").toDate();
+        const fireAt = moment(firstTimestamp).add(300, "s").toDate();
 
         const history = [];
 
@@ -347,8 +342,8 @@ export class TestHistories {
 
         if (iteration >= 2) {
             const secondIteration: Date = eventsBeatTimer
-                ? firstIteration.add(2500, "ms").toDate()
-                : firstIteration.add(31500, "ms").toDate();
+                ? moment(firstTimestamp).add(2500, "ms").toDate()
+                : moment(firstTimestamp).add(31500, "ms").toDate();
 
             history.push(
                 new OrchestratorStartedEvent({
@@ -360,7 +355,7 @@ export class TestHistories {
             history.push(
                 new EventRaisedEvent({
                     eventId: -1,
-                    timestamp: firstIteration.add(2, "s").toDate(),
+                    timestamp: moment(firstTimestamp).add(2, "s").toDate(),
                     isPlayed: false,
                     name: "firstRequiredEvent",
                 })
@@ -369,7 +364,7 @@ export class TestHistories {
                 history.push(
                     new EventRaisedEvent({
                         eventId: -1,
-                        timestamp: firstIteration.add(2, "s").toDate(),
+                        timestamp: moment(firstTimestamp).add(2, "s").toDate(),
                         isPlayed: false,
                         name: "secondRequiredEvent",
                     })
@@ -396,7 +391,7 @@ export class TestHistories {
                 history.push(
                     new EventRaisedEvent({
                         eventId: -1,
-                        timestamp: firstIteration.add(3, "s").toDate(),
+                        timestamp: moment(firstTimestamp).add(3, "s").toDate(),
                         isPlayed: false,
                         name: "secondRequiredEvent",
                     })
@@ -408,7 +403,6 @@ export class TestHistories {
     }
 
     public static GetCallEntitySet(firstTimestamp: Date, entityId: EntityId): HistoryEvent[] {
-        const firstMoment = moment(firstTimestamp);
         const orchestratorId = uuidv1();
         const messageId = uuidv1();
 
@@ -420,37 +414,37 @@ export class TestHistories {
             }),
             new ExecutionStartedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: true,
                 name: orchestratorId,
                 input: JSON.stringify(entityId),
             }),
             new EventSentEvent({
                 eventId: 0,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: true,
                 name: "op",
                 input: JSON.stringify({
                     id: messageId,
                     op: "set",
                     parent: orchestratorId,
-                    timestamp: firstMoment.add(1, "s").toDate(),
+                    timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 }),
                 instanceId: EntityId.getSchedulerIdFromEntityId(entityId),
             }),
             new OrchestratorCompletedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: true,
             }),
             new OrchestratorStartedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(2, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(2, "s").toDate(),
                 isPlayed: false,
             }),
             new EventRaisedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(2, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(2, "s").toDate(),
                 isPlayed: false,
                 name: messageId,
                 input: JSON.stringify({
@@ -464,8 +458,6 @@ export class TestHistories {
         firstTimestamp: Date,
         files: string[]
     ): HistoryEvent[] {
-        const firstMoment = moment(firstTimestamp);
-
         return [
             new OrchestratorStartedEvent({
                 eventId: -1,
@@ -493,12 +485,12 @@ export class TestHistories {
             }),
             new OrchestratorStartedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
             }),
             new TaskCompletedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
                 result: JSON.stringify(files),
                 taskScheduledId: 0,
@@ -510,7 +502,7 @@ export class TestHistories {
             }),
             new OrchestratorStartedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(2, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(2, "s").toDate(),
                 isPlayed: false,
             }),
         ]
@@ -519,7 +511,7 @@ export class TestHistories {
                     (file, index) =>
                         new TaskScheduledEvent({
                             eventId: index + 1,
-                            timestamp: firstMoment.add(2, "s").toDate(),
+                            timestamp: moment(firstTimestamp).add(2, "s").toDate(),
                             isPlayed: false,
                             name: "GetFileSize",
                             input: file,
@@ -534,19 +526,19 @@ export class TestHistories {
                 }),
                 new OrchestratorStartedEvent({
                     eventId: -1,
-                    timestamp: firstMoment.add(2, "s").toDate(),
+                    timestamp: moment(firstTimestamp).add(2, "s").toDate(),
                     isPlayed: false,
                 }),
                 new TaskCompletedEvent({
                     eventId: -1,
-                    timestamp: firstMoment.add(3, "s").toDate(),
+                    timestamp: moment(firstTimestamp).add(3, "s").toDate(),
                     isPlayed: false,
                     result: JSON.stringify(1),
                     taskScheduledId: 1,
                 }),
                 new TaskCompletedEvent({
                     eventId: -1,
-                    timestamp: firstMoment.add(3, "s").toDate(),
+                    timestamp: moment(firstTimestamp).add(3, "s").toDate(),
                     isPlayed: false,
                     result: JSON.stringify(2),
                     taskScheduledId: 2,
@@ -558,12 +550,12 @@ export class TestHistories {
                 }),
                 new OrchestratorStartedEvent({
                     eventId: -1,
-                    timestamp: firstMoment.add(4, "s").toDate(),
+                    timestamp: moment(firstTimestamp).add(4, "s").toDate(),
                     isPlayed: false,
                 }),
                 new TaskCompletedEvent({
                     eventId: -1,
-                    timestamp: firstMoment.add(4, "s").toDate(),
+                    timestamp: moment(firstTimestamp).add(4, "s").toDate(),
                     isPlayed: false,
                     result: JSON.stringify(3),
                     taskScheduledId: 3,
@@ -575,8 +567,6 @@ export class TestHistories {
         firstTimestamp: Date,
         files: string[]
     ): HistoryEvent[] {
-        const firstMoment = moment(firstTimestamp);
-
         return [
             new OrchestratorStartedEvent({
                 eventId: -1,
@@ -604,12 +594,12 @@ export class TestHistories {
             }),
             new OrchestratorStartedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
             }),
             new TaskCompletedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
                 result: JSON.stringify(files),
                 taskScheduledId: 0,
@@ -621,7 +611,7 @@ export class TestHistories {
             }),
             new OrchestratorStartedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(2, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(2, "s").toDate(),
                 isPlayed: false,
             }),
         ]
@@ -630,7 +620,7 @@ export class TestHistories {
                     (file, index) =>
                         new TaskScheduledEvent({
                             eventId: index + 1,
-                            timestamp: firstMoment.add(2, "s").toDate(),
+                            timestamp: moment(firstTimestamp).add(2, "s").toDate(),
                             isPlayed: false,
                             name: "GetFileSize",
                             input: file,
@@ -645,19 +635,19 @@ export class TestHistories {
                 }),
                 new OrchestratorStartedEvent({
                     eventId: -1,
-                    timestamp: firstMoment.add(4, "s").toDate(),
+                    timestamp: moment(firstTimestamp).add(4, "s").toDate(),
                     isPlayed: false,
                 }),
                 new TaskCompletedEvent({
                     eventId: -1,
-                    timestamp: firstMoment.add(3, "s").toDate(),
+                    timestamp: moment(firstTimestamp).add(3, "s").toDate(),
                     isPlayed: false,
                     result: JSON.stringify(1),
                     taskScheduledId: 1,
                 }),
                 new TaskFailedEvent({
                     eventId: -1,
-                    timestamp: firstMoment.add(3, "s").toDate(),
+                    timestamp: moment(firstTimestamp).add(3, "s").toDate(),
                     isPlayed: false,
                     result: JSON.stringify(2),
                     taskScheduledId: 2,
@@ -666,7 +656,7 @@ export class TestHistories {
                 }),
                 new TaskFailedEvent({
                     eventId: -1,
-                    timestamp: firstMoment.add(4, "s").toDate(),
+                    timestamp: moment(firstTimestamp).add(4, "s").toDate(),
                     isPlayed: false,
                     taskScheduledId: 3,
                     reason: `Activity function 'GetFileSize' failed: Could not find file ${files[2]}`,
@@ -679,8 +669,6 @@ export class TestHistories {
         firstTimestamp: Date,
         files: string[]
     ): HistoryEvent[] {
-        const firstMoment = moment(firstTimestamp);
-
         return [
             new OrchestratorStartedEvent({
                 eventId: -1,
@@ -708,12 +696,12 @@ export class TestHistories {
             }),
             new OrchestratorStartedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
             }),
             new TaskCompletedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
                 result: JSON.stringify(files),
                 taskScheduledId: 0,
@@ -725,7 +713,7 @@ export class TestHistories {
             }),
             new OrchestratorStartedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(2, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(2, "s").toDate(),
                 isPlayed: false,
             }),
         ]
@@ -734,7 +722,7 @@ export class TestHistories {
                     (file, index) =>
                         new TaskScheduledEvent({
                             eventId: index + 1,
-                            timestamp: firstMoment.add(2, "s").toDate(),
+                            timestamp: moment(firstTimestamp).add(2, "s").toDate(),
                             isPlayed: false,
                             name: "GetFileSize",
                             input: file,
@@ -749,12 +737,12 @@ export class TestHistories {
                 }),
                 new OrchestratorStartedEvent({
                     eventId: -1,
-                    timestamp: firstMoment.add(3, "s").toDate(),
+                    timestamp: moment(firstTimestamp).add(3, "s").toDate(),
                     isPlayed: false,
                 }),
                 new TaskCompletedEvent({
                     eventId: -1,
-                    timestamp: firstMoment.add(3, "s").toDate(),
+                    timestamp: moment(firstTimestamp).add(3, "s").toDate(),
                     isPlayed: false,
                     result: JSON.stringify(2),
                     taskScheduledId: 2,
@@ -766,8 +754,6 @@ export class TestHistories {
         firstTimestamp: Date,
         files: string[]
     ): HistoryEvent[] {
-        const firstMoment = moment(firstTimestamp);
-
         return [
             new OrchestratorStartedEvent({
                 eventId: -1,
@@ -795,12 +781,12 @@ export class TestHistories {
             }),
             new OrchestratorStartedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
             }),
             new TaskCompletedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
                 result: JSON.stringify(files),
                 taskScheduledId: 0,
@@ -809,8 +795,6 @@ export class TestHistories {
     }
 
     public static GetHelloSequenceReplayFinal(name: string, firstTimestamp: Date): HistoryEvent[] {
-        const firstMoment = moment(firstTimestamp);
-
         return [
             new OrchestratorStartedEvent({
                 eventId: -1,
@@ -837,58 +821,58 @@ export class TestHistories {
             }),
             new OrchestratorStartedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
             }),
             new TaskCompletedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: true,
                 result: JSON.stringify("Hello, Tokyo!"),
                 taskScheduledId: 0,
             }),
             new TaskScheduledEvent({
                 eventId: 1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
                 name: "Hello",
             }),
             new OrchestratorCompletedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
             }),
             new OrchestratorStartedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(2, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(2, "s").toDate(),
                 isPlayed: false,
             }),
             new TaskCompletedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(2, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(2, "s").toDate(),
                 isPlayed: true,
                 result: JSON.stringify("Hello, Seattle!"),
                 taskScheduledId: 1,
             }),
             new TaskScheduledEvent({
                 eventId: 2,
-                timestamp: firstMoment.add(2, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(2, "s").toDate(),
                 isPlayed: false,
                 name: "Hello",
             }),
             new OrchestratorCompletedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(2, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(2, "s").toDate(),
                 isPlayed: false,
             }),
             new OrchestratorStartedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
             }),
             new TaskCompletedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(3, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(3, "s").toDate(),
                 isPlayed: true,
                 result: JSON.stringify("Hello, London!"),
                 taskScheduledId: 2,
@@ -1150,8 +1134,6 @@ export class TestHistories {
         firstTimestamp: Date,
         input: unknown
     ): HistoryEvent[] {
-        const firstMoment = moment(firstTimestamp);
-
         return [
             new OrchestratorStartedEvent({
                 eventId: -1,
@@ -1179,12 +1161,12 @@ export class TestHistories {
             }),
             new OrchestratorStartedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
             }),
             new TaskCompletedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
                 result: JSON.stringify(`Hello, ${input}!`),
                 taskScheduledId: 0,
@@ -1242,8 +1224,6 @@ export class TestHistories {
         input: unknown,
         retryInterval: number
     ): HistoryEvent[] {
-        const firstMoment = moment(firstTimestamp);
-
         return [
             new OrchestratorStartedEvent({
                 eventId: -1,
@@ -1271,12 +1251,12 @@ export class TestHistories {
             }),
             new OrchestratorStartedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
             }),
             new TaskFailedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
                 taskScheduledId: 0,
                 details: "Big stack trace here",
@@ -1284,25 +1264,25 @@ export class TestHistories {
             }),
             new TimerCreatedEvent({
                 eventId: 1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
-                fireAt: firstMoment.add(1, "s").add(retryInterval, "ms").toDate(),
+                fireAt: moment(firstTimestamp).add(1, "s").add(retryInterval, "ms").toDate(),
             }),
             new OrchestratorCompletedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
             }),
             new OrchestratorStartedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").add(retryInterval, "ms").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").add(retryInterval, "ms").toDate(),
                 isPlayed: false,
             }),
             new TimerFiredEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").add(retryInterval, "ms").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").add(retryInterval, "ms").toDate(),
                 isPlayed: false,
-                fireAt: firstMoment.add(1, "s").add(retryInterval, "ms").toDate(),
+                fireAt: moment(firstTimestamp).add(1, "s").add(retryInterval, "ms").toDate(),
                 timerId: 1,
             }),
         ];
@@ -1313,41 +1293,47 @@ export class TestHistories {
         input: unknown,
         retryInterval: number
     ): HistoryEvent[] {
-        const firstMoment = moment(firstTimestamp);
+        const history: HistoryEvent[] = [];
+        let timestamp = firstTimestamp;
 
-        return [
+        history.push(
             new OrchestratorStartedEvent({
                 eventId: -1,
-                timestamp: firstTimestamp,
+                timestamp,
                 isPlayed: false,
             }),
             new ExecutionStartedEvent({
                 eventId: -1,
-                timestamp: firstTimestamp,
+                timestamp,
                 isPlayed: true,
                 name: "SayHelloWithActivityRetry",
                 input: JSON.stringify(input),
             }),
             new TaskScheduledEvent({
                 eventId: 0,
-                timestamp: firstTimestamp,
+                timestamp,
                 isPlayed: false,
                 name: "Hello",
                 input: undefined,
             }),
             new OrchestratorCompletedEvent({
                 eventId: -1,
-                timestamp: firstTimestamp,
+                timestamp,
                 isPlayed: false,
-            }),
+            })
+        );
+
+        timestamp = moment(firstTimestamp).add(20, "s").toDate();
+
+        history.push(
             new OrchestratorStartedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp,
                 isPlayed: false,
             }),
             new TaskFailedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp,
                 isPlayed: false,
                 taskScheduledId: 0,
                 details: "Big stack trace here",
@@ -1355,47 +1341,57 @@ export class TestHistories {
             }),
             new TimerCreatedEvent({
                 eventId: 1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp,
                 isPlayed: false,
-                fireAt: firstMoment.add(1, "s").add(retryInterval, "ms").toDate(),
+                fireAt: moment(timestamp).add(retryInterval, "ms").toDate(),
             }),
             new OrchestratorCompletedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp,
                 isPlayed: false,
-            }),
+            })
+        );
+
+        timestamp = moment(timestamp).add(retryInterval, "ms").toDate();
+
+        history.push(
             new OrchestratorStartedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(2, "s").add(retryInterval, "ms").toDate(),
+                timestamp,
                 isPlayed: false,
             }),
             new TimerFiredEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(2, "s").add(retryInterval, "ms").toDate(),
+                timestamp,
                 isPlayed: false,
-                fireAt: firstMoment.add(2, "s").add(retryInterval, "ms").toDate(),
+                fireAt: timestamp,
                 timerId: 1,
             }),
             new TaskScheduledEvent({
                 eventId: 2,
-                timestamp: firstTimestamp,
+                timestamp,
                 isPlayed: false,
                 name: "Hello",
                 input: undefined,
             }),
             new OrchestratorCompletedEvent({
                 eventId: -1,
-                timestamp: firstTimestamp,
+                timestamp,
                 isPlayed: false,
-            }),
+            })
+        );
+
+        timestamp = moment(timestamp).add(20, "s").toDate();
+
+        history.push(
             new OrchestratorStartedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(3, "s").toDate(),
+                timestamp,
                 isPlayed: false,
             }),
             new TaskFailedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(3, "s").toDate(),
+                timestamp,
                 isPlayed: false,
                 taskScheduledId: 2,
                 details: "Big stack trace here",
@@ -1403,28 +1399,35 @@ export class TestHistories {
             }),
             new TimerCreatedEvent({
                 eventId: 3,
-                timestamp: firstMoment.add(3, "s").toDate(),
+                timestamp,
                 isPlayed: false,
-                fireAt: firstMoment.add(3, "s").add(retryInterval, "ms").toDate(),
+                fireAt: moment(timestamp).add(retryInterval, "ms").toDate(),
             }),
             new OrchestratorCompletedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(3, "s").toDate(),
+                timestamp,
                 isPlayed: false,
-            }),
+            })
+        );
+
+        timestamp = moment(timestamp).add(retryInterval, "ms").toDate();
+
+        history.push(
             new OrchestratorStartedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(4, "s").add(retryInterval, "ms").toDate(),
+                timestamp,
                 isPlayed: false,
             }),
             new TimerFiredEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(4, "s").add(retryInterval, "ms").toDate(),
+                timestamp,
                 isPlayed: false,
-                fireAt: firstMoment.add(4, "s").add(retryInterval, "ms").toDate(),
+                fireAt: timestamp,
                 timerId: 3,
-            }),
-        ];
+            })
+        );
+
+        return history;
     }
 
     public static GetSayHelloWithActivityRetryFanout(
@@ -1432,8 +1435,6 @@ export class TestHistories {
         retryInterval: number,
         iteration: number
     ): HistoryEvent[] {
-        const firstMoment = moment(firstTimestamp);
-
         const historyEvents: HistoryEvent[] = [];
         if (iteration >= 1) {
             historyEvents.push(
@@ -1483,14 +1484,14 @@ export class TestHistories {
             historyEvents.push(
                 new OrchestratorStartedEvent({
                     eventId: -1,
-                    timestamp: firstMoment.add(110, "ms").toDate(),
+                    timestamp: moment(firstTimestamp).add(110, "ms").toDate(),
                     isPlayed: iteration > 2,
                 })
             );
             historyEvents.push(
                 new TaskFailedEvent({
                     eventId: -1,
-                    timestamp: firstMoment.add(100, "ms").toDate(),
+                    timestamp: moment(firstTimestamp).add(100, "ms").toDate(),
                     isPlayed: iteration > 2,
                     taskScheduledId: 0,
                     details: "Big stack trace here",
@@ -1500,15 +1501,15 @@ export class TestHistories {
             historyEvents.push(
                 new TimerCreatedEvent({
                     eventId: 2,
-                    timestamp: firstMoment.add(100, "ms").toDate(),
+                    timestamp: moment(firstTimestamp).add(100, "ms").toDate(),
                     isPlayed: iteration > 2,
-                    fireAt: firstMoment.add(100, "ms").add(retryInterval, "ms").toDate(),
+                    fireAt: moment(firstTimestamp).add(100, "ms").add(retryInterval, "ms").toDate(),
                 })
             );
             historyEvents.push(
                 new TaskCompletedEvent({
                     eventId: -1,
-                    timestamp: firstMoment
+                    timestamp: moment(firstTimestamp)
                         .add(100, "s")
                         .add(retryInterval, "ms")
                         .add(100, "ms")
@@ -1521,7 +1522,7 @@ export class TestHistories {
             historyEvents.push(
                 new OrchestratorCompletedEvent({
                     eventId: -1,
-                    timestamp: firstMoment.add(100, "ms").toDate(),
+                    timestamp: moment(firstTimestamp).add(100, "ms").toDate(),
                     isPlayed: iteration > 2,
                 })
             );
@@ -1531,23 +1532,29 @@ export class TestHistories {
             historyEvents.push(
                 new OrchestratorStartedEvent({
                     eventId: -1,
-                    timestamp: firstMoment.add(1, "s").add(retryInterval, "ms").toDate(),
+                    timestamp: moment(firstTimestamp).add(1, "s").add(retryInterval, "ms").toDate(),
                     isPlayed: iteration > 3,
                 })
             );
             historyEvents.push(
                 new TimerFiredEvent({
                     eventId: -1,
-                    timestamp: firstMoment.add(100, "ms").add(retryInterval, "ms").toDate(),
+                    timestamp: moment(firstTimestamp)
+                        .add(100, "ms")
+                        .add(retryInterval, "ms")
+                        .toDate(),
                     isPlayed: iteration > 3,
-                    fireAt: firstMoment.add(100, "s").add(retryInterval, "ms").toDate(),
+                    fireAt: moment(firstTimestamp).add(100, "s").add(retryInterval, "ms").toDate(),
                     timerId: 2,
                 })
             );
             historyEvents.push(
                 new TaskScheduledEvent({
                     eventId: 3,
-                    timestamp: firstMoment.add(100, "ms").add(retryInterval, "ms").toDate(),
+                    timestamp: moment(firstTimestamp)
+                        .add(100, "ms")
+                        .add(retryInterval, "ms")
+                        .toDate(),
                     isPlayed: iteration > 3,
                     name: "Hello",
                     input: "Tokyo",
@@ -1556,7 +1563,7 @@ export class TestHistories {
             historyEvents.push(
                 new OrchestratorCompletedEvent({
                     eventId: -1,
-                    timestamp: firstMoment.add(100, "ms").toDate(),
+                    timestamp: moment(firstTimestamp).add(100, "ms").toDate(),
                     isPlayed: iteration > 3,
                 })
             );
@@ -1566,7 +1573,7 @@ export class TestHistories {
             historyEvents.push(
                 new OrchestratorStartedEvent({
                     eventId: -1,
-                    timestamp: firstMoment
+                    timestamp: moment(firstTimestamp)
                         .add(100, "s")
                         .add(retryInterval, "ms")
                         .add(100, "ms")
@@ -1577,7 +1584,7 @@ export class TestHistories {
             historyEvents.push(
                 new TaskCompletedEvent({
                     eventId: -1,
-                    timestamp: firstMoment
+                    timestamp: moment(firstTimestamp)
                         .add(100, "s")
                         .add(retryInterval, "ms")
                         .add(100, "ms")
@@ -1598,8 +1605,6 @@ export class TestHistories {
         request: DurableHttpRequest,
         response: DurableHttpResponse
     ): HistoryEvent[] {
-        const firstMoment = moment(firstTimestamp);
-
         return [
             new OrchestratorStartedEvent({
                 eventId: -1,
@@ -1627,12 +1632,12 @@ export class TestHistories {
             }),
             new OrchestratorStartedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
             }),
             new TaskCompletedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
                 result: JSON.stringify(response),
                 taskScheduledId: 0,
@@ -1647,8 +1652,6 @@ export class TestHistories {
         subInstanceId: string,
         input?: string
     ): HistoryEvent[] {
-        const firstMoment = moment(firstTimestamp);
-
         return [
             new OrchestratorStartedEvent({
                 eventId: -1,
@@ -1677,12 +1680,12 @@ export class TestHistories {
             }),
             new OrchestratorStartedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
             }),
             new SubOrchestrationInstanceCompletedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
                 result: JSON.stringify(`Hello, ${input}!`),
                 taskScheduledId: 0,
@@ -1699,8 +1702,6 @@ export class TestHistories {
         subOrchestratorNames: string[],
         input: string
     ): HistoryEvent[] {
-        const firstMoment = moment(firstTimestamp);
-
         const baseSubInstanceId = "dummy-unique-id";
         const historyEvents = [
             new OrchestratorStartedEvent({
@@ -1736,7 +1737,7 @@ export class TestHistories {
             }),
             new OrchestratorStartedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
             })
         );
@@ -1745,7 +1746,7 @@ export class TestHistories {
             historyEvents.push(
                 new SubOrchestrationInstanceCompletedEvent({
                     eventId: -1,
-                    timestamp: firstMoment.add(1, "s").toDate(),
+                    timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                     isPlayed: false,
                     result: JSON.stringify(`Hello, ${input}_${subOrchestratorNames[i]}_${i}!`),
                     taskScheduledId: i,
@@ -1763,8 +1764,6 @@ export class TestHistories {
         subInstanceId: string,
         input?: string
     ): HistoryEvent[] {
-        const firstMoment = moment(firstTimestamp);
-
         return [
             new OrchestratorStartedEvent({
                 eventId: -1,
@@ -1793,12 +1792,12 @@ export class TestHistories {
             }),
             new OrchestratorStartedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
             }),
             new SubOrchestrationInstanceFailedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
                 details: "Big stack trace here",
                 reason: "Sub orchestrator function 'SayHelloInline' failed: Result: Failure",
@@ -1860,8 +1859,6 @@ export class TestHistories {
         input: string,
         retryInterval: number
     ): HistoryEvent[] {
-        const firstMoment = moment(firstTimestamp);
-
         return [
             new OrchestratorStartedEvent({
                 eventId: -1,
@@ -1903,25 +1900,25 @@ export class TestHistories {
             }),
             new TimerCreatedEvent({
                 eventId: 1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
-                fireAt: firstMoment.add(1, "s").add(retryInterval, "ms").toDate(),
+                fireAt: moment(firstTimestamp).add(1, "s").add(retryInterval, "ms").toDate(),
             }),
             new OrchestratorCompletedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
             }),
             new OrchestratorStartedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").add(retryInterval, "ms").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").add(retryInterval, "ms").toDate(),
                 isPlayed: false,
             }),
             new TimerFiredEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").add(retryInterval, "ms").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").add(retryInterval, "ms").toDate(),
                 isPlayed: false,
-                fireAt: firstMoment.add(1, "s").add(retryInterval, "ms").toDate(),
+                fireAt: moment(firstTimestamp).add(1, "s").add(retryInterval, "ms").toDate(),
                 timerId: 1,
             }),
         ];
@@ -1933,8 +1930,6 @@ export class TestHistories {
         input: string,
         retryInterval: number
     ): HistoryEvent[] {
-        const firstMoment = moment(firstTimestamp);
-
         return [
             new OrchestratorStartedEvent({
                 eventId: -1,
@@ -1976,25 +1971,25 @@ export class TestHistories {
             }),
             new TimerCreatedEvent({
                 eventId: 1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
-                fireAt: firstMoment.add(1, "s").add(retryInterval, "ms").toDate(),
+                fireAt: moment(firstTimestamp).add(1, "s").add(retryInterval, "ms").toDate(),
             }),
             new OrchestratorCompletedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
             }),
             new OrchestratorStartedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(2, "s").add(retryInterval, "ms").toDate(),
+                timestamp: moment(firstTimestamp).add(2, "s").add(retryInterval, "ms").toDate(),
                 isPlayed: false,
             }),
             new TimerFiredEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(2, "s").add(retryInterval, "ms").toDate(),
+                timestamp: moment(firstTimestamp).add(2, "s").add(retryInterval, "ms").toDate(),
                 isPlayed: false,
-                fireAt: firstMoment.add(2, "s").add(retryInterval, "ms").toDate(),
+                fireAt: moment(firstTimestamp).add(2, "s").add(retryInterval, "ms").toDate(),
                 timerId: 1,
             }),
             new SubOrchestrationInstanceCreatedEvent({
@@ -2025,25 +2020,25 @@ export class TestHistories {
             }),
             new TimerCreatedEvent({
                 eventId: 3,
-                timestamp: firstMoment.add(3, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(3, "s").toDate(),
                 isPlayed: false,
-                fireAt: firstMoment.add(3, "s").add(retryInterval, "ms").toDate(),
+                fireAt: moment(firstTimestamp).add(3, "s").add(retryInterval, "ms").toDate(),
             }),
             new OrchestratorCompletedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(3, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(3, "s").toDate(),
                 isPlayed: false,
             }),
             new OrchestratorStartedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(4, "s").add(retryInterval, "ms").toDate(),
+                timestamp: moment(firstTimestamp).add(4, "s").add(retryInterval, "ms").toDate(),
                 isPlayed: false,
             }),
             new TimerFiredEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(4, "s").add(retryInterval, "ms").toDate(),
+                timestamp: moment(firstTimestamp).add(4, "s").add(retryInterval, "ms").toDate(),
                 isPlayed: false,
-                fireAt: firstMoment.add(4, "s").add(retryInterval, "ms").toDate(),
+                fireAt: moment(firstTimestamp).add(4, "s").add(retryInterval, "ms").toDate(),
                 timerId: 3,
             }),
         ];
@@ -2054,7 +2049,6 @@ export class TestHistories {
         retryInterval: number,
         iteration: number
     ): HistoryEvent[] {
-        const firstMoment = moment(firstTimestamp);
         const instanceIds = [uuidv1(), uuidv1(), uuidv1()];
 
         const historyEvents: HistoryEvent[] = [];
@@ -2108,14 +2102,14 @@ export class TestHistories {
             historyEvents.push(
                 new OrchestratorStartedEvent({
                     eventId: -1,
-                    timestamp: firstMoment.add(110, "ms").toDate(),
+                    timestamp: moment(firstTimestamp).add(110, "ms").toDate(),
                     isPlayed: iteration > 2,
                 })
             );
             historyEvents.push(
                 new SubOrchestrationInstanceFailedEvent({
                     eventId: -1,
-                    timestamp: firstMoment.add(100, "ms").toDate(),
+                    timestamp: moment(firstTimestamp).add(100, "ms").toDate(),
                     isPlayed: iteration > 2,
                     taskScheduledId: 0,
                     details: "Big stack trace here",
@@ -2126,7 +2120,7 @@ export class TestHistories {
             historyEvents.push(
                 new SubOrchestrationInstanceCompletedEvent({
                     eventId: -1,
-                    timestamp: firstMoment
+                    timestamp: moment(firstTimestamp)
                         .add(100, "s")
                         .add(retryInterval, "ms")
                         .add(100, "ms")
@@ -2140,15 +2134,15 @@ export class TestHistories {
             historyEvents.push(
                 new TimerCreatedEvent({
                     eventId: 2,
-                    timestamp: firstMoment.add(100, "ms").toDate(),
+                    timestamp: moment(firstTimestamp).add(100, "ms").toDate(),
                     isPlayed: iteration > 2,
-                    fireAt: firstMoment.add(100, "ms").add(retryInterval, "ms").toDate(),
+                    fireAt: moment(firstTimestamp).add(100, "ms").add(retryInterval, "ms").toDate(),
                 })
             );
             historyEvents.push(
                 new OrchestratorCompletedEvent({
                     eventId: -1,
-                    timestamp: firstMoment.add(100, "ms").toDate(),
+                    timestamp: moment(firstTimestamp).add(100, "ms").toDate(),
                     isPlayed: iteration > 2,
                 })
             );
@@ -2158,23 +2152,29 @@ export class TestHistories {
             historyEvents.push(
                 new OrchestratorStartedEvent({
                     eventId: -1,
-                    timestamp: firstMoment.add(1, "s").add(retryInterval, "ms").toDate(),
+                    timestamp: moment(firstTimestamp).add(1, "s").add(retryInterval, "ms").toDate(),
                     isPlayed: iteration > 3,
                 })
             );
             historyEvents.push(
                 new TimerFiredEvent({
                     eventId: -1,
-                    timestamp: firstMoment.add(100, "ms").add(retryInterval, "ms").toDate(),
+                    timestamp: moment(firstTimestamp)
+                        .add(100, "ms")
+                        .add(retryInterval, "ms")
+                        .toDate(),
                     isPlayed: iteration > 3,
-                    fireAt: firstMoment.add(100, "s").add(retryInterval, "ms").toDate(),
+                    fireAt: moment(firstTimestamp).add(100, "s").add(retryInterval, "ms").toDate(),
                     timerId: 2,
                 })
             );
             historyEvents.push(
                 new SubOrchestrationInstanceCreatedEvent({
                     eventId: 3,
-                    timestamp: firstMoment.add(100, "ms").add(retryInterval, "ms").toDate(),
+                    timestamp: moment(firstTimestamp)
+                        .add(100, "ms")
+                        .add(retryInterval, "ms")
+                        .toDate(),
                     isPlayed: iteration > 3,
                     name: "SayHelloInline",
                     input: "Tokyo",
@@ -2184,7 +2184,7 @@ export class TestHistories {
             historyEvents.push(
                 new OrchestratorCompletedEvent({
                     eventId: -1,
-                    timestamp: firstMoment.add(100, "ms").toDate(),
+                    timestamp: moment(firstTimestamp).add(100, "ms").toDate(),
                     isPlayed: iteration > 3,
                 })
             );
@@ -2194,7 +2194,7 @@ export class TestHistories {
             historyEvents.push(
                 new OrchestratorStartedEvent({
                     eventId: -1,
-                    timestamp: firstMoment
+                    timestamp: moment(firstTimestamp)
                         .add(100, "s")
                         .add(retryInterval, "ms")
                         .add(100, "ms")
@@ -2205,7 +2205,7 @@ export class TestHistories {
             historyEvents.push(
                 new SubOrchestrationInstanceCompletedEvent({
                     eventId: -1,
-                    timestamp: firstMoment
+                    timestamp: moment(firstTimestamp)
                         .add(100, "s")
                         .add(retryInterval, "ms")
                         .add(100, "ms")
@@ -2268,8 +2268,6 @@ export class TestHistories {
         eventName: string,
         input?: unknown
     ): HistoryEvent[] {
-        const firstMoment = moment(firstTimestamp);
-
         return [
             new OrchestratorStartedEvent({
                 eventId: -1,
@@ -2290,12 +2288,12 @@ export class TestHistories {
             }),
             new OrchestratorStartedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
             }),
             new EventRaisedEvent({
                 eventId: -1,
-                timestamp: firstMoment.add(1, "s").toDate(),
+                timestamp: moment(firstTimestamp).add(1, "s").toDate(),
                 isPlayed: false,
                 input: JSON.stringify(input),
                 name: eventName,

--- a/test/testobjects/testhistories.ts
+++ b/test/testobjects/testhistories.ts
@@ -1323,7 +1323,7 @@ export class TestHistories {
             })
         );
 
-        timestamp = moment(firstTimestamp).add(20, "s").toDate();
+        timestamp = moment(firstTimestamp).add(30, "s").toDate();
 
         history.push(
             new OrchestratorStartedEvent({
@@ -1352,7 +1352,8 @@ export class TestHistories {
             })
         );
 
-        timestamp = moment(timestamp).add(retryInterval, "ms").toDate();
+        let fireAt = moment(timestamp).add(retryInterval, "ms").toDate();
+        timestamp = moment(fireAt).add(10, "s").toDate();
 
         history.push(
             new OrchestratorStartedEvent({
@@ -1364,7 +1365,7 @@ export class TestHistories {
                 eventId: -1,
                 timestamp,
                 isPlayed: false,
-                fireAt: timestamp,
+                fireAt,
                 timerId: 1,
             }),
             new TaskScheduledEvent({
@@ -1410,7 +1411,8 @@ export class TestHistories {
             })
         );
 
-        timestamp = moment(timestamp).add(retryInterval, "ms").toDate();
+        fireAt = moment(timestamp).add(retryInterval, "ms").toDate();
+        timestamp = moment(fireAt).add(10, "s").toDate();
 
         history.push(
             new OrchestratorStartedEvent({
@@ -1422,7 +1424,7 @@ export class TestHistories {
                 eventId: -1,
                 timestamp,
                 isPlayed: false,
-                fireAt: timestamp,
+                fireAt,
                 timerId: 3,
             })
         );


### PR DESCRIPTION
`Moment` objects are mutable, and the `moment().add()` method mutates the original moment object. This is sometimes counterintuitive and can lead to some nasty bugs. This PR avoid mutating any moment objects that are reused. Instead, we wrap Date objects in a new moment object before calling `add()`.

Thankfully, use of `moment.add` was limited to tests, and did not affect any test result (with the exception of one test). However, I still think that these uses of `moment.add` did not intend to use the mutability of the objects, and even when it did, it's cleaner to explicitly state that to avoid any misunderstandings :) 