### PR TITLE
Make callHttp accept one options object argument

### DIFF
--- a/src/durablehttprequest.ts
+++ b/src/durablehttprequest.ts
@@ -1,4 +1,4 @@
-import { TokenSource } from "./tokensource";
+import { TokenSource } from "./types";
 
 /**
  * Data structure representing a durable HTTP request.

--- a/src/durableorchestrationcontext.ts
+++ b/src/durableorchestrationcontext.ts
@@ -313,7 +313,7 @@ export class DurableOrchestrationContext {
             content as string,
             options.headers,
             options.tokenSource,
-            typeof options.asynchronousPatternEnabled === "undefined"
+            options.asynchronousPatternEnabled === undefined
                 ? true
                 : options.asynchronousPatternEnabled
         );

--- a/src/tokensource.ts
+++ b/src/tokensource.ts
@@ -31,6 +31,3 @@ export class ManagedIdentityTokenSource {
         public readonly resource: string
     ) {}
 }
-
-// Over time we will likely add more implementations
-export type TokenSource = ManagedIdentityTokenSource;

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,7 +50,7 @@ export interface CallHttpOptions {
      * Specifies whether the DurableHttpRequest should handle the asynchronous pattern.
      * @default true
      */
-    asynchronousPatternEnabled: boolean;
+    asynchronousPatternEnabled?: boolean;
 }
 
 // Over time we will likely add more implementations

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ import {
 } from "@azure/functions";
 import { IEntityFunctionContext } from "../src/ientityfunctioncontext";
 import { IOrchestrationFunctionContext } from "../src/iorchestrationfunctioncontext";
+import { ManagedIdentityTokenSource } from "./tokensource";
 
 // orchestrations
 export type OrchestrationHandler = (
@@ -20,6 +21,40 @@ export interface OrchestrationOptions extends Partial<FunctionOptions> {
 export interface OrchestrationTrigger extends FunctionTrigger {
     type: "orchestrationTrigger";
 }
+
+/**
+ * Options object provided to `callHttp()` methods on orchestration contexts
+ */
+export interface CallHttpOptions {
+    /**
+     * The HTTP request method.
+     */
+    method: string;
+    /**
+     * The HTTP request URL.
+     */
+    url: string;
+    /**
+     * The HTTP request body.
+     */
+    body?: string | object;
+    /**
+     * The HTTP request headers.
+     */
+    headers?: { [key: string]: string };
+    /**
+     * The source of the OAuth token to add to the request.
+     */
+    tokenSource?: TokenSource;
+    /**
+     * Specifies whether the DurableHttpRequest should handle the asynchronous pattern.
+     * @default true
+     */
+    asynchronousPatternEnabled: boolean;
+}
+
+// Over time we will likely add more implementations
+export type TokenSource = ManagedIdentityTokenSource;
 
 // entities
 export type EntityHandler<T> = (context: IEntityFunctionContext<T>) => void;

--- a/test/testobjects/TestOrchestrations.ts
+++ b/test/testobjects/TestOrchestrations.ts
@@ -318,14 +318,14 @@ export class TestOrchestrations {
 
     public static SendHttpRequest: any = createOrchestrator(function* (context) {
         const input = context.df.getInput() as df.DurableHttpRequest;
-        const output = yield context.df.callHttp(
-            input.method,
-            input.uri,
-            input.content,
-            input.headers,
-            input.tokenSource,
-            input.asynchronousPatternEnabled
-        );
+        const output = yield context.df.callHttp({
+            method: input.method,
+            url: input.uri,
+            body: input.content,
+            headers: input.headers,
+            tokenSource: input.tokenSource,
+            asynchronousPatternEnabled: input.asynchronousPatternEnabled,
+        });
         return output;
     });
 


### PR DESCRIPTION
Following the lead of #415 and #429, this PR also switches the `context.df.callHttp()` on orchestration contexts from using explicit arguments to using one options argument for all parameters, following the lead of popular frameworks like `axios`

Before (actual sample from our docs [here](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-http-features?tabs=javascript#managed-identities)):

```TS
const restartResponse = yield context.df.callHttp(
        "POST",
        `https://management.azure.com/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.Compute/virtualMachines/${vmName}/restart?api-version=${apiVersion}`,
        undefined, // no request content
        undefined, // no request headers (besides auth which is handled by the token source)
        tokenSource
);
```

After:

```TS
const restartResponse = yield context.df.callHttp({
        method: "POST",
        url: `https://management.azure.com/subscriptions/${subscriptionId}/resourceGroups/${resourceGroup}/providers/Microsoft.Compute/virtualMachines/${vmName}/restart?api-version=${apiVersion}`,
        tokenSource,
});
```

Changes that were made in this PR:

* Now accepting an options argument inside of 5 different arguments
* Renamed `uri` to `url`
* Renamed `content` to `body` (I'm assuming that's what "request content" meant?)


If there are other (breaking) changes we want to make to the `callHttp` API, now is the time to call them out. For example:
* Do we want to follow `@azure/functions`'s lead and accept an `undici` `HttpHeaders` type for `headers` parameter instead of an object of strings?
* Do we want to rename the `asynchronousPatternEnabled` argument? It always felt like a confusing name to me, but this is the same the extension uses.