### PR TITLE
Make entities use async/await only

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -20,11 +20,11 @@ const log = debug("orchestrator");
 export class Entity<T> {
     constructor(public fn: (context: IEntityFunctionContext<T>) => void) {}
 
-    public listen(): (context: IEntityFunctionContext<T>) => Promise<void> {
+    public listen(): (context: IEntityFunctionContext<T>) => Promise<EntityState> {
         return this.handle.bind(this);
     }
 
-    private async handle(context: IEntityFunctionContext<T>): Promise<void> {
+    private async handle(context: IEntityFunctionContext<T>): Promise<EntityState> {
         const entityBinding = Utils.getInstancesOf<DurableEntityBindingInfo>(
             context.bindings,
             new DurableEntityBindingInfoReqFields(
@@ -67,7 +67,7 @@ export class Entity<T> {
             }
         }
 
-        context.done(null, returnState);
+        return returnState;
     }
 
     private getCurrentDurableEntityContext(

--- a/src/shim.ts
+++ b/src/shim.ts
@@ -1,5 +1,6 @@
 import {
     Entity,
+    EntityState,
     IEntityFunctionContext,
     IOrchestrationFunctionContext,
     Orchestrator,
@@ -30,9 +31,9 @@ export function orchestrator(
 
 export function entity<T = unknown>(
     fn: (context: IEntityFunctionContext<T>) => void
-): (context: IEntityFunctionContext<T>) => void {
+): (context: IEntityFunctionContext<T>) => Promise<EntityState> {
     const listener = new Entity<T>(fn).listen();
-    return async (context): Promise<void> => {
-        await listener(context);
+    return async (context): Promise<EntityState> => {
+        return await listener(context);
     };
 }

--- a/test/integration/entity-spec.ts
+++ b/test/integration/entity-spec.ts
@@ -11,6 +11,7 @@ import {
     HttpRequest,
     TraceContext,
 } from "@azure/functions";
+import sinon = require("sinon");
 
 describe("Entity", () => {
     it("StringStore entity with no initial state.", async () => {
@@ -25,12 +26,13 @@ describe("Entity", () => {
         const mockContext = new MockContext<string>({
             context: testData.input,
         });
-        await entity(mockContext);
+        const result = await entity(mockContext);
 
-        expect(mockContext.doneValue).to.not.equal(undefined);
+        expect(mockContext.done.callCount).to.equal(0);
+        expect(result).to.not.be.undefined;
 
-        if (mockContext.doneValue) {
-            entityStateMatchesExpected(mockContext.doneValue, testData.output);
+        if (result) {
+            entityStateMatchesExpected(result, testData.output);
         }
     });
 
@@ -43,12 +45,13 @@ describe("Entity", () => {
         const mockContext = new MockContext<string>({
             context: testData.input,
         });
-        await entity(mockContext);
+        const result = await entity(mockContext);
 
-        expect(mockContext.doneValue).to.not.equal(undefined);
+        expect(mockContext.done.callCount).to.equal(0);
+        expect(result).to.not.be.undefined;
 
-        if (mockContext.doneValue) {
-            entityStateMatchesExpected(mockContext.doneValue, testData.output);
+        if (result) {
+            entityStateMatchesExpected(result, testData.output);
         }
     });
 
@@ -64,12 +67,13 @@ describe("Entity", () => {
         const mockContext = new MockContext<string>({
             context: testData.input,
         });
-        await entity(mockContext);
+        const result = await entity(mockContext);
 
-        expect(mockContext.doneValue).to.not.equal(undefined);
+        expect(mockContext.done.callCount).to.equal(0);
+        expect(result).to.not.be.undefined;
 
-        if (mockContext.doneValue) {
-            entityStateMatchesExpected(mockContext.doneValue, testData.output);
+        if (result) {
+            entityStateMatchesExpected(result, testData.output);
         }
     });
 });
@@ -90,7 +94,9 @@ class MockContext<T> implements IEntityFunctionContext<T> {
         public bindings: IBindings,
         public doneValue?: EntityState,
         public err?: Error | string | null
-    ) {}
+    ) {
+        this.done = sinon.spy();
+    }
     traceContext: TraceContext;
     public invocationId: string;
     public executionContext: ExecutionContext;
@@ -101,10 +107,7 @@ class MockContext<T> implements IEntityFunctionContext<T> {
     public res?: { [key: string]: any } | undefined;
     public df: DurableEntityContext<T>;
 
-    public done(err?: Error | string | null, result?: EntityState): void {
-        this.doneValue = result;
-        this.err = err;
-    }
+    public done: sinon.SinonSpy & ((err?: Error | string | null, result?: EntityState) => void);
 }
 
 interface IBindings {


### PR DESCRIPTION
Fixes #373. The `df.entity()` function before was returning an async function that also calls `context.done()`, causing the error:

```
Error: Choose either to return a promise or call 'done'. Do not use both in your script. Learn more: https://go.microsoft.com/fwlink/?linkid=2097909
```

To be thrown, which was hidden from logs before, but was surfaced after a node worker bug was fixed in https://github.com/Azure/azure-functions-nodejs-worker/pull/555. 

This PR removes the `context.done()` call and replaces it with the return value of the function. Potentially could be considred a "breaking" change since it changes the type signature of the customer-facing `df.entity()` function