### PR TITLE
Implement CallHttp Polling Replay Logic

### DIFF
--- a/src/durablehttprequest.ts
+++ b/src/durablehttprequest.ts
@@ -13,6 +13,7 @@ export class DurableHttpRequest {
      * @param content The HTTP request content.
      * @param headers The HTTP request headers.
      * @param tokenSource The source of OAuth tokens to add to the request.
+     * @param asynchronousPatternEnabled Specifies whether the DurableHttpRequest should handle the asynchronous pattern.
      */
     constructor(
         /** The HTTP request method. */
@@ -26,6 +27,8 @@ export class DurableHttpRequest {
             [key: string]: string;
         },
         /** The source of OAuth token to add to the request. */
-        public readonly tokenSource?: TokenSource
+        public readonly tokenSource?: TokenSource,
+        /**  Whether the DurableHttpRequest should handle the asynchronous pattern. **/
+        public readonly asynchronousPatternEnabled?: boolean
     ) {}
 }

--- a/src/durablehttprequest.ts
+++ b/src/durablehttprequest.ts
@@ -29,6 +29,6 @@ export class DurableHttpRequest {
         /** The source of OAuth token to add to the request. */
         public readonly tokenSource?: TokenSource,
         /**  Whether the DurableHttpRequest should handle the asynchronous pattern. **/
-        public readonly asynchronousPatternEnabled?: boolean
+        public readonly asynchronousPatternEnabled: boolean = true
     ) {}
 }

--- a/src/durablehttpresponse.ts
+++ b/src/durablehttpresponse.ts
@@ -27,8 +27,9 @@ export class DurableHttpResponse {
     // returns undefined if the header is not set
     public getHeader(name: string): string | undefined {
         if (this.headers) {
+            const lowerCaseName = name.toLowerCase();
             const foundKey = Object.keys(this.headers).find(
-                (key) => key.toLowerCase() === name.toLowerCase()
+                (key) => key.toLowerCase() === lowerCaseName
             );
             if (foundKey) {
                 return this.headers[foundKey];

--- a/src/durablehttpresponse.ts
+++ b/src/durablehttpresponse.ts
@@ -22,4 +22,18 @@ export class DurableHttpResponse {
             [key: string]: string;
         }
     ) {}
+
+    // returns the specified header, case insensitively
+    // returns undefined if the header is not set
+    public getHeader(name: string): string | undefined {
+        if (this.headers) {
+            const foundKey = Object.keys(this.headers).find(
+                (key) => key.toLowerCase() === name.toLowerCase()
+            );
+            if (foundKey) {
+                return this.headers[foundKey];
+            }
+        }
+        return undefined;
+    }
 }

--- a/src/durableorchestrationbindinginfo.ts
+++ b/src/durableorchestrationbindinginfo.ts
@@ -13,6 +13,7 @@ export class DurableOrchestrationBindingInfo {
         public readonly parentInstanceId?: string,
         public readonly maximumShortTimerDuration?: string,
         public readonly longRunningTimerIntervalDuration?: string,
+        public readonly defaultHttpAsyncRequestSleepTimeMillseconds?: number,
         upperSchemaVersion = 0 // TODO: Implement entity locking // public readonly contextLocks?: EntityId[],
     ) {
         // It is assumed that the extension supports all schemas in range [0, upperSchemaVersion].

--- a/src/durableorchestrationcontext.ts
+++ b/src/durableorchestrationcontext.ts
@@ -63,9 +63,7 @@ export class DurableOrchestrationContext {
         this.maximumShortTimerDuration = maximumShortTimerDuration
             ? moment.duration(maximumShortTimerDuration)
             : undefined;
-        this.defaultHttpAsyncRequestSleepDuration = defaultHttpAsyncRequestSleepTimeMillseconds
-            ? moment.duration(defaultHttpAsyncRequestSleepTimeMillseconds, "ms")
-            : undefined;
+        this.defaultHttpAsyncRequestSleepTimeMillseconds = defaultHttpAsyncRequestSleepTimeMillseconds;
         this.schemaVersion = schemaVersion;
         this.input = input;
         this.newGuidCounter = 0;
@@ -81,7 +79,7 @@ export class DurableOrchestrationContext {
      * This duration is used unless a different value (in seconds) is specified in the
      * 'Retry-After' header of the 202 response.
      */
-    private readonly defaultHttpAsyncRequestSleepDuration?: moment.Duration;
+    private readonly defaultHttpAsyncRequestSleepTimeMillseconds?: number;
 
     /**
      * The ID of the current orchestration instance.
@@ -309,7 +307,7 @@ export class DurableOrchestrationContext {
         content?: string | object,
         headers?: { [key: string]: string },
         tokenSource?: TokenSource,
-        asynchronousPatternEnabled?: boolean
+        asynchronousPatternEnabled = true
     ): Task {
         if (content && typeof content !== "string") {
             content = JSON.stringify(content);
@@ -325,7 +323,7 @@ export class DurableOrchestrationContext {
         );
         const newAction = new CallHttpAction(req);
         if (this.schemaVersion >= ReplaySchema.V3 && req.asynchronousPatternEnabled) {
-            if (!this.defaultHttpAsyncRequestSleepDuration) {
+            if (!this.defaultHttpAsyncRequestSleepTimeMillseconds) {
                 throw Error(
                     "A framework-internal error was detected: replay schema version >= V3 is being used, " +
                         "but `defaultHttpAsyncRequestSleepDuration` property is not defined. " +
@@ -338,7 +336,7 @@ export class DurableOrchestrationContext {
                 newAction,
                 this,
                 this.taskOrchestratorExecutor,
-                this.defaultHttpAsyncRequestSleepDuration.toISOString()
+                this.defaultHttpAsyncRequestSleepTimeMillseconds
             );
         }
         return new AtomicTask(false, newAction);

--- a/src/durableorchestrationcontext.ts
+++ b/src/durableorchestrationcontext.ts
@@ -29,6 +29,7 @@ import {
     TimerTask,
     DFTask,
     LongTimerTask,
+    CallHttpWithPollingTask,
 } from "./task";
 import moment = require("moment");
 import { ReplaySchema } from "./replaySchema";
@@ -46,6 +47,7 @@ export class DurableOrchestrationContext {
         parentInstanceId: string | undefined,
         longRunningTimerIntervalDuration: string | undefined,
         maximumShortTimerDuration: string | undefined,
+        defaultHttpAsyncRequestSleepTimeMillseconds: number | undefined,
         schemaVersion: ReplaySchema,
         input: unknown,
         private taskOrchestratorExecutor: TaskOrchestrationExecutor
@@ -61,6 +63,9 @@ export class DurableOrchestrationContext {
         this.maximumShortTimerDuration = maximumShortTimerDuration
             ? moment.duration(maximumShortTimerDuration)
             : undefined;
+        this.defaultHttpAsyncRequestSleepDuration = defaultHttpAsyncRequestSleepTimeMillseconds
+            ? moment.duration(defaultHttpAsyncRequestSleepTimeMillseconds, "ms")
+            : undefined;
         this.schemaVersion = schemaVersion;
         this.input = input;
         this.newGuidCounter = 0;
@@ -70,6 +75,13 @@ export class DurableOrchestrationContext {
     private readonly state: HistoryEvent[];
     private newGuidCounter: number;
     public customStatus: unknown;
+
+    /**
+     * The default time to wait between attempts when making HTTP polling requests
+     * This duration is used unless a different value (in seconds) is specified in the
+     * 'Retry-After' header of the 202 response.
+     */
+    private readonly defaultHttpAsyncRequestSleepDuration?: moment.Duration;
 
     /**
      * The ID of the current orchestration instance.
@@ -296,16 +308,40 @@ export class DurableOrchestrationContext {
         uri: string,
         content?: string | object,
         headers?: { [key: string]: string },
-        tokenSource?: TokenSource
+        tokenSource?: TokenSource,
+        asynchronousPatternEnabled?: boolean
     ): Task {
         if (content && typeof content !== "string") {
             content = JSON.stringify(content);
         }
 
-        const req = new DurableHttpRequest(method, uri, content as string, headers, tokenSource);
+        const req = new DurableHttpRequest(
+            method,
+            uri,
+            content as string,
+            headers,
+            tokenSource,
+            asynchronousPatternEnabled
+        );
         const newAction = new CallHttpAction(req);
-        const task = new AtomicTask(false, newAction);
-        return task;
+        if (this.schemaVersion >= ReplaySchema.V3 && req.asynchronousPatternEnabled) {
+            if (!this.defaultHttpAsyncRequestSleepDuration) {
+                throw Error(
+                    "A framework-internal error was detected: replay schema version >= V3 is being used, " +
+                        "but `defaultHttpAsyncRequestSleepDuration` property is not defined. " +
+                        "This is likely an issue with the Durable Functions Extension. " +
+                        "Please report this bug here: https://github.com/Azure/azure-functions-durable-js/issues"
+                );
+            }
+            return new CallHttpWithPollingTask(
+                false,
+                newAction,
+                this,
+                this.taskOrchestratorExecutor,
+                this.defaultHttpAsyncRequestSleepDuration.toISOString()
+            );
+        }
+        return new AtomicTask(false, newAction);
     }
 
     /**

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -63,6 +63,7 @@ export class Orchestrator {
                 orchestrationBinding.parentInstanceId,
                 orchestrationBinding.longRunningTimerIntervalDuration,
                 orchestrationBinding.maximumShortTimerDuration,
+                orchestrationBinding.defaultHttpAsyncRequestSleepTimeMillseconds,
                 upperSchemaVersion,
                 input,
                 this.taskOrchestrationExecutor

--- a/src/task.ts
+++ b/src/task.ts
@@ -415,9 +415,10 @@ export class CallHttpWithPollingTask extends CompoundTask {
         if (child.stateObj === TaskState.Completed) {
             if (child.actionObj instanceof CallHttpAction) {
                 const result = child.result as DurableHttpResponse;
-                if (result.statusCode === 202 && result.headers && result.headers.Location) {
-                    const delay: moment.Duration = result.headers["Retry-After"]
-                        ? moment.duration(result.headers["Retry-After"], "s")
+                if (result.statusCode === 202 && result.getHeader("Location")) {
+                    const retryAfterHeaderValue = result.getHeader("Retry-After");
+                    const delay: moment.Duration = retryAfterHeaderValue
+                        ? moment.duration(retryAfterHeaderValue, "s")
                         : this.defaultHttpAsyncRequestSleepDuration;
 
                     const currentTime = this.orchestrationContext.currentUtcDateTime;

--- a/src/task.ts
+++ b/src/task.ts
@@ -1,5 +1,5 @@
-import { RetryOptions } from ".";
-import { IAction, CreateTimerAction } from "./classes";
+import { DurableHttpResponse, RetryOptions } from ".";
+import { IAction, CreateTimerAction, CallHttpAction } from "./classes";
 import { TaskOrchestrationExecutor } from "./taskorchestrationexecutor";
 import moment = require("moment");
 import { DurableOrchestrationContext } from "./durableorchestrationcontext";
@@ -376,6 +376,85 @@ export class WhenAnyTask extends CompoundTask {
         if (this.state === TaskState.Running) {
             this.setValue(false, child);
         }
+    }
+}
+
+/**
+ * @hidden
+ *
+ * CallHttp Task with polling logic
+ *
+ * If the HTTP requests returns a 202 status code with a 'Location' header,
+ * then a timer task is created, after which another HTTP request is made,
+ * until a different status code is returned.
+ *
+ * Any other result from the HTTP requests is the result of the whole task.
+ *
+ * The duration of the timer is specified by the 'Retry-After' header (in seconds)
+ * of the 202 response, or a default value specified by the durable extension is used.
+ *
+ */
+export class CallHttpWithPollingTask extends CompoundTask {
+    protected action: CallHttpAction;
+    private readonly defaultHttpAsyncRequestSleepDuration: moment.Duration;
+
+    public constructor(
+        id: TaskID,
+        action: CallHttpAction,
+        private readonly orchestrationContext: DurableOrchestrationContext,
+        private readonly executor: TaskOrchestrationExecutor,
+        defaultAsyncSleepRequestTime: string
+    ) {
+        super([new AtomicTask(id, action)], action);
+        this.id = id;
+        this.action = action;
+        this.defaultHttpAsyncRequestSleepDuration = moment.duration(defaultAsyncSleepRequestTime);
+    }
+
+    public trySetValue(child: TaskBase): void {
+        if (child.stateObj === TaskState.Completed) {
+            if (child.actionObj instanceof CallHttpAction) {
+                const result = child.result as DurableHttpResponse;
+                if (result.statusCode === 202 && result.headers && result.headers.Location) {
+                    const delay: moment.Duration = result.headers["Retry-After"]
+                        ? moment.duration(result.headers["Retry-After"], "s")
+                        : this.defaultHttpAsyncRequestSleepDuration;
+
+                    const currentTime = this.orchestrationContext.currentUtcDateTime;
+                    const timerFireTime = moment(currentTime).add(delay).toDate();
+
+                    // this should be safe since both types returned by this call
+                    // (DFTimerTask and LongTimerTask) are TaskBase-conforming
+                    const timerTask = (this.orchestrationContext.createTimer(
+                        timerFireTime
+                    ) as unknown) as TaskBase;
+                    const callHttpTask = new AtomicTask(
+                        false,
+                        new CallHttpAction(this.action.httpRequest)
+                    );
+
+                    this.addNewChildren([timerTask, callHttpTask]);
+                } else {
+                    // Set the value of a non-redirect HTTP response as the value of the entire
+                    // compound task
+                    this.setValue(false, result);
+                }
+            }
+        } else {
+            // If any subtask failed, we fail the entire compound task
+            if (this.firstError === undefined) {
+                this.firstError = child.result as Error;
+                this.setValue(true, this.firstError);
+            }
+        }
+    }
+
+    private addNewChildren(children: TaskBase[]): void {
+        children.map((child) => {
+            child.parent = this;
+            this.children.push(child);
+            this.executor.trackOpenTask(child);
+        });
     }
 }
 

--- a/src/testingUtils.ts
+++ b/src/testingUtils.ts
@@ -36,6 +36,7 @@ export class DummyOrchestrationContext implements IOrchestrationFunctionContext 
      * @param isReplaying Whether the orchestration is to be marked as isReplaying the its first event
      * @param longRunningTimerIntervalDuration The duration to break smaller timers into if a long timer exceeds the maximum allowed duration
      * @param maximumShortTimerDuration The maximum duration for a timer allowed by the underlying storage infrastructure
+     * @param defaultHttpAsyncRequestSleepDurationInMillseconds The default amount of time to wait between sending requests in a callHttp polling scenario
      * @param schemaVersion The schema version currently used after being negotiated with the extension
      * @param parentInstanceId The instanceId of the orchestration's parent, if this is a sub-orchestration
      */
@@ -46,6 +47,7 @@ export class DummyOrchestrationContext implements IOrchestrationFunctionContext 
         currentUtcDateTime: Date = new Date(),
         longRunningTimerIntervalDuration = "3.00:00:00",
         maximumShortTimerDuration = "6.00:00:00",
+        defaultHttpAsyncRequestSleepDurationInMillseconds = 30000,
         schemaVersion: ReplaySchema = ReplaySchema.V1,
         isReplaying = false,
         parentInstanceId = ""
@@ -63,6 +65,7 @@ export class DummyOrchestrationContext implements IOrchestrationFunctionContext 
             parentInstanceId,
             longRunningTimerIntervalDuration,
             maximumShortTimerDuration,
+            defaultHttpAsyncRequestSleepDurationInMillseconds,
             schemaVersion,
             input,
             new TaskOrchestrationExecutor()

--- a/src/testingUtils.ts
+++ b/src/testingUtils.ts
@@ -17,7 +17,6 @@ import {
 } from "./classes";
 import { IOrchestrationFunctionContext } from "./iorchestrationfunctioncontext";
 import { ReplaySchema } from "./replaySchema";
-import { TaskOrchestrationExecutor } from "./taskorchestrationexecutor";
 
 /**
  * An orchestration context with dummy default values to facilitate mocking/stubbing the
@@ -44,10 +43,9 @@ export class DummyOrchestrationContext implements IOrchestrationFunctionContext 
         instanceId = "",
         history: HistoryEvent[] | undefined = undefined,
         input: any = undefined,
-        currentUtcDateTime: Date = new Date(),
         longRunningTimerIntervalDuration = "3.00:00:00",
         maximumShortTimerDuration = "6.00:00:00",
-        defaultHttpAsyncRequestSleepDurationInMillseconds = 30000,
+        defaultHttpAsyncRequestSleepTimeMillseconds = 30000,
         schemaVersion: ReplaySchema = ReplaySchema.V1,
         isReplaying = false,
         parentInstanceId = ""
@@ -56,20 +54,22 @@ export class DummyOrchestrationContext implements IOrchestrationFunctionContext 
             const opts = new HistoryEventOptions(0, new Date());
             history = [new OrchestratorStartedEvent(opts)];
         }
-        this.bindings = [new DurableOrchestrationBindingInfo(history)];
-        this.df = new DurableOrchestrationContext(
-            history,
-            instanceId,
-            currentUtcDateTime,
-            isReplaying,
-            parentInstanceId,
-            longRunningTimerIntervalDuration,
-            maximumShortTimerDuration,
-            defaultHttpAsyncRequestSleepDurationInMillseconds,
-            schemaVersion,
-            input,
-            new TaskOrchestrationExecutor()
-        );
+        this.bindings = [
+            new DurableOrchestrationBindingInfo(
+                history,
+                input,
+                instanceId,
+                isReplaying,
+                parentInstanceId,
+                maximumShortTimerDuration,
+                longRunningTimerIntervalDuration,
+                defaultHttpAsyncRequestSleepTimeMillseconds,
+                schemaVersion
+            ),
+        ];
+
+        // Set this as undefined, let it be initialized by the orchestrator
+        this.df = (undefined as unknown) as DurableOrchestrationContext;
     }
     public doneValue: IOrchestratorState | undefined;
     public err: string | Error | null | undefined;

--- a/test/integration/orchestrator-spec.ts
+++ b/test/integration/orchestrator-spec.ts
@@ -871,6 +871,7 @@ describe("Orchestrator", () => {
                                 uri: req.uri,
                                 content: req.content,
                                 headers: req.headers,
+                                asynchronousPatternEnabled: req.asynchronousPatternEnabled,
                                 tokenSource: {
                                     resource: "https://management.core.windows.net",
                                     kind: "AzureManagedIdentity",
@@ -1578,6 +1579,7 @@ describe("Orchestrator", () => {
                         undefined,
                         "6.00:00:00",
                         "3.00:00:00",
+                        30000,
                         ReplaySchema.V3
                     ),
                 });
@@ -1611,6 +1613,7 @@ describe("Orchestrator", () => {
                         undefined,
                         "6.00:00:00",
                         "3.00:00:00",
+                        30000,
                         ReplaySchema.V3
                     ),
                 });
@@ -1644,6 +1647,7 @@ describe("Orchestrator", () => {
                         undefined,
                         "6.00:00:00",
                         "3.00:00:00",
+                        300000,
                         ReplaySchema.V3
                     ),
                 });

--- a/test/integration/orchestrator-spec.ts
+++ b/test/integration/orchestrator-spec.ts
@@ -925,7 +925,7 @@ describe("Orchestrator", () => {
         });
 
         describe("callHttp with polling", () => {
-            it("returns the result of the first non-redirect response if success", () => {
+            it("returns the result of the first success non-redirect response", () => {
                 const orchestrator = TestOrchestrations.SendHttpRequest;
                 const req = new DurableHttpRequest(
                     "GET",
@@ -970,7 +970,7 @@ describe("Orchestrator", () => {
                     })
                 );
             });
-            it("returns the result of the first non-redirect response if failure", () => {
+            it("returns the result of the first failure non-redirect response", () => {
                 const orchestrator = TestOrchestrations.SendHttpRequest;
                 const req = new DurableHttpRequest(
                     "GET",
@@ -1044,49 +1044,12 @@ describe("Orchestrator", () => {
                     })
                 );
             });
-            it("treats headers case insensitively", () => {
+            it("treats headers case-insensitively", () => {
                 const orchestrator = TestOrchestrations.SendHttpRequest;
                 const req = new DurableHttpRequest("GET", "https://bing.com");
 
                 const fakeRedirectResponse = new DurableHttpResponse(202, "redirect", {
                     LoCaTiOn: "https://bing.com",
-                });
-
-                const mockContext = new DummyOrchestrationContext(
-                    "",
-                    TestHistories.GetSendHttpRequestReplayOne(
-                        "SendHttpRequest",
-                        moment.utc().toDate(),
-                        req,
-                        fakeRedirectResponse
-                    ),
-                    req,
-                    undefined,
-                    undefined,
-                    30000,
-                    ReplaySchema.V3
-                );
-
-                orchestrator(mockContext);
-
-                expect(mockContext.doneValue).to.be.deep.equal(
-                    new OrchestratorState({
-                        isDone: false,
-                        output: undefined,
-                        actions: [[new CallHttpAction(req)]],
-                        schemaVersion: ReplaySchema.V3,
-                    })
-                );
-            });
-            it("respects retry-after header and long timer scenario", () => {
-                const orchestrator = TestOrchestrations.SendHttpRequest;
-                const req = new DurableHttpRequest("GET", "https://bing.com");
-
-                const retryAfter = moment.duration(10, "d").seconds();
-
-                const fakeRedirectResponse = new DurableHttpResponse(202, "redirect", {
-                    "Retry-After": retryAfter.toString(),
-                    Location: "https://bing.com",
                 });
 
                 const mockContext = new DummyOrchestrationContext(
@@ -1222,7 +1185,7 @@ describe("Orchestrator", () => {
                     })
                 );
             });
-            it("fails if a sub HTTP request fails", () => {
+            it("fails if a sub-HTTP request task fails", () => {
                 const orchestrator = TestOrchestrations.SendHttpRequest;
                 const req = new DurableHttpRequest(
                     "GET",

--- a/test/integration/orchestrator-spec.ts
+++ b/test/integration/orchestrator-spec.ts
@@ -1,11 +1,18 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { TraceContext } from "@azure/functions";
+import {
+    BindingDefinition,
+    ContextBindingData,
+    ContextBindings,
+    ExecutionContext,
+    HttpRequest,
+    Logger,
+    TraceContext,
+} from "@azure/functions";
 import { expect } from "chai";
 import "mocha";
 import * as moment from "moment";
-import { start } from "repl";
 import * as uuidv1 from "uuid/v1";
-import { ManagedIdentityTokenSource } from "../../src";
+import { DummyOrchestrationContext, ManagedIdentityTokenSource } from "../../src";
 import {
     ActionType,
     CallActivityAction,
@@ -915,6 +922,251 @@ describe("Orchestrator", () => {
                     true
                 )
             );
+        });
+
+        describe("callHttp with polling", () => {
+            it("returns the result of the first non-redirect response if success", () => {
+                const orchestrator = TestOrchestrations.SendHttpRequest;
+                const req = new DurableHttpRequest(
+                    "GET",
+                    "https://bing.com",
+                    undefined,
+                    undefined,
+                    undefined,
+                    true
+                );
+                const res = new DurableHttpResponse(
+                    200,
+                    '<!DOCTYPE html><html lang="en">...</html>',
+                    {
+                        "Content-Type": "text/html; charset=utf-8",
+                        "Cache-control": "private, max-age=8",
+                    }
+                );
+
+                const mockContext = new DummyOrchestrationContext(
+                    "",
+                    TestHistories.GetCompletedHttpRequestWithPolling(
+                        moment.utc().toDate(),
+                        req,
+                        res,
+                        30000
+                    ),
+                    req,
+                    undefined,
+                    undefined,
+                    30000,
+                    ReplaySchema.V3
+                );
+
+                orchestrator(mockContext);
+
+                expect(mockContext.doneValue).to.be.deep.equal(
+                    new OrchestratorState({
+                        isDone: true,
+                        actions: [[new CallHttpAction(req)]],
+                        output: res,
+                        schemaVersion: ReplaySchema.V3,
+                    })
+                );
+            });
+            it("returns the result of the first non-redirect response if failure", () => {
+                const orchestrator = TestOrchestrations.SendHttpRequest;
+                const req = new DurableHttpRequest(
+                    "GET",
+                    "https://bing.com",
+                    undefined,
+                    undefined,
+                    undefined,
+                    true
+                );
+                const res = new DurableHttpResponse(404, "Not found!", {});
+
+                const mockContext = new DummyOrchestrationContext(
+                    "",
+                    TestHistories.GetCompletedHttpRequestWithPolling(
+                        moment.utc().toDate(),
+                        req,
+                        res,
+                        30000
+                    ),
+                    req,
+                    undefined,
+                    undefined,
+                    30000,
+                    ReplaySchema.V3
+                );
+
+                orchestrator(mockContext);
+
+                expect(mockContext.doneValue).to.be.deep.equal(
+                    new OrchestratorState({
+                        isDone: true,
+                        actions: [[new CallHttpAction(req)]],
+                        output: res,
+                        schemaVersion: ReplaySchema.V3,
+                    })
+                );
+            });
+            it("does not complete if redirect response is received", () => {
+                const orchestrator = TestOrchestrations.SendHttpRequest;
+                const req = new DurableHttpRequest(
+                    "GET",
+                    "https://bing.com",
+                    undefined,
+                    undefined,
+                    undefined,
+                    true
+                );
+
+                const mockContext = new DummyOrchestrationContext(
+                    "",
+                    TestHistories.GetPendingHttpPollingRequest(moment.utc().toDate(), req, 30000),
+                    req,
+                    undefined,
+                    undefined,
+                    30000,
+                    ReplaySchema.V3
+                );
+
+                orchestrator(mockContext);
+
+                expect(mockContext.doneValue).to.be.deep.equal(
+                    new OrchestratorState({
+                        isDone: false,
+                        output: undefined,
+                        actions: [[new CallHttpAction(req)]],
+                        schemaVersion: ReplaySchema.V3,
+                    })
+                );
+            });
+            it("defaults to polling", () => {
+                const orchestrator = TestOrchestrations.SendHttpRequest;
+                const req = new DurableHttpRequest("GET", "https://bing.com");
+
+                const redirectResponse = new DurableHttpResponse(202, "redirect", {
+                    Location: "https://bing.com",
+                });
+
+                const mockContext = new DummyOrchestrationContext(
+                    "",
+                    TestHistories.GetSendHttpRequestReplayOne(
+                        "SendHttpRequest",
+                        moment.utc().toDate(),
+                        req,
+                        redirectResponse
+                    ),
+                    req
+                );
+
+                orchestrator(mockContext);
+
+                expect(mockContext.doneValue).to.be.deep.equal(
+                    new OrchestratorState({
+                        isDone: false,
+                        output: undefined,
+                        actions: [[new CallHttpAction(req)]],
+                        schemaVersion: ReplaySchema.V1,
+                    })
+                );
+            });
+            it("requires schema version V3", () => {
+                const orchestrator = TestOrchestrations.SendHttpRequest;
+                const req = new DurableHttpRequest(
+                    "GET",
+                    "https://bing.com",
+                    undefined,
+                    undefined,
+                    undefined,
+                    true
+                );
+
+                const redirectResponse = new DurableHttpResponse(202, "redirect", {
+                    Location: "https://bing.com",
+                });
+
+                const mockContext = new DummyOrchestrationContext(
+                    "",
+                    TestHistories.GetSendHttpRequestReplayOne(
+                        "SendHttpRequest",
+                        moment.utc().toDate(),
+                        req,
+                        redirectResponse
+                    ),
+                    req,
+                    undefined,
+                    undefined,
+                    30000,
+                    ReplaySchema.V1
+                );
+
+                orchestrator(mockContext);
+
+                expect(mockContext.doneValue).to.be.deep.equal(
+                    new OrchestratorState({
+                        isDone: true,
+                        output: redirectResponse,
+                        actions: [[new CallHttpAction(req)]],
+                        schemaVersion: ReplaySchema.V1,
+                    })
+                );
+            });
+            it("fails if a sub HTTP request fails", () => {
+                const orchestrator = TestOrchestrations.SendHttpRequest;
+                const req = new DurableHttpRequest(
+                    "GET",
+                    "https://bing.com",
+                    undefined,
+                    undefined,
+                    undefined,
+                    true
+                );
+
+                const mockContext = new DummyOrchestrationContext(
+                    "",
+                    TestHistories.GetCallHttpWithPollingFailedRequest(
+                        moment.utc().toDate(),
+                        req,
+                        30000
+                    ),
+                    req,
+                    undefined,
+                    undefined,
+                    30000,
+                    ReplaySchema.V3
+                );
+
+                orchestrator(mockContext);
+
+                expect(mockContext.err).to.be.an.instanceOf(OrchestrationFailureError);
+            });
+            it("errors if V3 is used and defaultHttpAsyncRequestSleepTimeMillseconds is undefined", () => {
+                const orchestrator = TestOrchestrations.SendHttpRequest;
+                const req = new DurableHttpRequest(
+                    "GET",
+                    "https://bing.com",
+                    undefined,
+                    undefined,
+                    undefined,
+                    true
+                );
+
+                const mockContext = new DummyOrchestrationContext(
+                    "",
+                    TestHistories.GetCallHttpWithPollingFailedRequest(
+                        moment.utc().toDate(),
+                        req,
+                        30000
+                    ),
+                    req,
+                    undefined,
+                    undefined,
+                    undefined,
+                    ReplaySchema.V3
+                );
+
+                expect(orchestrator(mockContext)).to.throw;
+            });
         });
     });
 
@@ -2451,23 +2703,19 @@ describe("Orchestrator", () => {
 class MockContext implements IOrchestrationFunctionContext {
     public doneValue: IOrchestratorState | undefined;
     public err: string | Error | null | undefined;
-    constructor(public bindings: IBindings) {}
+    constructor(public bindings: ContextBindings) {}
     traceContext: TraceContext;
     df: DurableOrchestrationContext;
     invocationId: string;
-    executionContext: import("@azure/functions").ExecutionContext;
-    bindingData: { [key: string]: any };
-    bindingDefinitions: import("@azure/functions").BindingDefinition[];
-    log: import("@azure/functions").Logger;
-    req?: import("@azure/functions").HttpRequest | undefined;
-    res?: { [key: string]: any } | undefined;
+    executionContext: ExecutionContext;
+    bindingData: ContextBindingData;
+    bindingDefinitions: BindingDefinition[];
+    log: Logger;
+    req?: HttpRequest;
+    res?: { [key: string]: any };
 
     public done(err?: Error | string | null, result?: IOrchestratorState): void {
         this.doneValue = result;
         this.err = err;
     }
-}
-
-interface IBindings {
-    [key: string]: unknown;
 }

--- a/test/testobjects/TestOrchestrations.ts
+++ b/test/testobjects/TestOrchestrations.ts
@@ -312,7 +312,8 @@ export class TestOrchestrations {
             input.uri,
             input.content,
             input.headers,
-            input.tokenSource
+            input.tokenSource,
+            input.asynchronousPatternEnabled
         );
         return output;
     });


### PR DESCRIPTION
Resolves #284 . This PR:

- Adds the `asynchronousPatternEnabled` property to `DurableHttpRequest`, which is expected by the extension and enable polling logic
- Accepts the `defaultHttpAsyncRequestSleepTimeMillseconds` from the extension payload, which specifies the default period to wait between polling requests (Extension PR: https://github.com/Azure/azure-functions-durable-extension/pull/2142)
- Introduces a new `CompoundTask`, the `CallHttpWithPollingTask`, which implements the logic for creating timers and new `CallHttpAction`s when polling is enabled
- In CallHttp
    - If polling is enabled, a `CallHttpWithPollingTask` is returned, else a normal `AtomicTask` is returned
- In `CallHttpWithPollingTask`'s `trySetValue`:
    - If the response code is 202 and the Location header is set, a new timer task and new call http task are created and added to the children
    - If any other response is given, it is set as the result of the entire task
    - If any child task fails, the entire compound task fails

Some questions/concerns:

- Do we need to worry about case sensitivity for HTTP headers? There are two places where we use headers: the `Location` header to determine whether to poll, and the `Retry-After` header to determine the timeout between polling requests. Currently they are case insensitive, but I'm not sure if we should be more lenient about this. As far as I could tell, [extension code](https://github.com/Azure/azure-functions-durable-extension/blob/d5cdaf3303aaed7829d55b11f599191a4afd918b/src/WebJobs.Extensions.DurableTask/ContextImplementations/DurableOrchestrationContext.cs#L274) was also case insensitive, but I might be wrong. 
- Should we make `asynchronousPatternEnabled` true by default? On the one hand, technically this isn't a new feature, but rather a bug in the previous implementation, and polling should've worked out of the box, so it makes sense to make it true by default (it is also true by default on the extension side), but on the other hand, if some customers were returning some 202 response code without intending to poll, they would now get unexpected behavior.
- Similarly, I also had a similar guard and error [here ](https://github.com/Azure/azure-functions-durable-js/blob/ea39df4aa6b6aa5c3ada78787441877d744c375d/src/durableorchestrationcontext.ts#L330) that I used for the long timers, essentially blocking this feature unless replay schema V3 is being used. However, this is slightly different from the long timers in that it doesn't require any logical changes on the extension side. So, should I instead allow this to be used with replay schema < V3, and use some default value (perhaps the same default value used by the extension, bearing in mind that in the future, they could end up out of sync) for `defaultHttpAsyncRequestSleepTimeMillseconds`?