### PR TITLE
Add signalEntity API to orchestrations

### DIFF
--- a/src/actions/actiontype.ts
+++ b/src/actions/actiontype.ts
@@ -17,8 +17,8 @@ export enum ActionType {
     WaitForExternalEvent = 6,
     CallEntity = 7,
     CallHttp = 8,
-    // ActionType 9 and 10 correspond to SignalEntity and ScheduledSignalEntity
-    // Those two are not supported yet.
+    SignalEntity = 9,
+    // ActionType 10 corresponds to ScheduledSignalEntity, which is not supported yet
     WhenAny = 11,
     WhenAll = 12,
 }

--- a/src/actions/signalentityaction.ts
+++ b/src/actions/signalentityaction.ts
@@ -1,0 +1,17 @@
+import { ActionType, EntityId, IAction, Utils } from "../classes";
+
+/** @hidden */
+export class SignalEntityAction implements IAction {
+    public readonly actionType: ActionType = ActionType.SignalEntity;
+    public readonly instanceId: string;
+    public readonly input: unknown;
+
+    constructor(entityId: EntityId, public readonly operation: string, input?: unknown) {
+        if (!entityId) {
+            throw new Error("Must provide EntityId to SignalEntityAction constructor");
+        }
+        this.input = Utils.processInput(input);
+        Utils.throwIfEmpty(operation, "operation");
+        this.instanceId = EntityId.getSchedulerIdFromEntityId(entityId);
+    }
+}

--- a/src/durableorchestrationcontext.ts
+++ b/src/durableorchestrationcontext.ts
@@ -15,7 +15,6 @@ import {
     GuidManager,
     HistoryEvent,
     WaitForExternalEventAction,
-    IAction,
 } from "./classes";
 import { TaskOrchestrationExecutor } from "./taskorchestrationexecutor";
 import { WhenAllAction } from "./actions/whenallaction";

--- a/src/durableorchestrationcontext.ts
+++ b/src/durableorchestrationcontext.ts
@@ -15,6 +15,7 @@ import {
     GuidManager,
     HistoryEvent,
     WaitForExternalEventAction,
+    IAction,
 } from "./classes";
 import { TaskOrchestrationExecutor } from "./taskorchestrationexecutor";
 import { WhenAllAction } from "./actions/whenallaction";
@@ -33,6 +34,7 @@ import {
 } from "./task";
 import moment = require("moment");
 import { ReplaySchema } from "./replaySchema";
+import { SignalEntityAction } from "./actions/signalentityaction";
 
 /**
  * Parameter data for orchestration bindings that can be used to schedule
@@ -238,6 +240,21 @@ export class DurableOrchestrationContext {
     public callEntity(entityId: EntityId, operationName: string, operationInput?: unknown): Task {
         const newAction = new CallEntityAction(entityId, operationName, operationInput);
         const task = new AtomicTask(false, newAction);
+        return task;
+    }
+
+    /**
+     * Send a signal operation to a Durable Entity, passing an argument, without
+     * waiting for a response. A fire-and-forget operation.
+     *
+     * @param entityId ID of the target entity.
+     * @param operationName The name of the operation.
+     * @param operationInput (optional) input for the operation.
+     */
+    public signalEntity(entityId: EntityId, operationName: string, operationInput?: unknown): Task {
+        const action = new SignalEntityAction(entityId, operationName, operationInput);
+        const task = new AtomicTask(false, action);
+        this.taskOrchestratorExecutor.recordFireAndForgetAction(action);
         return task;
     }
 

--- a/src/durableorchestrationcontext.ts
+++ b/src/durableorchestrationcontext.ts
@@ -251,11 +251,9 @@ export class DurableOrchestrationContext {
      * @param operationName The name of the operation.
      * @param operationInput (optional) input for the operation.
      */
-    public signalEntity(entityId: EntityId, operationName: string, operationInput?: unknown): Task {
+    public signalEntity(entityId: EntityId, operationName: string, operationInput?: unknown): void {
         const action = new SignalEntityAction(entityId, operationName, operationInput);
-        const task = new AtomicTask(false, action);
         this.taskOrchestratorExecutor.recordFireAndForgetAction(action);
-        return task;
     }
 
     /**

--- a/src/taskorchestrationexecutor.ts
+++ b/src/taskorchestrationexecutor.ts
@@ -400,10 +400,17 @@ export class TaskOrchestrationExecutor {
                 newTask = generatorResult.value;
             } else {
                 // non-task was yielded. This isn't supported
-                throw Error(
-                    `Orchestration yielded data of type ${typeof generatorResult.value}. Only Task types can be yielded.` +
-                        "Please refactor your orchestration to yield only Tasks."
-                );
+                let errorMsg = `Durable Functions programming constraint violation: Orchestration yielded data of type ${typeof generatorResult.value}.`;
+                errorMsg +=
+                    typeof generatorResult.value === "undefined"
+                        ? ' This is likely a result of yielding a "fire-and-forget API" such as signalEntity or continueAsNew.' +
+                          " These APIs should not be yielded as they are not blocking operations. Please remove the yield statement preceding those invocations." +
+                          " If you are not calling those APIs, p"
+                        : " Only Task types can be yielded. P";
+                errorMsg +=
+                    "lease check your yield statements to make sure you only yield Task types resulting from calling Durable Functions APIs.";
+
+                throw Error(errorMsg);
             }
         } catch (exception) {
             // The generator threw an exception

--- a/src/taskorchestrationexecutor.ts
+++ b/src/taskorchestrationexecutor.ts
@@ -443,6 +443,13 @@ export class TaskOrchestrationExecutor {
         }
     }
 
+    public recordFireAndForgetAction(action: IAction): void {
+        if (!this.willContinueAsNew) {
+            this.addToActions(action);
+            this.sequenceNumber++;
+        }
+    }
+
     /**
      * @hidden
      * Tracks this task as waiting for completion.

--- a/test/integration/orchestrator-spec.ts
+++ b/test/integration/orchestrator-spec.ts
@@ -2268,6 +2268,44 @@ describe("Orchestrator", () => {
         });
     });
 
+    describe("signalEntity()", () => {
+        it("sends a signal to entity", () => {
+            const orchestrator = TestOrchestrations.signalEntity;
+            const operationName = "add";
+            const operationArgument = 1;
+            const mockContext = new MockContext({
+                context: new DurableOrchestrationBindingInfo(
+                    TestHistories.GetOrchestratorStart("signalEntity", new Date()),
+                    {
+                        id: "myCounter",
+                        entityName: "Counter",
+                        operationName,
+                        operationArgument,
+                    }
+                ),
+            });
+
+            orchestrator(mockContext);
+
+            expect(mockContext.doneValue).to.deep.equal(
+                new OrchestratorState({
+                    isDone: true,
+                    output: null,
+                    actions: [[]],
+                    schemaVersion: ReplaySchema.V1,
+                })
+            );
+        });
+        it("proceeds after signalling entity", () => {
+            const yes = true;
+            expect(yes).to.be.true;
+        });
+        it("doesn't allow signalEntity() to be yielded", () => {
+            const no = false;
+            expect(no).to.be.false;
+        });
+    });
+
     describe("Task.all() and Task.any()", () => {
         it("schedules a parallel set of tasks", async () => {
             const orchestrator = TestOrchestrations.FanOutFanInDiskUsage;

--- a/test/testobjects/TestOrchestrations.ts
+++ b/test/testobjects/TestOrchestrations.ts
@@ -5,6 +5,10 @@ export class TestOrchestrations {
         return "Hello";
     });
 
+    public static YieldInteger: any = df.orchestrator(function* () {
+        yield 4;
+    });
+
     public static AnyAOrB: any = df.orchestrator(function* (context: any) {
         const completeInOrder = context.df.getInput();
 

--- a/test/testobjects/TestOrchestrations.ts
+++ b/test/testobjects/TestOrchestrations.ts
@@ -104,9 +104,16 @@ export class TestOrchestrations {
     });
 
     public static signalEntity: any = df.orchestrator(function* (context: any) {
-        const { id, entityName } = context.df.getInput();
+        const { id, entityName, operationName, operationArgument } = context.df.getInput();
         const entityId = new df.EntityId(entityName, id);
-        context.df.signalEntity(entityId, "add", 1);
+        context.df.signalEntity(entityId, operationName, operationArgument);
+        return;
+    });
+
+    public static signalEntityYield: any = df.orchestrator(function* (context: any) {
+        const { id, entityName, operationName, operationArgument } = context.df.getInput();
+        const entityId = new df.EntityId(entityName, id);
+        yield context.df.signalEntity(entityId, operationName, operationArgument);
         return;
     });
 

--- a/test/testobjects/TestOrchestrations.ts
+++ b/test/testobjects/TestOrchestrations.ts
@@ -103,6 +103,13 @@ export class TestOrchestrations {
         return currentValue;
     });
 
+    public static signalEntity: any = df.orchestrator(function* (context: any) {
+        const { id, entityName } = context.df.getInput();
+        const entityId = new df.EntityId(entityName, id);
+        context.df.signalEntity(entityId, "add", 1);
+        return;
+    });
+
     public static FanOutFanInDiskUsage: any = df.orchestrator(function* (context: any) {
         const directory = context.df.getInput();
         const files = yield context.df.callActivity("GetFileList", directory);


### PR DESCRIPTION
Resolves #327 . Allows orchestrations to have a "fire-and-forget" `signalEntity` operation, in addition to the existing blocking `callEntity` API.

## Design decisions/questions

Some design decisions made in this PR which could require additional discussions:

### An error encountered after a `signalEntity` call
The entity is still signaled if an error is encountered after the `signalEntity` call.

Code like the below:

```TS
const orchestrator = df.orchestrator(function* (context) {
    const id:string = context.df.getInput()
    const entityId = new df.EntityId("Counter", id);
    context.df.signalEntity(entityId, "add", 1)
    throw new Error("test");
});
```

Will result in:

* The orchestrator fails with an error message "test"
* The entity `Counter` is signaled once


### Yielding a `signalEntity` call
`signalEntity` is a fire-and-forget operation, and therefore it doesn't return a `Task` object and cannot be `yield`ed. Attempting to yield `signalEntity` call will cause your orchestration to fail with an error, but the signal call will still go through.

Code as the following:

```TS
const orchestrator = df.orchestrator(function* (context) {
    const id:string = context.df.getInput()
    const entityId = new df.EntityId("Counter", id);
    yield context.df.signalEntity(entityId, "add", 1)
});
```

Will result in:
* An error thrown in Core Tools (if running locally) with a message like the below:

```
Orchestration yielded data of type undefined. Only Task types can be yielded.Please refactor your orchestration to yield only Tasks.
```

* Orchestration status failed with the output message similar to the one above
* The `Counter` entity is still signaled once

