### PR TITLE
Remove IHttpRequest and IHttpResponse interfaces

### DIFF
--- a/src/classes.ts
+++ b/src/classes.ts
@@ -50,9 +50,6 @@ export { OrchestrationClientInputData } from "./orchestrationclientinputdata";
 export { HttpCreationPayload } from "./httpcreationpayload";
 export { HttpManagementPayload } from "./httpmanagementpayload";
 
-export { IHttpRequest } from "./ihttprequest";
-export { IHttpResponse } from "./ihttpresponse";
-
 export { DurableOrchestrationStatus } from "./durableorchestrationstatus";
 export { OrchestrationRuntimeStatus } from "./orchestrationruntimestatus";
 export { PurgeHistoryResult } from "./purgehistoryresult";

--- a/src/ihttprequest.ts
+++ b/src/ihttprequest.ts
@@ -1,5 +1,0 @@
-export interface IHttpRequest {
-    http: {
-        url: string;
-    };
-}

--- a/src/ihttpresponse.ts
+++ b/src/ihttpresponse.ts
@@ -1,5 +1,0 @@
-export interface IHttpResponse {
-    status: number;
-    body: unknown;
-    headers?: object;
-}

--- a/test/unit/orchestrationclient-spec.ts
+++ b/test/unit/orchestrationclient-spec.ts
@@ -90,32 +90,6 @@ describe("Orchestration Client", () => {
             expect(response.headers.get("Retry-After")).to.equal("10");
         });
 
-        it(`returns a proper response object from request.http.url`, async () => {
-            const client = new DurableOrchestrationClient(defaultClientInputData);
-            const requestObj = {
-                http: {
-                    url: defaultRequestUrl,
-                    method: "GET",
-                },
-            };
-
-            const response = client.createCheckStatusResponse(requestObj, defaultInstanceId);
-            const responseBody = await response.json();
-
-            const expectedPayload = TestUtils.createHttpManagementPayload(
-                defaultInstanceId,
-                Constants.DefaultLocalOrigin,
-                defaultTaskHub,
-                defaultConnection
-            );
-
-            expect(response.status).to.equal(202);
-            expect(responseBody).to.deep.equal(expectedPayload);
-            expect(response.headers.get("Content-Type")).to.equal("application/json");
-            expect(response.headers.get("Location")).to.equal(expectedPayload.statusQueryGetUri);
-            expect(response.headers.get("Retry-After")).to.equal("10");
-        });
-
         it("returns a proper response object when request is undefined", async () => {
             const client = new DurableOrchestrationClient(defaultClientInputData);
 
@@ -1160,21 +1134,17 @@ describe("Orchestration Client", () => {
 
             nock(Constants.DefaultLocalOrigin).get(/.*/).reply(202, expectedStatus);
 
-            const expectedResponse = {
-                status: 200,
-                body: JSON.stringify(expectedOutput),
-                headers: {
-                    "Content-Type": "application/json",
-                },
-            };
-
             const res = await client.waitForCompletionOrCreateCheckStatusResponse(
                 defaultRequest,
                 defaultInstanceId,
                 defaultTimeout,
                 defaultInterval
             );
-            expect(res).to.be.deep.equal(expectedResponse);
+
+            const body = await res.json();
+            expect(res.status).to.equal(200);
+            expect(body).to.equal(JSON.stringify(expectedOutput));
+            expect(res.headers.get("Content-Type")).to.equal("application/json");
         });
 
         it("returns expected result for canceled instance", async () => {
@@ -1193,13 +1163,6 @@ describe("Orchestration Client", () => {
             nock(Constants.DefaultLocalOrigin).get(/.*/).reply(202, expectedStatus);
 
             const expectedStatusAsJson = JSON.stringify(expectedStatus);
-            const expectedResponse = {
-                status: 200,
-                body: expectedStatusAsJson,
-                headers: {
-                    "Content-Type": "application/json",
-                },
-            };
 
             const res = await client.waitForCompletionOrCreateCheckStatusResponse(
                 defaultRequest,
@@ -1207,7 +1170,11 @@ describe("Orchestration Client", () => {
                 defaultTimeout,
                 defaultInterval
             );
-            expect(res).to.be.deep.equal(expectedResponse);
+
+            const body = await res.json();
+            expect(res.status).to.equal(200);
+            expect(body).to.equal(expectedStatusAsJson);
+            expect(res.headers.get("Content-Type")).to.equal("application/json");
         });
 
         it("returns expected result for terminated instance", async () => {
@@ -1226,13 +1193,6 @@ describe("Orchestration Client", () => {
             nock(Constants.DefaultLocalOrigin).get(/.*/).reply(202, expectedStatus);
 
             const expectedStatusAsJson = JSON.stringify(expectedStatus);
-            const expectedResponse = {
-                status: 200,
-                body: expectedStatusAsJson,
-                headers: {
-                    "Content-Type": "application/json",
-                },
-            };
 
             const res = await client.waitForCompletionOrCreateCheckStatusResponse(
                 defaultRequest,
@@ -1240,7 +1200,11 @@ describe("Orchestration Client", () => {
                 defaultTimeout,
                 defaultInterval
             );
-            expect(res).to.be.deep.equal(expectedResponse);
+
+            const body = await res.json();
+            expect(res.status).to.equal(200);
+            expect(body).to.equal(expectedStatusAsJson);
+            expect(res.headers.get("Content-Type")).to.equal("application/json");
         });
 
         it("returns expected result for failed instance", async () => {
@@ -1259,13 +1223,6 @@ describe("Orchestration Client", () => {
             nock(Constants.DefaultLocalOrigin).get(/.*/).reply(202, expectedStatus);
 
             const expectedStatusAsJson = JSON.stringify(expectedStatus);
-            const expectedResponse = {
-                status: 500,
-                body: expectedStatusAsJson,
-                headers: {
-                    "Content-Type": "application/json",
-                },
-            };
 
             const res = await client.waitForCompletionOrCreateCheckStatusResponse(
                 defaultRequest,
@@ -1273,7 +1230,11 @@ describe("Orchestration Client", () => {
                 defaultTimeout,
                 defaultInterval
             );
-            expect(res).to.be.deep.equal(expectedResponse);
+
+            const body = await res.json();
+            expect(res.status).to.equal(500);
+            expect(body).to.equal(expectedStatusAsJson);
+            expect(res.headers.get("Content-Type")).to.equal("application/json");
         });
 
         it("continues polling for running instance", async () => {
@@ -1318,21 +1279,17 @@ describe("Orchestration Client", () => {
                     "Content-Type": "application/json",
                 });
 
-            const expectedResponse = {
-                status: 200,
-                body: JSON.stringify(expectedOutput),
-                headers: {
-                    "Content-Type": "application/json",
-                },
-            };
-
             const res = await client.waitForCompletionOrCreateCheckStatusResponse(
                 defaultRequest,
                 defaultInstanceId,
                 defaultTimeout,
                 defaultInterval
             );
-            expect(res).to.be.deep.equal(expectedResponse);
+
+            const body = await res.json();
+            expect(res.status).to.equal(200);
+            expect(body).to.equal(JSON.stringify(expectedOutput));
+            expect(res.headers.get("Content-Type")).to.equal("application/json");
             expect(scope.isDone()).to.be.equal(true);
         });
 


### PR DESCRIPTION
Resolves #454. This PR removes the `IHttpResponse` and `IHttpRequest` object, and instead relies on the `HttpResponse` and `HttpRequest` objects from `@azure/functions` (respectively). Since this affects the type signatures of public APIs, this _is_ a breaking change, but we discussed offline, and we decided this is a breaking change worth pursuing. In most cases, this should actually _help_ customers, since the expected `HttpRequest` argument to APIs is usually the request object given to the client functions (which now has `HttpRequest` type), and the `HttpResponse` type is usually passed as the return value of the function, which now is expected to be `HttpResponse`. I'm not sure why the `IHttpResponse` and `IHttpRequest` types were honored/respected before, but I've removed the checks/tests related to that as well. 