### PR TITLE
Remove moment types from exported types

### DIFF
--- a/src/durableorchestrationcontext.ts
+++ b/src/durableorchestrationcontext.ts
@@ -354,8 +354,8 @@ export class DurableOrchestrationContext {
                     timerAction,
                     this,
                     this.taskOrchestratorExecutor,
-                    this.maximumShortTimerDuration,
-                    this.longRunningTimerIntervalDuration
+                    this.maximumShortTimerDuration.toISOString(),
+                    this.longRunningTimerIntervalDuration.toISOString()
                 );
             }
         }


### PR DESCRIPTION
Partially addresses #353 . Removes the `moment.Duration` type from the `LongTimerTask` constructor.