### PR TITLE
cancelled -> canceled

### DIFF
--- a/src/actions/createtimeraction.ts
+++ b/src/actions/createtimeraction.ts
@@ -5,7 +5,7 @@ import { ActionType, IAction } from "../classes";
 export class CreateTimerAction implements IAction {
     public readonly actionType: ActionType = ActionType.CreateTimer;
 
-    constructor(public readonly fireAt: Date, public isCancelled: boolean = false) {
+    constructor(public readonly fireAt: Date, public isCanceled: boolean = false) {
         if (!isDate(fireAt)) {
             throw new TypeError(`fireAt: Expected valid Date object but got ${fireAt}`);
         }

--- a/src/task.ts
+++ b/src/task.ts
@@ -304,7 +304,7 @@ export class DFTimerTask extends AtomicTask implements TimerTask {
         if (this.hasResult) {
             throw Error("Cannot cancel a completed task.");
         }
-        this.action.isCanceled = true; // TODO: fix typo
+        this.action.isCanceled = true;
     }
 }
 

--- a/src/task.ts
+++ b/src/task.ts
@@ -94,7 +94,7 @@ export interface TimerTask extends Task {
     /**
      * @returns Whether or not the timer has been canceled.
      */
-    isCancelled: boolean;
+    isCanceled: boolean;
     /**
      * Indicates the timer should be canceled. This request will execute on the
      * next `yield` or `return` statement.
@@ -290,9 +290,9 @@ export class DFTimerTask extends AtomicTask implements TimerTask {
         super(id, action);
     }
 
-    /** Whether this timer task is cancelled */
-    get isCancelled(): boolean {
-        return this.action.isCancelled;
+    /** Whether this timer task is canceled */
+    get isCanceled(): boolean {
+        return this.action.isCanceled;
     }
 
     /**
@@ -304,7 +304,7 @@ export class DFTimerTask extends AtomicTask implements TimerTask {
         if (this.hasResult) {
             throw Error("Cannot cancel a completed task.");
         }
-        this.action.isCancelled = true; // TODO: fix typo
+        this.action.isCanceled = true; // TODO: fix typo
     }
 }
 

--- a/test/unit/timertask-spec.ts
+++ b/test/unit/timertask-spec.ts
@@ -5,9 +5,9 @@ import { DFTimerTask } from "../../src/task";
 
 describe("TimerTask", () => {
     it("throws cannot cancel a completed task", async () => {
-        const isCancelled = false;
+        const isCanceled = false;
         const date = new Date();
-        const action = new CreateTimerAction(date, isCancelled);
+        const action = new CreateTimerAction(date, isCanceled);
         const task = new DFTimerTask(0, action);
         task.setValue(false, undefined); // set value to complete task
 
@@ -17,21 +17,21 @@ describe("TimerTask", () => {
     });
 
     it("cancels an incomplete task", async () => {
-        const isCancelled = false;
+        const isCanceled = false;
         const date = new Date();
-        const action = new CreateTimerAction(date, isCancelled);
+        const action = new CreateTimerAction(date, isCanceled);
         const task = new DFTimerTask(0, action);
 
         task.cancel();
-        expect(task.isCancelled).to.equal(true);
+        expect(task.isCanceled).to.equal(true);
     });
 
     it("is canceled when its action is canceled", async () => {
-        const isCancelled = true;
+        const isCanceled = true;
         const date = new Date();
-        const action = new CreateTimerAction(date, isCancelled);
+        const action = new CreateTimerAction(date, isCanceled);
         const task = new DFTimerTask(0, action);
 
-        expect(task.isCancelled).to.equal(true);
+        expect(task.isCanceled).to.equal(true);
     });
 });


### PR DESCRIPTION
Changing instances of `isCancelled` to `isCanceled` to match naming used by the extensions. Fixes a bug where actions were not being canceled, e.g. timers.