### PR TITLE
Add signalEntity support to v3

### DIFF
--- a/src/actions/actiontype.ts
+++ b/src/actions/actiontype.ts
@@ -17,8 +17,8 @@ export enum ActionType {
     WaitForExternalEvent = 6,
     CallEntity = 7,
     CallHttp = 8,
-    // ActionType 9 and 10 correspond to SignalEntity and ScheduledSignalEntity
-    // Those two are not supported yet.
+    SignalEntity = 9,
+    // ActionType 10 corresponds to ScheduledSignalEntity, which is not supported yet
     WhenAny = 11,
     WhenAll = 12,
 }

--- a/src/actions/signalentityaction.ts
+++ b/src/actions/signalentityaction.ts
@@ -10,7 +10,7 @@ export class SignalEntityAction implements IAction {
         if (!entityId) {
             throw new Error("Must provide EntityId to SignalEntityAction constructor");
         }
-        this.input = Utils.processInput(input);
+        this.input = input;
         Utils.throwIfEmpty(operation, "operation");
         this.instanceId = EntityId.getSchedulerIdFromEntityId(entityId);
     }

--- a/src/actions/signalentityaction.ts
+++ b/src/actions/signalentityaction.ts
@@ -1,0 +1,17 @@
+import { ActionType, EntityId, IAction, Utils } from "../classes";
+
+/** @hidden */
+export class SignalEntityAction implements IAction {
+    public readonly actionType: ActionType = ActionType.SignalEntity;
+    public readonly instanceId: string;
+    public readonly input: unknown;
+
+    constructor(entityId: EntityId, public readonly operation: string, input?: unknown) {
+        if (!entityId) {
+            throw new Error("Must provide EntityId to SignalEntityAction constructor");
+        }
+        this.input = Utils.processInput(input);
+        Utils.throwIfEmpty(operation, "operation");
+        this.instanceId = EntityId.getSchedulerIdFromEntityId(entityId);
+    }
+}

--- a/src/durableorchestrationcontext.ts
+++ b/src/durableorchestrationcontext.ts
@@ -31,6 +31,7 @@ import {
 import moment = require("moment");
 import { ReplaySchema } from "./replaySchema";
 import { CallHttpOptions, Task, TimerTask } from "./types";
+import { SignalEntityAction } from "./actions/signalentityaction";
 
 /**
  * Parameter data for orchestration bindings that can be used to schedule
@@ -237,6 +238,19 @@ export class DurableOrchestrationContext {
         const newAction = new CallEntityAction(entityId, operationName, operationInput);
         const task = new AtomicTask(false, newAction);
         return task;
+    }
+
+    /**
+     * Send a signal operation to a Durable Entity, passing an argument, without
+     * waiting for a response. A fire-and-forget operation.
+     *
+     * @param entityId ID of the target entity.
+     * @param operationName The name of the operation.
+     * @param operationInput (optional) input for the operation.
+     */
+    public signalEntity(entityId: EntityId, operationName: string, operationInput?: unknown): void {
+        const action = new SignalEntityAction(entityId, operationName, operationInput);
+        this.taskOrchestratorExecutor.recordFireAndForgetAction(action);
     }
 
     /**

--- a/test/integration/orchestrator-spec.ts
+++ b/test/integration/orchestrator-spec.ts
@@ -59,34 +59,32 @@ describe("Orchestrator", () => {
 
     it("doesn't allow yielding non-Task types", async () => {
         const orchestrator = TestOrchestrations.YieldInteger;
-        const mockContext = new MockContext({
-            context: new DurableOrchestrationBindingInfo(
-                TestHistories.StarterHistory(moment.utc().toDate())
-            ),
-        });
-
-        orchestrator(mockContext);
+        const mockContext = new DummyOrchestrationContext();
+        const orchestrationInput = new DurableOrchestrationInput(
+            "",
+            TestHistories.StarterHistory(moment.utc().toDate())
+        );
 
         const errorMsg =
             `Durable Functions programming constraint violation: Orchestration yielded data of type number.` +
             " Only Task types can be yielded. Please check your yield statements to make sure you only yield Task types resulting from calling Durable Functions APIs.";
 
-        const expectedErr = new OrchestrationFailureError(
-            false,
-            new OrchestratorState(
-                {
-                    isDone: false,
-                    actions: [],
-                    schemaVersion: ReplaySchema.V1,
-                    error: errorMsg,
-                    output: undefined,
-                },
-                true
-            )
-        );
-
-        expect(mockContext.doneValue).to.be.undefined;
-        expect(mockContext.err?.toString()).to.equal(expectedErr.toString());
+        let errored = false;
+        try {
+            await orchestrator(orchestrationInput, mockContext);
+        } catch (err) {
+            errored = true;
+            expect(err).to.be.an.instanceOf(OrchestrationFailureError);
+            const orchestrationState = TestUtils.extractStateFromError(
+                err as OrchestrationFailureError
+            );
+            expect(orchestrationState).to.be.an("object").that.deep.include({
+                isDone: false,
+                actions: [],
+            });
+            expect(orchestrationState.error).to.include(errorMsg);
+        }
+        expect(errored).to.be.true;
     });
 
     it("handles a simple orchestration function (no activity functions)", async () => {
@@ -1328,28 +1326,28 @@ describe("Orchestrator", () => {
     });
 
     describe("signalEntity()", () => {
-        it("scheduled a SignalEntity action", () => {
+        it("scheduled a SignalEntity action", async () => {
             const orchestrator = TestOrchestrations.signalEntity;
             const entityName = "Counter";
             const id = "1234";
             const expectedEntity = new EntityId(entityName, id);
             const operationName = "add";
             const operationArgument = 1;
-            const mockContext = new MockContext({
-                context: new DurableOrchestrationBindingInfo(
-                    TestHistories.GetOrchestratorStart("signalEntity", new Date()),
-                    {
-                        id,
-                        entityName,
-                        operationName,
-                        operationArgument,
-                    }
-                ),
-            });
+            const mockContext = new DummyOrchestrationContext();
+            const orchestrationInput = new DurableOrchestrationInput(
+                "",
+                TestHistories.GetOrchestratorStart("signalEntity", new Date()),
+                {
+                    id,
+                    entityName,
+                    operationName,
+                    operationArgument,
+                }
+            );
 
-            orchestrator(mockContext);
+            const result = await orchestrator(orchestrationInput, mockContext);
 
-            expect(mockContext.doneValue).to.deep.equal(
+            expect(result).to.deep.equal(
                 new OrchestratorState(
                     {
                         isDone: true,
@@ -1370,37 +1368,45 @@ describe("Orchestrator", () => {
             );
         });
 
-        it("doesn't allow signalEntity() to be yielded", () => {
+        it("doesn't allow signalEntity() to be yielded", async () => {
             const orchestrator = TestOrchestrations.signalEntityYield;
             const entityName = "Counter";
             const id = "1234";
             const expectedEntity = new EntityId(entityName, id);
             const operationName = "add";
             const operationArgument = 1;
-            const mockContext = new MockContext({
-                context: new DurableOrchestrationBindingInfo(
-                    TestHistories.GetOrchestratorStart("signalEntity", new Date()),
-                    {
-                        id,
-                        entityName,
-                        operationName,
-                        operationArgument,
-                    }
-                ),
-            });
+            const mockContext = new DummyOrchestrationContext();
+            const orchestrationInput = new DurableOrchestrationInput(
+                "",
+                TestHistories.GetOrchestratorStart("signalEntity", new Date()),
+                {
+                    id,
+                    entityName,
+                    operationName,
+                    operationArgument,
+                }
+            );
 
-            orchestrator(mockContext);
+            let errored = false;
+            try {
+                await orchestrator(orchestrationInput, mockContext);
+            } catch (err) {
+                errored = true;
+                const errorMsg =
+                    `Durable Functions programming constraint violation: Orchestration yielded data of type undefined.` +
+                    ' This is likely a result of yielding a "fire-and-forget API" such as signalEntity or continueAsNew.' +
+                    " These APIs should not be yielded as they are not blocking operations. Please remove the yield statement preceding those invocations." +
+                    " If you are not calling those APIs, please check your yield statements to make sure you only yield Task types resulting from calling Durable Functions APIs.";
 
-            const errorMsg =
-                `Durable Functions programming constraint violation: Orchestration yielded data of type undefined.` +
-                ' This is likely a result of yielding a "fire-and-forget API" such as signalEntity or continueAsNew.' +
-                " These APIs should not be yielded as they are not blocking operations. Please remove the yield statement preceding those invocations." +
-                " If you are not calling those APIs, please check your yield statements to make sure you only yield Task types resulting from calling Durable Functions APIs.";
+                expect(err).to.be.an.instanceOf(OrchestrationFailureError);
 
-            const expectedErr = new OrchestrationFailureError(
-                false,
-                new OrchestratorState(
-                    {
+                const orchestrationState = TestUtils.extractStateFromError(
+                    err as OrchestrationFailureError
+                );
+
+                expect(orchestrationState)
+                    .to.be.an("object")
+                    .that.deep.include({
                         isDone: false,
                         actions: [
                             [
@@ -1413,14 +1419,10 @@ describe("Orchestrator", () => {
                         ],
                         schemaVersion: ReplaySchema.V1,
                         error: errorMsg,
-                        output: undefined,
-                    },
-                    true
-                )
-            );
-
-            expect(mockContext.doneValue).to.be.undefined;
-            expect(mockContext.err?.toString()).to.equal(expectedErr.toString());
+                    });
+                expect(orchestrationState.error).to.include(errorMsg);
+            }
+            expect(errored).to.be.true;
         });
     });
 

--- a/test/testobjects/TestOrchestrations.ts
+++ b/test/testobjects/TestOrchestrations.ts
@@ -6,6 +6,10 @@ export class TestOrchestrations {
         return "Hello";
     });
 
+    public static YieldInteger: any = createOrchestrator(function* () {
+        yield 4;
+    });
+
     public static AnyAOrB: any = createOrchestrator(function* (context: any) {
         const completeInOrder = context.df.getInput();
 
@@ -102,6 +106,20 @@ export class TestOrchestrations {
         context.df.continueAsNew({ value: currentValue });
 
         return currentValue;
+    });
+
+    public static signalEntity: any = createOrchestrator(function* (context: any) {
+        const { id, entityName, operationName, operationArgument } = context.df.getInput();
+        const entityId = new df.EntityId(entityName, id);
+        context.df.signalEntity(entityId, operationName, operationArgument);
+        return;
+    });
+
+    public static signalEntityYield: any = createOrchestrator(function* (context: any) {
+        const { id, entityName, operationName, operationArgument } = context.df.getInput();
+        const entityId = new df.EntityId(entityName, id);
+        yield context.df.signalEntity(entityId, operationName, operationArgument);
+        return;
     });
 
     public static FanOutFanInDiskUsage: any = createOrchestrator(function* (context: any) {


### PR DESCRIPTION
Cherry-pick of #383. Feature was added to `v2.x` after `v3.x` was branched off of it. Also took the chance to fix the same double serialization issue in this API too.