### PR TITLE
Add enablePolling property to CallHttpOptions

### DIFF
--- a/src/durableorchestrationcontext.ts
+++ b/src/durableorchestrationcontext.ts
@@ -305,15 +305,19 @@ export class DurableOrchestrationContext {
             content = JSON.stringify(content);
         }
 
+        let enablePolling = true;
+        if (options.enablePolling !== undefined) {
+            enablePolling = options.enablePolling;
+        } else if (options.asynchronousPatternEnabled !== undefined) {
+            enablePolling = options.asynchronousPatternEnabled;
+        }
         const request = new DurableHttpRequest(
             options.method,
             options.url,
             content as string,
             options.headers,
             options.tokenSource,
-            options.asynchronousPatternEnabled === undefined
-                ? true
-                : options.asynchronousPatternEnabled
+            enablePolling
         );
         const newAction = new CallHttpAction(request);
         if (this.schemaVersion >= ReplaySchema.V3 && request.asynchronousPatternEnabled) {

--- a/src/types/orchestrationTypes.ts
+++ b/src/types/orchestrationTypes.ts
@@ -52,24 +52,16 @@ export interface CallHttpOptions {
      */
     tokenSource?: TokenSource;
     /**
-     * Specifies whether the Durable extension should continue
-     * polling the request after receiving a 202 response.
-     *
-     * This porperty name replaces the previous `asynchronousPatternEnabled` argument.
-     * If both are specified, this property takes precedence.
+     * Specifies whether to continue polling the request after receiving a 202 response.
+     * This replaces `asynchronousPatternEnabled`. If both are specified,
+     * `enablePolling` takes precedence.
      *
      * @default true
      */
     enablePolling?: boolean;
     /**
-     * Specifies whether the Durable extension should continue
-     * polling the request after receiving a 202 response.
-     *
-     * @deprecated this property name is deprecated.
-     * Please use the new `enablePolling` property instead.
-     * If both are specified, the `enablePolling` property takes precedence.
-     *
-     * @default true
+     * @deprecated use `enablePolling` instead. If both are specified,
+     * `enablePolling` takes precedence.
      */
     asynchronousPatternEnabled?: boolean;
 }

--- a/src/types/orchestrationTypes.ts
+++ b/src/types/orchestrationTypes.ts
@@ -52,7 +52,23 @@ export interface CallHttpOptions {
      */
     tokenSource?: TokenSource;
     /**
-     * Specifies whether the DurableHttpRequest should handle the asynchronous pattern.
+     * Specifies whether the Durable extension should continue
+     * polling the request after receiving a 202 response.
+     *
+     * This porperty name replaces the previous `asynchronousPatternEnabled` argument.
+     * If both are specified, this property takes precedence.
+     *
+     * @default true
+     */
+    enablePolling?: boolean;
+    /**
+     * Specifies whether the Durable extension should continue
+     * polling the request after receiving a 202 response.
+     *
+     * @deprecated this property name is deprecated.
+     * Please use the new `enablePolling` property instead.
+     * If both are specified, the `enablePolling` property takes precedence.
+     *
      * @default true
      */
     asynchronousPatternEnabled?: boolean;

--- a/test/testobjects/TestOrchestrations.ts
+++ b/test/testobjects/TestOrchestrations.ts
@@ -324,7 +324,7 @@ export class TestOrchestrations {
             body: input.content,
             headers: input.headers,
             tokenSource: input.tokenSource,
-            asynchronousPatternEnabled: input.asynchronousPatternEnabled,
+            enablePolling: input.asynchronousPatternEnabled,
         });
         return output;
     });


### PR DESCRIPTION
Resolves #439. 

* Adds an `enablePolling` property to `CallHttpOptions` (accepted as an argument to `context.df.callHttp()`)
* Adds a `@deprecated` flag to the `asynchronousPatternEnabled` property, directing users to use the new name
* Updates the `callHttp()` implementation so that `enablePolling` takes precedence, followed by `asynchronousPatternEnabled`, while still defaulting to `true` if none are set.