### PR TITLE
Patch isReplaying on WhenAll

### DIFF
--- a/src/task.ts
+++ b/src/task.ts
@@ -245,7 +245,6 @@ export abstract class CompoundTask extends DFTask {
         // If the task has no children, then it's completed by definition.
         if (children.length == 0) {
             this.state = TaskState.Completed;
-            // TODO: how should isPlayed change here?
         }
 
         // Sub-tasks may have already completed, so we process them

--- a/src/task.ts
+++ b/src/task.ts
@@ -344,8 +344,7 @@ export class WhenAllTask extends CompoundTask {
     }
 
     trySetIsPlayed(): void {
-        const isPlayed = this.children.every((c) => c.isPlayed);
-        this.isPlayed = isPlayed;
+        this.isPlayed = this.children.every((c) => c.isPlayed);
     }
 
     /**
@@ -380,8 +379,7 @@ export class WhenAllTask extends CompoundTask {
  */
 export class WhenAnyTask extends CompoundTask {
     trySetIsPlayed(): void {
-        const isPlayed = this.children.some((c) => c.isPlayed);
-        this.isPlayed = isPlayed;
+        this.isPlayed = this.children.some((c) => c.isPlayed);
     }
     /**
      * @hidden

--- a/test/integration/orchestrator-spec.ts
+++ b/test/integration/orchestrator-spec.ts
@@ -224,6 +224,20 @@ describe("Orchestrator", () => {
             expect(mockContext.doneValue?.output).to.be.deep.equal([true, false]);
         });
 
+        it("can assign isReplaying to False in WhenAll", async () => {
+            const orchestrator = TestOrchestrations.FanningIsReplaying;
+
+            const mockHistory = TestHistories.GetSimpleFanOut(moment.utc().toDate());
+
+            const mockContext = new MockContext({
+                context: new DurableOrchestrationBindingInfo(mockHistory, "SimpleFanOut"),
+            });
+
+            orchestrator(mockContext);
+
+            expect(mockContext.doneValue?.output).to.be.deep.equal([true, false]);
+        });
+
         it("handles creating a composite task out of an already completed task", async () => {
             const orchestrator = TestOrchestrations.MultiYieldWhenAll;
             const name = "World";

--- a/test/testobjects/TestOrchestrations.ts
+++ b/test/testobjects/TestOrchestrations.ts
@@ -332,6 +332,19 @@ export class TestOrchestrations {
         return output;
     });
 
+    public static FanningIsReplaying: any = df.orchestrator(function* (context: any) {
+        const output = [];
+
+        output.push(context.df.isReplaying);
+        const tasks = [
+            context.df.callActivity("Hello", "Tokyo"),
+            context.df.callActivity("Hello", "Seattle"),
+        ];
+        yield context.df.Task.all(tasks);
+        output.push(context.df.isReplaying);
+        return output;
+    });
+
     public static MultiYieldWhenAll: any = df.orchestrator(function* (context: any) {
         const output = [];
 

--- a/test/testobjects/testhistories.ts
+++ b/test/testobjects/testhistories.ts
@@ -1434,6 +1434,88 @@ export class TestHistories {
         return history;
     }
 
+    public static GetSimpleFanOut(firstTimestamp: Date) {
+        const historyEvents: HistoryEvent[] = [];
+
+        historyEvents.push(
+            new OrchestratorStartedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: true,
+            })
+        );
+        historyEvents.push(
+            new ExecutionStartedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: true,
+                name: "SayHelloWithActivityRetryFanout",
+                input: undefined,
+            })
+        );
+        historyEvents.push(
+            new TaskScheduledEvent({
+                eventId: 0,
+                timestamp: firstTimestamp,
+                isPlayed: true,
+                name: "Hello",
+                input: "Tokyo",
+            })
+        );
+        historyEvents.push(
+            new TaskScheduledEvent({
+                eventId: 1,
+                timestamp: firstTimestamp,
+                isPlayed: true,
+                name: "Hello",
+                input: "Seattle",
+            })
+        );
+        historyEvents.push(
+            new OrchestratorCompletedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: true,
+            })
+        );
+
+        historyEvents.push(
+            new OrchestratorStartedEvent({
+                eventId: -1,
+                timestamp: moment(firstTimestamp).add(100, "s").toDate(),
+                isPlayed: true,
+            })
+        );
+        historyEvents.push(
+            new TaskCompletedEvent({
+                eventId: -1,
+                timestamp: moment(firstTimestamp).add(100, "s").toDate(),
+                isPlayed: true,
+                result: JSON.stringify(`Hello, Tokyo!`),
+                taskScheduledId: 0,
+            })
+        );
+
+        historyEvents.push(
+            new OrchestratorStartedEvent({
+                eventId: -1,
+                timestamp: moment(firstTimestamp).add(100, "s").toDate(),
+                isPlayed: false,
+            })
+        );
+        historyEvents.push(
+            new TaskCompletedEvent({
+                eventId: -1,
+                timestamp: moment(firstTimestamp).add(100, "s").toDate(),
+                isPlayed: false,
+                result: JSON.stringify(`Hello, Seattle!`),
+                taskScheduledId: 1,
+            })
+        );
+
+        return historyEvents;
+    }
+
     public static GetSayHelloWithActivityRetryFanout(
         firstTimestamp: Date,
         retryInterval: number,


### PR DESCRIPTION
Resolves: https://github.com/Azure/azure-functions-durable-js/issues/404

We currently have a bug where in WhenAll where ithe value of `isPlayed` for the `WhenAll` task will be set to `True` if any of its sub-tasks has a `isPlayed` value of `True`. The correct behavior is that the value of `WhenAll's` `IsPlayed` should be `True` when *all* of its sub-tasks are `True`. 

This PR addresses this.

Note: for `WhenAny` it suffices that only one of its Tasks have `isPlayed` as `True` for it's `isPlayed` to be `True` as well