### PR TITLE
Remove dependency on `context.done()`

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -20,11 +20,11 @@ const log = debug("orchestrator");
 export class Entity<T> {
     constructor(public fn: (context: IEntityFunctionContext<T>) => void) {}
 
-    public listen(): (context: IEntityFunctionContext<T>) => Promise<void> {
+    public listen(): (context: IEntityFunctionContext<T>) => Promise<EntityState> {
         return this.handle.bind(this);
     }
 
-    private async handle(context: IEntityFunctionContext<T>): Promise<void> {
+    private async handle(context: IEntityFunctionContext<T>): Promise<EntityState> {
         const entityBinding = Utils.getInstancesOf<DurableEntityBindingInfo>(
             context.bindings,
             new DurableEntityBindingInfoReqFields(
@@ -67,7 +67,7 @@ export class Entity<T> {
             }
         }
 
-        context.done(null, returnState);
+        return returnState;
     }
 
     private getCurrentDurableEntityContext(

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -88,11 +88,13 @@ export class Orchestrator {
             );
         }
 
-        return await this.taskOrchestrationExecutor.execute(
+        const orchestratorState = await this.taskOrchestrationExecutor.execute(
             context,
             state,
             upperSchemaVersion,
             this.fn
         );
+
+        return orchestratorState;
     }
 }

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -88,13 +88,11 @@ export class Orchestrator {
             );
         }
 
-        const orchestratorState = await this.taskOrchestrationExecutor.execute(
+        return await this.taskOrchestrationExecutor.execute(
             context,
             state,
             upperSchemaVersion,
             this.fn
         );
-
-        return orchestratorState;
     }
 }

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -3,6 +3,7 @@ import {
     HistoryEvent,
     HistoryEventType,
     IOrchestrationFunctionContext,
+    OrchestratorState,
     Utils,
 } from "./classes";
 import { DurableOrchestrationContext } from "./durableorchestrationcontext";
@@ -21,11 +22,11 @@ export class Orchestrator {
     // As a result, we are currently constrained to initialize all of our data in the `handle` method.
     constructor(public fn: (context: IOrchestrationFunctionContext) => IterableIterator<unknown>) {}
 
-    public listen(): (context: IOrchestrationFunctionContext) => Promise<void> {
+    public listen(): (context: IOrchestrationFunctionContext) => Promise<OrchestratorState> {
         return this.handle.bind(this);
     }
 
-    private async handle(context: IOrchestrationFunctionContext): Promise<void> {
+    private async handle(context: IOrchestrationFunctionContext): Promise<OrchestratorState> {
         this.taskOrchestrationExecutor = new TaskOrchestrationExecutor();
         const orchestrationBinding = Utils.getInstancesOf<DurableOrchestrationBindingInfo>(
             context.bindings,
@@ -87,7 +88,11 @@ export class Orchestrator {
             );
         }
 
-        await this.taskOrchestrationExecutor.execute(context, state, upperSchemaVersion, this.fn);
-        return;
+        return await this.taskOrchestrationExecutor.execute(
+            context,
+            state,
+            upperSchemaVersion,
+            this.fn
+        );
     }
 }

--- a/src/shim.ts
+++ b/src/shim.ts
@@ -5,6 +5,7 @@ import {
     IOrchestrationFunctionContext,
     Orchestrator,
 } from "./classes";
+import { OrchestratorState } from "./orchestratorstate";
 
 /**
  * Enables a generator function to act as an orchestrator function.
@@ -22,10 +23,10 @@ import {
  */
 export function orchestrator(
     fn: (context: IOrchestrationFunctionContext) => Generator<unknown, unknown, any>
-): (context: IOrchestrationFunctionContext) => void {
+): (context: IOrchestrationFunctionContext) => Promise<OrchestratorState> {
     const listener = new Orchestrator(fn).listen();
-    return (context): void => {
-        listener(context);
+    return async (context): Promise<OrchestratorState> => {
+        return await listener(context);
     };
 }
 

--- a/src/shim.ts
+++ b/src/shim.ts
@@ -26,7 +26,8 @@ export function orchestrator(
 ): (context: IOrchestrationFunctionContext) => Promise<OrchestratorState> {
     const listener = new Orchestrator(fn).listen();
     return async (context): Promise<OrchestratorState> => {
-        return await listener(context);
+        const orchestratorState = await listener(context);
+        return orchestratorState;
     };
 }
 
@@ -35,6 +36,7 @@ export function entity<T = unknown>(
 ): (context: IEntityFunctionContext<T>) => Promise<EntityState> {
     const listener = new Entity<T>(fn).listen();
     return async (context): Promise<EntityState> => {
-        return await listener(context);
+        const entityState = await listener(context);
+        return entityState;
     };
 }

--- a/src/shim.ts
+++ b/src/shim.ts
@@ -26,8 +26,7 @@ export function orchestrator(
 ): (context: IOrchestrationFunctionContext) => Promise<OrchestratorState> {
     const listener = new Orchestrator(fn).listen();
     return async (context): Promise<OrchestratorState> => {
-        const orchestratorState = await listener(context);
-        return orchestratorState;
+        return await listener(context);
     };
 }
 
@@ -36,7 +35,6 @@ export function entity<T = unknown>(
 ): (context: IEntityFunctionContext<T>) => Promise<EntityState> {
     const listener = new Entity<T>(fn).listen();
     return async (context): Promise<EntityState> => {
-        const entityState = await listener(context);
-        return entityState;
+        return await listener(context);
     };
 }

--- a/src/shim.ts
+++ b/src/shim.ts
@@ -1,5 +1,6 @@
 import {
     Entity,
+    EntityState,
     IEntityFunctionContext,
     IOrchestrationFunctionContext,
     Orchestrator,
@@ -30,9 +31,9 @@ export function orchestrator(
 
 export function entity<T = unknown>(
     fn: (context: IEntityFunctionContext<T>) => void
-): (context: IEntityFunctionContext<T>) => void {
+): (context: IEntityFunctionContext<T>) => Promise<EntityState> {
     const listener = new Entity<T>(fn).listen();
-    return async (context): Promise<void> => {
-        await listener(context);
+    return async (context): Promise<EntityState> => {
+        return await listener(context);
     };
 }

--- a/src/taskorchestrationexecutor.ts
+++ b/src/taskorchestrationexecutor.ts
@@ -99,7 +99,7 @@ export class TaskOrchestrationExecutor {
         history: HistoryEvent[],
         schemaVersion: ReplaySchema,
         fn: (context: IOrchestrationFunctionContext) => IterableIterator<unknown>
-    ): Promise<void> {
+    ): Promise<OrchestratorState> {
         this.schemaVersion = schemaVersion;
         this.context = context.df;
         this.generator = fn(context) as Generator<TaskBase, any, any>;
@@ -123,17 +123,12 @@ export class TaskOrchestrationExecutor {
             schemaVersion: this.schemaVersion,
         });
 
-        // Record errors, if any
-        let error = undefined;
-        let result: any = orchestratorState;
+        // Throw errors, if any
         if (this.exception !== undefined) {
-            error = new OrchestrationFailureError(this.orchestratorReturned, orchestratorState);
-            result = undefined;
+            throw new OrchestrationFailureError(this.orchestratorReturned, orchestratorState);
         }
 
-        // Communicate the orchestration's current state
-        context.done(error, result);
-        return;
+        return orchestratorState;
     }
 
     /**

--- a/src/testingUtils.ts
+++ b/src/testingUtils.ts
@@ -12,7 +12,6 @@ import {
     DurableOrchestrationContext,
     HistoryEvent,
     HistoryEventOptions,
-    IOrchestratorState,
     OrchestratorStartedEvent,
 } from "./classes";
 import { IOrchestrationFunctionContext } from "./iorchestrationfunctioncontext";
@@ -71,8 +70,6 @@ export class DummyOrchestrationContext implements IOrchestrationFunctionContext 
         // Set this as undefined, let it be initialized by the orchestrator
         this.df = (undefined as unknown) as DurableOrchestrationContext;
     }
-    public doneValue: IOrchestratorState | undefined;
-    public err: string | Error | null | undefined;
     df: DurableOrchestrationContext;
     invocationId: string;
     executionContext: ExecutionContext;
@@ -81,10 +78,7 @@ export class DummyOrchestrationContext implements IOrchestrationFunctionContext 
     traceContext: TraceContext;
     bindingDefinitions: BindingDefinition[];
     log: Logger;
-    done(err?: string | Error, result?: any): void {
-        this.doneValue = result;
-        this.err = err;
-    }
+    done: (err?: string | Error, result?: any) => void;
     req?: HttpRequest;
     res?: { [key: string]: any };
 }

--- a/test/integration/entity-spec.ts
+++ b/test/integration/entity-spec.ts
@@ -11,6 +11,7 @@ import {
     HttpRequest,
     TraceContext,
 } from "@azure/functions";
+import sinon = require("sinon");
 
 describe("Entity", () => {
     it("StringStore entity with no initial state.", async () => {
@@ -25,12 +26,13 @@ describe("Entity", () => {
         const mockContext = new MockContext<string>({
             context: testData.input,
         });
-        await entity(mockContext);
+        const result = await entity(mockContext);
 
-        expect(mockContext.doneValue).to.not.equal(undefined);
+        expect(mockContext.done.callCount).to.equal(0);
+        expect(result).to.not.be.undefined;
 
-        if (mockContext.doneValue) {
-            entityStateMatchesExpected(mockContext.doneValue, testData.output);
+        if (result) {
+            entityStateMatchesExpected(result, testData.output);
         }
     });
 
@@ -43,12 +45,13 @@ describe("Entity", () => {
         const mockContext = new MockContext<string>({
             context: testData.input,
         });
-        await entity(mockContext);
+        const result = await entity(mockContext);
 
-        expect(mockContext.doneValue).to.not.equal(undefined);
+        expect(mockContext.done.callCount).to.equal(0);
+        expect(result).to.not.be.undefined;
 
-        if (mockContext.doneValue) {
-            entityStateMatchesExpected(mockContext.doneValue, testData.output);
+        if (result) {
+            entityStateMatchesExpected(result, testData.output);
         }
     });
 
@@ -64,12 +67,13 @@ describe("Entity", () => {
         const mockContext = new MockContext<string>({
             context: testData.input,
         });
-        await entity(mockContext);
+        const result = await entity(mockContext);
 
-        expect(mockContext.doneValue).to.not.equal(undefined);
+        expect(mockContext.done.callCount).to.equal(0);
+        expect(result).to.not.be.undefined;
 
-        if (mockContext.doneValue) {
-            entityStateMatchesExpected(mockContext.doneValue, testData.output);
+        if (result) {
+            entityStateMatchesExpected(result, testData.output);
         }
     });
 });
@@ -90,7 +94,9 @@ class MockContext<T> implements IEntityFunctionContext<T> {
         public bindings: IBindings,
         public doneValue?: EntityState,
         public err?: Error | string | null
-    ) {}
+    ) {
+        this.done = sinon.spy();
+    }
     traceContext: TraceContext;
     public invocationId: string;
     public executionContext: ExecutionContext;
@@ -101,10 +107,7 @@ class MockContext<T> implements IEntityFunctionContext<T> {
     public res?: { [key: string]: any } | undefined;
     public df: DurableEntityContext<T>;
 
-    public done(err?: Error | string | null, result?: EntityState): void {
-        this.doneValue = result;
-        this.err = err;
-    }
+    public done: sinon.SinonSpy & ((err?: Error | string | null, result?: EntityState) => void);
 }
 
 interface IBindings {

--- a/test/integration/entity-spec.ts
+++ b/test/integration/entity-spec.ts
@@ -11,7 +11,6 @@ import {
     HttpRequest,
     TraceContext,
 } from "@azure/functions";
-import sinon = require("sinon");
 
 describe("Entity", () => {
     it("StringStore entity with no initial state.", async () => {
@@ -28,7 +27,6 @@ describe("Entity", () => {
         });
         const result = await entity(mockContext);
 
-        expect(mockContext.done.callCount).to.equal(0);
         expect(result).to.not.be.undefined;
 
         if (result) {
@@ -47,7 +45,6 @@ describe("Entity", () => {
         });
         const result = await entity(mockContext);
 
-        expect(mockContext.done.callCount).to.equal(0);
         expect(result).to.not.be.undefined;
 
         if (result) {
@@ -69,7 +66,6 @@ describe("Entity", () => {
         });
         const result = await entity(mockContext);
 
-        expect(mockContext.done.callCount).to.equal(0);
         expect(result).to.not.be.undefined;
 
         if (result) {
@@ -90,13 +86,7 @@ function entityStateMatchesExpected(actual: EntityState, expected: EntityState):
 }
 
 class MockContext<T> implements IEntityFunctionContext<T> {
-    constructor(
-        public bindings: IBindings,
-        public doneValue?: EntityState,
-        public err?: Error | string | null
-    ) {
-        this.done = sinon.spy();
-    }
+    constructor(public bindings: IBindings) {}
     traceContext: TraceContext;
     public invocationId: string;
     public executionContext: ExecutionContext;
@@ -107,7 +97,7 @@ class MockContext<T> implements IEntityFunctionContext<T> {
     public res?: { [key: string]: any } | undefined;
     public df: DurableEntityContext<T>;
 
-    public done: sinon.SinonSpy & ((err?: Error | string | null, result?: EntityState) => void);
+    public done: (err?: Error | string | null, result?: EntityState) => void;
 }
 
 interface IBindings {

--- a/test/testobjects/TestOrchestrations.ts
+++ b/test/testobjects/TestOrchestrations.ts
@@ -1,7 +1,8 @@
 import * as df from "../../src";
 
 export class TestOrchestrations {
-    public static NotGenerator: any = df.orchestrator(function* (context: any) {
+    public static NotGenerator: any = df.orchestrator(function* (_context: any) {
+        void _context;
         return "Hello";
     });
 

--- a/test/testobjects/TestOrchestrations.ts
+++ b/test/testobjects/TestOrchestrations.ts
@@ -1,8 +1,7 @@
 import * as df from "../../src";
 
 export class TestOrchestrations {
-    public static NotGenerator: any = df.orchestrator(function* (_context: any) {
-        void _context;
+    public static NotGenerator: any = df.orchestrator(function* () {
         return "Hello";
     });
 


### PR DESCRIPTION
Related to #384. As part of supporting the new programming model, we have to stop depending on constructs that existed in the old programming model that no longer exist in the new one. One of the main breaking changes we need is to return orchestrator and entity states as the return value of functions rather than using `context.done()`, which doesn't exist in the new programming model. This PR does that and updates our internal testing infrastructure accordingly