### PR TITLE
Switch to using an options object for all applicable APIs

### DIFF
--- a/src/durableorchestrationclient.ts
+++ b/src/durableorchestrationclient.ts
@@ -222,11 +222,7 @@ export class DurableOrchestrationClient implements DurableClient {
     public async getStatusBy(
         selectionOptions: SelectionOptions
     ): Promise<DurableOrchestrationStatus[]> {
-        const internalOptions: GetStatusInternalOptions = {
-            ...selectionOptions,
-        };
-
-        const response = await this.getStatusInternal(internalOptions);
+        const response = await this.getStatusInternal(selectionOptions);
         switch (response.status) {
             case 200:
                 return response.data as DurableOrchestrationStatus[];

--- a/src/durableorchestrationclient.ts
+++ b/src/durableorchestrationclient.ts
@@ -217,10 +217,8 @@ export class DurableOrchestrationClient implements DurableClient {
         }
     }
 
-    public async getStatusBy(
-        filterOptions: OrchestrationFilter
-    ): Promise<DurableOrchestrationStatus[]> {
-        const response = await this.getStatusInternal(filterOptions);
+    public async getStatusBy(filter: OrchestrationFilter): Promise<DurableOrchestrationStatus[]> {
+        const response = await this.getStatusInternal(filter);
         switch (response.status) {
             case 200:
                 return response.data as DurableOrchestrationStatus[];
@@ -252,11 +250,9 @@ export class DurableOrchestrationClient implements DurableClient {
         }
     }
 
-    public async purgeInstanceHistoryBy(
-        filterOptions: OrchestrationFilter
-    ): Promise<PurgeHistoryResult> {
+    public async purgeInstanceHistoryBy(filter: OrchestrationFilter): Promise<PurgeHistoryResult> {
         let requestUrl: string;
-        const { createdTimeFrom, createdTimeTo, runtimeStatus } = filterOptions;
+        const { createdTimeFrom, createdTimeTo, runtimeStatus } = filter;
         if (this.clientData.rpcBaseUrl) {
             // Fast local RPC path
             let path = new URL("instances/", this.clientData.rpcBaseUrl).href;

--- a/src/durableorchestrationclient.ts
+++ b/src/durableorchestrationclient.ts
@@ -27,7 +27,6 @@ import {
     DurableClient,
     GetStatusOptions,
     SelectionOptions,
-    RaiseEventOptions,
     TaskHubOptions,
     SignalEntityOptions,
     WaitForCompletionOptions,
@@ -321,8 +320,13 @@ export class DurableOrchestrationClient implements DurableClient {
         }
     }
 
-    public async raiseEvent(options: RaiseEventOptions): Promise<void> {
-        const { eventName, instanceId, eventData, taskHubName, connectionName } = options;
+    public async raiseEvent(
+        instanceId: string,
+        eventName: string,
+        eventData: unknown,
+        options: TaskHubOptions = {}
+    ): Promise<void> {
+        const { taskHubName, connectionName } = options;
         if (!eventName) {
             throw new Error("eventName must be a valid string.");
         }

--- a/src/durableorchestrationclient.ts
+++ b/src/durableorchestrationclient.ts
@@ -599,8 +599,14 @@ export class DurableOrchestrationClient implements DurableClient {
         instanceId: string,
         waitOptions: WaitForCompletionOptions = {}
     ): Promise<HttpResponse> {
-        const timeoutInMilliseconds: number = waitOptions.timeoutInMilliseconds || 10000;
-        const retryIntervalInMilliseconds: number = waitOptions.retryIntervalInMilliseconds || 1000;
+        const timeoutInMilliseconds: number =
+            waitOptions.timeoutInMilliseconds !== undefined
+                ? waitOptions.timeoutInMilliseconds
+                : 10000;
+        const retryIntervalInMilliseconds: number =
+            waitOptions.retryIntervalInMilliseconds !== undefined
+                ? waitOptions.retryIntervalInMilliseconds
+                : 1000;
 
         if (retryIntervalInMilliseconds > timeoutInMilliseconds) {
             throw new Error(

--- a/src/durableorchestrationclient.ts
+++ b/src/durableorchestrationclient.ts
@@ -26,7 +26,7 @@ import {
     DurableClientInput,
     DurableClient,
     GetStatusOptions,
-    SelectionOptions,
+    OrchestrationFilter,
     TaskHubOptions,
     SignalEntityOptions,
     WaitForCompletionOptions,
@@ -219,9 +219,9 @@ export class DurableOrchestrationClient implements DurableClient {
     }
 
     public async getStatusBy(
-        selectionOptions: SelectionOptions
+        filterOptions: OrchestrationFilter
     ): Promise<DurableOrchestrationStatus[]> {
-        const response = await this.getStatusInternal(selectionOptions);
+        const response = await this.getStatusInternal(filterOptions);
         switch (response.status) {
             case 200:
                 return response.data as DurableOrchestrationStatus[];
@@ -254,10 +254,10 @@ export class DurableOrchestrationClient implements DurableClient {
     }
 
     public async purgeInstanceHistoryBy(
-        selectionOptions: SelectionOptions
+        filterOptions: OrchestrationFilter
     ): Promise<PurgeHistoryResult> {
         let requestUrl: string;
-        const { createdTimeFrom, createdTimeTo, runtimeStatus } = selectionOptions;
+        const { createdTimeFrom, createdTimeTo, runtimeStatus } = filterOptions;
         if (this.clientData.rpcBaseUrl) {
             // Fast local RPC path
             let path = new URL("instances/", this.clientData.rpcBaseUrl).href;

--- a/src/durableorchestrationclient.ts
+++ b/src/durableorchestrationclient.ts
@@ -28,7 +28,6 @@ import {
     GetStatusOptions,
     OrchestrationFilter,
     TaskHubOptions,
-    SignalEntityOptions,
     WaitForCompletionOptions,
 } from "durable-functions";
 import { WebhookUtils } from "./webhookutils";
@@ -478,9 +477,11 @@ export class DurableOrchestrationClient implements DurableClient {
 
     public async signalEntity(
         entityId: EntityId,
-        options: SignalEntityOptions = {}
+        operationName?: string,
+        operationContent?: unknown,
+        options: TaskHubOptions = {}
     ): Promise<void> {
-        const { operationName, operationContent, taskHubName, connectionName } = options;
+        const { taskHubName, connectionName } = options;
         let requestUrl: string;
         if (this.clientData.rpcBaseUrl) {
             // Fast local RPC path

--- a/src/durableorchestrationcontext.ts
+++ b/src/durableorchestrationcontext.ts
@@ -30,7 +30,7 @@ import {
 } from "./task";
 import moment = require("moment");
 import { ReplaySchema } from "./replaySchema";
-import { CallHttpOptions, Task, TimerTask } from "durable-functions";
+import { CallHttpOptions, CallSubOrchestratorOptions, Task, TimerTask } from "durable-functions";
 import * as types from "durable-functions";
 import { SignalEntityAction } from "./actions/signalentityaction";
 
@@ -176,14 +176,14 @@ export class DurableOrchestrationContext implements types.DurableOrchestrationCo
         this.taskOrchestratorExecutor.recordFireAndForgetAction(action);
     }
 
-    public callSubOrchestrator(name: string, input?: unknown, instanceId?: string): Task {
+    public callSubOrchestrator(name: string, options: CallSubOrchestratorOptions = {}): Task {
         if (!name) {
             throw new Error(
                 "A sub-orchestration function name must be provided when attempting to create a suborchestration"
             );
         }
 
-        const newAction = new CallSubOrchestratorAction(name, instanceId, input);
+        const newAction = new CallSubOrchestratorAction(name, options.instanceId, options.input);
         const task = new AtomicTask(false, newAction);
         return task;
     }
@@ -191,8 +191,7 @@ export class DurableOrchestrationContext implements types.DurableOrchestrationCo
     public callSubOrchestratorWithRetry(
         name: string,
         retryOptions: RetryOptions,
-        input?: unknown,
-        instanceId?: string
+        options: CallSubOrchestratorOptions = {}
     ): Task {
         if (!name) {
             throw new Error(
@@ -203,8 +202,8 @@ export class DurableOrchestrationContext implements types.DurableOrchestrationCo
         const newAction = new CallSubOrchestratorWithRetryAction(
             name,
             retryOptions,
-            input,
-            instanceId
+            options.input,
+            options.instanceId
         );
         const backingTask = new AtomicTask(false, newAction);
         const task = new RetryableTask(backingTask, retryOptions, this.taskOrchestratorExecutor);

--- a/src/durableorchestrationcontext.ts
+++ b/src/durableorchestrationcontext.ts
@@ -30,7 +30,7 @@ import {
 } from "./task";
 import moment = require("moment");
 import { ReplaySchema } from "./replaySchema";
-import { CallHttpOptions, CallSubOrchestratorOptions, Task, TimerTask } from "durable-functions";
+import { CallHttpOptions, Task, TimerTask } from "durable-functions";
 import * as types from "durable-functions";
 import { SignalEntityAction } from "./actions/signalentityaction";
 
@@ -176,14 +176,14 @@ export class DurableOrchestrationContext implements types.DurableOrchestrationCo
         this.taskOrchestratorExecutor.recordFireAndForgetAction(action);
     }
 
-    public callSubOrchestrator(name: string, options: CallSubOrchestratorOptions = {}): Task {
+    public callSubOrchestrator(name: string, input?: unknown, instanceId?: string): Task {
         if (!name) {
             throw new Error(
                 "A sub-orchestration function name must be provided when attempting to create a suborchestration"
             );
         }
 
-        const newAction = new CallSubOrchestratorAction(name, options.instanceId, options.input);
+        const newAction = new CallSubOrchestratorAction(name, instanceId, input);
         const task = new AtomicTask(false, newAction);
         return task;
     }
@@ -191,7 +191,8 @@ export class DurableOrchestrationContext implements types.DurableOrchestrationCo
     public callSubOrchestratorWithRetry(
         name: string,
         retryOptions: RetryOptions,
-        options: CallSubOrchestratorOptions = {}
+        input?: unknown,
+        instanceId?: string
     ): Task {
         if (!name) {
             throw new Error(
@@ -202,8 +203,8 @@ export class DurableOrchestrationContext implements types.DurableOrchestrationCo
         const newAction = new CallSubOrchestratorWithRetryAction(
             name,
             retryOptions,
-            options.input,
-            options.instanceId
+            input,
+            instanceId
         );
         const backingTask = new AtomicTask(false, newAction);
         const task = new RetryableTask(backingTask, retryOptions, this.taskOrchestratorExecutor);

--- a/test/testobjects/TestOrchestrations.ts
+++ b/test/testobjects/TestOrchestrations.ts
@@ -1,5 +1,5 @@
 import * as df from "../../src";
-import { OrchestrationContext } from "durable-functions";
+import { OrchestrationContext, OrchestrationHandler } from "durable-functions";
 import { createOrchestrator } from "../../src/shim";
 
 export class TestOrchestrations {
@@ -267,18 +267,23 @@ export class TestOrchestrations {
         return output;
     });
 
-    public static SayHelloWithSubOrchestrator: any = createOrchestrator(function* (context: any) {
+    public static SayHelloWithSubOrchestrator = createOrchestrator(function* (
+        context: OrchestrationContext
+    ) {
         const input = context.df.getInput();
         const childId = context.df.instanceId + ":0";
-        const output = yield context.df.callSubOrchestrator("SayHelloWithActivity", input, childId);
+        const output = yield context.df.callSubOrchestrator("SayHelloWithActivity", {
+            input,
+            instanceId: childId,
+        });
         return output;
     });
 
-    public static SayHelloWithSubOrchestratorNoSubId: any = createOrchestrator(function* (
-        context: any
+    public static SayHelloWithSubOrchestratorNoSubId = createOrchestrator(function* (
+        context: OrchestrationContext
     ) {
         const input = context.df.getInput();
-        const output = yield context.df.callSubOrchestrator("SayHelloWithActivity", input);
+        const output = yield context.df.callSubOrchestrator("SayHelloWithActivity", { input });
         return output;
     });
 
@@ -288,10 +293,18 @@ export class TestOrchestrations {
         const input = context.df.getInput();
         const subOrchName1 = "SayHelloWithActivity";
         const subOrchName2 = "SayHelloInline";
-        const output = context.df.callSubOrchestrator(subOrchName1, `${input}_${subOrchName1}_0`);
-        const output2 = context.df.callSubOrchestrator(subOrchName2, `${input}_${subOrchName2}_1`);
-        const output3 = context.df.callSubOrchestrator(subOrchName1, `${input}_${subOrchName1}_2`);
-        const output4 = context.df.callSubOrchestrator(subOrchName2, `${input}_${subOrchName2}_3`);
+        const output = context.df.callSubOrchestrator(subOrchName1, {
+            input: `${input}_${subOrchName1}_0`,
+        });
+        const output2 = context.df.callSubOrchestrator(subOrchName2, {
+            input: `${input}_${subOrchName2}_1`,
+        });
+        const output3 = context.df.callSubOrchestrator(subOrchName1, {
+            input: `${input}_${subOrchName1}_2`,
+        });
+        const output4 = context.df.callSubOrchestrator(subOrchName2, {
+            input: `${input}_${subOrchName2}_3`,
+        });
         return yield context.df.Task.all([output, output2, output3, output4]);
     });
 
@@ -304,8 +317,7 @@ export class TestOrchestrations {
         const output = yield context.df.callSubOrchestratorWithRetry(
             "SayHelloInline",
             retryOptions,
-            input,
-            childId
+            { input, instanceId: childId }
         );
         return output;
     });
@@ -316,10 +328,14 @@ export class TestOrchestrations {
         const retryOptions = new df.RetryOptions(100, 5);
         const output = [];
         output.push(
-            context.df.callSubOrchestratorWithRetry("SayHelloInline", retryOptions, "Tokyo")
+            context.df.callSubOrchestratorWithRetry("SayHelloInline", retryOptions, {
+                input: "Tokyo",
+            })
         );
         output.push(
-            context.df.callSubOrchestratorWithRetry("SayHelloInline", retryOptions, "Seattle")
+            context.df.callSubOrchestratorWithRetry("SayHelloInline", retryOptions, {
+                input: "Seattle",
+            })
         );
         return yield context.df.Task.all(output);
     });
@@ -328,12 +344,10 @@ export class TestOrchestrations {
         context: any
     ) {
         const childId = context.df.instanceId + ":0";
-        const output = yield context.df.callSubOrchestratorWithRetry(
-            "SayHelloInline",
-            undefined,
-            "World",
-            childId
-        );
+        const output = yield context.df.callSubOrchestratorWithRetry("SayHelloInline", undefined, {
+            input: "World",
+            instanceId: childId,
+        });
         return output;
     });
 

--- a/test/testobjects/TestOrchestrations.ts
+++ b/test/testobjects/TestOrchestrations.ts
@@ -272,10 +272,7 @@ export class TestOrchestrations {
     ) {
         const input = context.df.getInput();
         const childId = context.df.instanceId + ":0";
-        const output = yield context.df.callSubOrchestrator("SayHelloWithActivity", {
-            input,
-            instanceId: childId,
-        });
+        const output = yield context.df.callSubOrchestrator("SayHelloWithActivity", input, childId);
         return output;
     });
 
@@ -283,7 +280,7 @@ export class TestOrchestrations {
         context: OrchestrationContext
     ) {
         const input = context.df.getInput();
-        const output = yield context.df.callSubOrchestrator("SayHelloWithActivity", { input });
+        const output = yield context.df.callSubOrchestrator("SayHelloWithActivity", input);
         return output;
     });
 
@@ -293,18 +290,10 @@ export class TestOrchestrations {
         const input = context.df.getInput();
         const subOrchName1 = "SayHelloWithActivity";
         const subOrchName2 = "SayHelloInline";
-        const output = context.df.callSubOrchestrator(subOrchName1, {
-            input: `${input}_${subOrchName1}_0`,
-        });
-        const output2 = context.df.callSubOrchestrator(subOrchName2, {
-            input: `${input}_${subOrchName2}_1`,
-        });
-        const output3 = context.df.callSubOrchestrator(subOrchName1, {
-            input: `${input}_${subOrchName1}_2`,
-        });
-        const output4 = context.df.callSubOrchestrator(subOrchName2, {
-            input: `${input}_${subOrchName2}_3`,
-        });
+        const output = context.df.callSubOrchestrator(subOrchName1, `${input}_${subOrchName1}_0`);
+        const output2 = context.df.callSubOrchestrator(subOrchName2, `${input}_${subOrchName2}_1`);
+        const output3 = context.df.callSubOrchestrator(subOrchName1, `${input}_${subOrchName1}_2`);
+        const output4 = context.df.callSubOrchestrator(subOrchName2, `${input}_${subOrchName2}_3`);
         return yield context.df.Task.all([output, output2, output3, output4]);
     });
 
@@ -317,7 +306,8 @@ export class TestOrchestrations {
         const output = yield context.df.callSubOrchestratorWithRetry(
             "SayHelloInline",
             retryOptions,
-            { input, instanceId: childId }
+            input,
+            childId
         );
         return output;
     });
@@ -328,14 +318,10 @@ export class TestOrchestrations {
         const retryOptions = new df.RetryOptions(100, 5);
         const output = [];
         output.push(
-            context.df.callSubOrchestratorWithRetry("SayHelloInline", retryOptions, {
-                input: "Tokyo",
-            })
+            context.df.callSubOrchestratorWithRetry("SayHelloInline", retryOptions, "Tokyo")
         );
         output.push(
-            context.df.callSubOrchestratorWithRetry("SayHelloInline", retryOptions, {
-                input: "Seattle",
-            })
+            context.df.callSubOrchestratorWithRetry("SayHelloInline", retryOptions, "Seattle")
         );
         return yield context.df.Task.all(output);
     });
@@ -344,10 +330,12 @@ export class TestOrchestrations {
         context: any
     ) {
         const childId = context.df.instanceId + ":0";
-        const output = yield context.df.callSubOrchestratorWithRetry("SayHelloInline", undefined, {
-            input: "World",
-            instanceId: childId,
-        });
+        const output = yield context.df.callSubOrchestratorWithRetry(
+            "SayHelloInline",
+            undefined,
+            "World",
+            childId
+        );
         return output;
     });
 

--- a/test/testobjects/TestOrchestrations.ts
+++ b/test/testobjects/TestOrchestrations.ts
@@ -1,5 +1,5 @@
 import * as df from "../../src";
-import { OrchestrationContext, OrchestrationHandler } from "durable-functions";
+import { OrchestrationContext } from "durable-functions";
 import { createOrchestrator } from "../../src/shim";
 
 export class TestOrchestrations {
@@ -279,7 +279,7 @@ export class TestOrchestrations {
         return output;
     });
 
-    public static SayHelloWithSubOrchestratorNoSubId = createOrchestrator(function* (
+    public static SayHelloWithSubOrchestratorNoSubId: any = createOrchestrator(function* (
         context: OrchestrationContext
     ) {
         const input = context.df.getInput();

--- a/test/unit/durableclient-spec.ts
+++ b/test/unit/durableclient-spec.ts
@@ -135,7 +135,7 @@ describe("Durable client RPC endpoint", () => {
                 .post(expectedUrl.pathname, eventData)
                 .reply(202);
 
-            await client.raiseEvent(instanceId, eventName, eventData);
+            await client.raiseEvent({ instanceId, eventName, eventData });
             expect(scope.isDone()).to.be.equal(true);
         });
 
@@ -160,7 +160,13 @@ describe("Durable client RPC endpoint", () => {
                 .query({ taskHub, connection })
                 .reply(202);
 
-            await client.raiseEvent(instanceId, eventName, eventData, taskHub, connection);
+            await client.raiseEvent({
+                instanceId,
+                eventName,
+                eventData,
+                taskHubName: taskHub,
+                connectionName: connection,
+            });
             expect(scope.isDone()).to.be.equal(true);
         });
     });
@@ -207,7 +213,11 @@ describe("Durable client RPC endpoint", () => {
                     history: [],
                 });
 
-            const result = await client.getStatus(instanceId, true, true, true);
+            const result = await client.getStatus(instanceId, {
+                showHistory: true,
+                showHistoryOutput: true,
+                showInput: true,
+            });
             expect(scope.isDone()).to.be.equal(true);
             expect(result).to.be.an("object");
         });
@@ -237,11 +247,11 @@ describe("Durable client RPC endpoint", () => {
                             status as keyof typeof OrchestrationRuntimeStatus
                         ]
                 );
-            const result = await client.getStatusBy(
-                new Date(createdTimeFrom),
-                new Date(createdTimeTo),
-                statusList
-            );
+            const result = await client.getStatusBy({
+                createdTimeFrom: new Date(createdTimeFrom),
+                createdTimeTo: new Date(createdTimeTo),
+                runtimeStatus: statusList,
+            });
             expect(scope.isDone()).to.be.equal(true);
             expect(result).to.be.an("array");
         });
@@ -293,11 +303,11 @@ describe("Durable client RPC endpoint", () => {
                             status as keyof typeof OrchestrationRuntimeStatus
                         ]
                 );
-            const result = await client.getStatusBy(
-                new Date(createdTimeFrom),
-                new Date(createdTimeTo),
-                statusList
-            );
+            const result = await client.getStatusBy({
+                createdTimeFrom: new Date(createdTimeFrom),
+                createdTimeTo: new Date(createdTimeTo),
+                runtimeStatus: statusList,
+            });
             expect(scopeWithTokenResponse.isDone()).to.be.equal(true);
             expect(scopeNoTokenResponse.isDone()).to.be.equal(true);
             expect(result).to.be.an("array");
@@ -368,11 +378,11 @@ describe("Durable client RPC endpoint", () => {
                             status as keyof typeof OrchestrationRuntimeStatus
                         ]
                 );
-            const result: PurgeHistoryResult = await client.purgeInstanceHistoryBy(
-                new Date(createdTimeFrom),
-                new Date(createdTimeTo),
-                statusList
-            );
+            const result: PurgeHistoryResult = await client.purgeInstanceHistoryBy({
+                createdTimeFrom: new Date(createdTimeFrom),
+                createdTimeTo: new Date(createdTimeTo),
+                runtimeStatus: statusList,
+            });
             expect(scope.isDone()).to.be.equal(true);
             expect(result.instancesDeleted).to.be.equal(10);
         });
@@ -416,7 +426,10 @@ describe("Durable client RPC endpoint", () => {
                 .query({ reason, taskHub, connection })
                 .reply(202);
 
-            await client.rewind(instanceId, reason, taskHub, connection);
+            await client.rewind(instanceId, reason, {
+                taskHubName: taskHub,
+                connectionName: connection,
+            });
             expect(scope.isDone()).to.be.equal(true);
         });
     });
@@ -459,7 +472,12 @@ describe("Durable client RPC endpoint", () => {
                 .query({ op, taskHub, connection })
                 .reply(202);
 
-            await client.signalEntity(entityId, op, payload, taskHub, connection);
+            await client.signalEntity(entityId, {
+                operationName: op,
+                operationContent: payload,
+                taskHubName: taskHub,
+                connectionName: connection,
+            });
             expect(scope.isDone()).to.equal(true);
         });
     });
@@ -506,7 +524,10 @@ describe("Durable client RPC endpoint", () => {
                 .query({ taskHub, connection })
                 .reply(200, expectedEntityState);
 
-            const result = await client.readEntityState(entityId, taskHub, connection);
+            const result = await client.readEntityState(entityId, {
+                taskHubName: taskHub,
+                connectionName: connection,
+            });
             expect(scope.isDone()).to.equal(true);
             expect(result.entityExists).to.equal(true);
             expect(result.entityState).to.deep.equal(expectedEntityState);

--- a/test/unit/durableclient-spec.ts
+++ b/test/unit/durableclient-spec.ts
@@ -135,7 +135,7 @@ describe("Durable client RPC endpoint", () => {
                 .post(expectedUrl.pathname, eventData)
                 .reply(202);
 
-            await client.raiseEvent({ instanceId, eventName, eventData });
+            await client.raiseEvent(instanceId, eventName, eventData);
             expect(scope.isDone()).to.be.equal(true);
         });
 
@@ -160,10 +160,7 @@ describe("Durable client RPC endpoint", () => {
                 .query({ taskHub, connection })
                 .reply(202);
 
-            await client.raiseEvent({
-                instanceId,
-                eventName,
-                eventData,
+            await client.raiseEvent(instanceId, eventName, eventData, {
                 taskHubName: taskHub,
                 connectionName: connection,
             });

--- a/test/unit/durableclient-spec.ts
+++ b/test/unit/durableclient-spec.ts
@@ -469,9 +469,7 @@ describe("Durable client RPC endpoint", () => {
                 .query({ op, taskHub, connection })
                 .reply(202);
 
-            await client.signalEntity(entityId, {
-                operationName: op,
-                operationContent: payload,
+            await client.signalEntity(entityId, op, payload, {
                 taskHubName: taskHub,
                 connectionName: connection,
             });

--- a/test/unit/orchestrationclient-spec.ts
+++ b/test/unit/orchestrationclient-spec.ts
@@ -192,7 +192,9 @@ describe("Orchestration Client", () => {
                 )
                 .reply(202, expectedStatus);
 
-            const result = await client.getStatus(defaultInstanceId, true);
+            const result = await client.getStatus(defaultInstanceId, {
+                showHistory: true,
+            });
             expect(scope.isDone()).to.be.equal(true);
             expect(JSON.stringify(result)).to.be.equal(JSON.stringify(expectedStatus));
         });
@@ -223,7 +225,10 @@ describe("Orchestration Client", () => {
                 )
                 .reply(202, expectedStatus);
 
-            const result = await client.getStatus(defaultInstanceId, false, true);
+            const result = await client.getStatus(defaultInstanceId, {
+                showHistory: false,
+                showHistoryOutput: true,
+            });
             expect(scope.isDone()).to.be.equal(true);
             expect(JSON.stringify(result)).to.be.equal(JSON.stringify(expectedStatus));
         });
@@ -254,7 +259,11 @@ describe("Orchestration Client", () => {
                 )
                 .reply(202, expectedStatus);
 
-            const result = await client.getStatus(defaultInstanceId, false, false, false);
+            const result = await client.getStatus(defaultInstanceId, {
+                showHistory: false,
+                showHistoryOutput: false,
+                showInput: false,
+            });
             expect(scope.isDone()).to.be.equal(true);
             expect(JSON.stringify(result)).to.be.equal(JSON.stringify(expectedStatus));
         });
@@ -352,11 +361,11 @@ describe("Orchestration Client", () => {
                 )
                 .reply(200, expectedStatuses);
 
-            const result = await client.getStatusBy(
+            const result = await client.getStatusBy({
                 createdTimeFrom,
                 createdTimeTo,
-                runtimeStatuses
-            );
+                runtimeStatus: runtimeStatuses,
+            });
             expect(scope.isDone()).to.be.equal(true);
             expect(JSON.stringify(result)).to.be.equal(JSON.stringify(expectedStatuses));
         });
@@ -383,7 +392,7 @@ describe("Orchestration Client", () => {
                 )
                 .reply(200, expectedStatuses);
 
-            const result = await client.getStatusBy(undefined, undefined, runtimeStatuses);
+            const result = await client.getStatusBy({ runtimeStatus: runtimeStatuses });
             expect(scope.isDone()).to.be.equal(true);
             expect(result).to.be.deep.equal(expectedStatuses);
         });
@@ -480,11 +489,11 @@ describe("Orchestration Client", () => {
                 })
                 .reply(200, expectedResult);
 
-            const result = await client.purgeInstanceHistoryBy(
+            const result = await client.purgeInstanceHistoryBy({
                 createdTimeFrom,
                 createdTimeTo,
-                runtimeStatuses
-            );
+                runtimeStatus: runtimeStatuses,
+            });
             expect(scope.isDone()).to.be.equal(true);
             expect(result).to.be.deep.equal(expectedResult);
         });
@@ -514,11 +523,10 @@ describe("Orchestration Client", () => {
                 })
                 .reply(404);
 
-            const result = await client.purgeInstanceHistoryBy(
+            const result = await client.purgeInstanceHistoryBy({
                 createdTimeFrom,
-                undefined,
-                runtimeStatuses
-            );
+                runtimeStatus: runtimeStatuses,
+            });
             expect(scope.isDone()).to.be.equal(true);
             expect(result).to.be.deep.equal(expectedResult);
         });
@@ -552,11 +560,11 @@ describe("Orchestration Client", () => {
                 )
                 .reply(202);
 
-            const result = await client.raiseEvent(
-                defaultInstanceId,
-                defaultTestEvent,
-                defaultTestData
-            );
+            const result = await client.raiseEvent({
+                instanceId: defaultInstanceId,
+                eventName: defaultTestEvent,
+                eventData: defaultTestData,
+            });
             expect(scope.isDone()).to.be.equal(true);
             expect(result).to.be.equal(undefined);
         });
@@ -578,12 +586,12 @@ describe("Orchestration Client", () => {
                 )
                 .reply(202);
 
-            const result = await client.raiseEvent(
-                defaultInstanceId,
-                defaultTestEvent,
-                defaultTestData,
-                testTaskHub
-            );
+            const result = await client.raiseEvent({
+                instanceId: defaultInstanceId,
+                eventName: defaultTestEvent,
+                eventData: defaultTestData,
+                taskHubName: testTaskHub,
+            });
             expect(scope.isDone()).to.be.equal(true);
             expect(result).to.be.equal(undefined);
         });
@@ -605,13 +613,12 @@ describe("Orchestration Client", () => {
                 )
                 .reply(202);
 
-            const result = await client.raiseEvent(
-                defaultInstanceId,
-                defaultTestEvent,
-                defaultTestData,
-                undefined,
-                testConnection
-            );
+            const result = await client.raiseEvent({
+                instanceId: defaultInstanceId,
+                eventName: defaultTestEvent,
+                eventData: defaultTestData,
+                connectionName: testConnection,
+            });
             expect(scope.isDone()).to.be.equal(true);
             expect(result).to.be.equal(undefined);
         });
@@ -633,7 +640,11 @@ describe("Orchestration Client", () => {
                 .reply(404, undefined);
 
             await expect(
-                client.raiseEvent(id, defaultTestEvent, defaultTestData)
+                client.raiseEvent({
+                    instanceId: id,
+                    eventName: defaultTestEvent,
+                    eventData: defaultTestData,
+                })
             ).to.be.rejectedWith(`No instance with ID '${id}' found.`);
             expect(scope.isDone()).to.be.equal(true);
         });
@@ -705,11 +716,10 @@ describe("Orchestration Client", () => {
                 )
                 .reply(200, expectedEntityStateResponse);
 
-            const result = await client.readEntityState<TestEntityState>(
-                defaultEntityId,
-                testTaskHub,
-                testConn
-            );
+            const result = await client.readEntityState<TestEntityState>(defaultEntityId, {
+                taskHubName: testTaskHub,
+                connectionName: testConn,
+            });
             expect(scope.isDone()).to.be.equal(true);
             expect(result).to.be.deep.equal(expectedStateResponse);
         });
@@ -864,11 +874,10 @@ describe("Orchestration Client", () => {
                 )
                 .reply(202);
 
-            const result = await client.signalEntity(
-                defaultEntityId,
-                defaultEntityOp,
-                testSignalData
-            );
+            const result = await client.signalEntity(defaultEntityId, {
+                operationName: defaultEntityOp,
+                operationContent: testSignalData,
+            });
             expect(scope.isDone()).to.be.equal(true);
             expect(result).to.be.equal(undefined);
         });
@@ -891,13 +900,12 @@ describe("Orchestration Client", () => {
                 )
                 .reply(202);
 
-            const result = await client.signalEntity(
-                defaultEntityId,
-                defaultEntityOp,
-                testSignalData,
-                testTaskHub,
-                testConn
-            );
+            const result = await client.signalEntity(defaultEntityId, {
+                operationName: defaultEntityOp,
+                operationContent: testSignalData,
+                taskHubName: testTaskHub,
+                connectionName: testConn,
+            });
             expect(scope.isDone()).to.be.equal(true);
             expect(result).to.be.equal(undefined);
         });
@@ -918,7 +926,9 @@ describe("Orchestration Client", () => {
                 )
                 .reply(202);
 
-            const result = await client.signalEntity(defaultEntityId, undefined, testSignalData);
+            const result = await client.signalEntity(defaultEntityId, {
+                operationContent: testSignalData,
+            });
             expect(scope.isDone()).to.be.equal(true);
             expect(result).to.be.equal(undefined);
         });
@@ -1107,8 +1117,10 @@ describe("Orchestration Client", () => {
                 client.waitForCompletionOrCreateCheckStatusResponse(
                     defaultRequest,
                     defaultInstanceId,
-                    defaultTimeout,
-                    badInterval
+                    {
+                        timeoutInMilliseconds: defaultTimeout,
+                        retryIntervalInMilliseconds: badInterval,
+                    }
                 )
             ).to.be.rejectedWith(
                 `Total timeout ${defaultTimeout} (ms) should be bigger than retry timeout ${badInterval} (ms)`
@@ -1137,8 +1149,10 @@ describe("Orchestration Client", () => {
             const res = await client.waitForCompletionOrCreateCheckStatusResponse(
                 defaultRequest,
                 defaultInstanceId,
-                defaultTimeout,
-                defaultInterval
+                {
+                    timeoutInMilliseconds: defaultTimeout,
+                    retryIntervalInMilliseconds: defaultInterval,
+                }
             );
 
             const body = await res.json();
@@ -1167,8 +1181,10 @@ describe("Orchestration Client", () => {
             const res = await client.waitForCompletionOrCreateCheckStatusResponse(
                 defaultRequest,
                 defaultInstanceId,
-                defaultTimeout,
-                defaultInterval
+                {
+                    timeoutInMilliseconds: defaultTimeout,
+                    retryIntervalInMilliseconds: defaultInterval,
+                }
             );
 
             const body = await res.json();
@@ -1197,8 +1213,10 @@ describe("Orchestration Client", () => {
             const res = await client.waitForCompletionOrCreateCheckStatusResponse(
                 defaultRequest,
                 defaultInstanceId,
-                defaultTimeout,
-                defaultInterval
+                {
+                    timeoutInMilliseconds: defaultTimeout,
+                    retryIntervalInMilliseconds: defaultInterval,
+                }
             );
 
             const body = await res.json();
@@ -1227,8 +1245,10 @@ describe("Orchestration Client", () => {
             const res = await client.waitForCompletionOrCreateCheckStatusResponse(
                 defaultRequest,
                 defaultInstanceId,
-                defaultTimeout,
-                defaultInterval
+                {
+                    timeoutInMilliseconds: defaultTimeout,
+                    retryIntervalInMilliseconds: defaultInterval,
+                }
             );
 
             const body = await res.json();
@@ -1282,8 +1302,10 @@ describe("Orchestration Client", () => {
             const res = await client.waitForCompletionOrCreateCheckStatusResponse(
                 defaultRequest,
                 defaultInstanceId,
-                defaultTimeout,
-                defaultInterval
+                {
+                    timeoutInMilliseconds: defaultTimeout,
+                    retryIntervalInMilliseconds: defaultInterval,
+                }
             );
 
             const body = await res.json();
@@ -1329,8 +1351,10 @@ describe("Orchestration Client", () => {
             const res = await client.waitForCompletionOrCreateCheckStatusResponse(
                 defaultRequest,
                 defaultInstanceId,
-                defaultTimeout,
-                defaultInterval
+                {
+                    timeoutInMilliseconds: defaultTimeout,
+                    retryIntervalInMilliseconds: defaultInterval,
+                }
             );
             expect(res).to.be.deep.equal(expectedResponse);
 

--- a/test/unit/orchestrationclient-spec.ts
+++ b/test/unit/orchestrationclient-spec.ts
@@ -560,11 +560,11 @@ describe("Orchestration Client", () => {
                 )
                 .reply(202);
 
-            const result = await client.raiseEvent({
-                instanceId: defaultInstanceId,
-                eventName: defaultTestEvent,
-                eventData: defaultTestData,
-            });
+            const result = await client.raiseEvent(
+                defaultInstanceId,
+                defaultTestEvent,
+                defaultTestData
+            );
             expect(scope.isDone()).to.be.equal(true);
             expect(result).to.be.equal(undefined);
         });
@@ -586,12 +586,14 @@ describe("Orchestration Client", () => {
                 )
                 .reply(202);
 
-            const result = await client.raiseEvent({
-                instanceId: defaultInstanceId,
-                eventName: defaultTestEvent,
-                eventData: defaultTestData,
-                taskHubName: testTaskHub,
-            });
+            const result = await client.raiseEvent(
+                defaultInstanceId,
+                defaultTestEvent,
+                defaultTestData,
+                {
+                    taskHubName: testTaskHub,
+                }
+            );
             expect(scope.isDone()).to.be.equal(true);
             expect(result).to.be.equal(undefined);
         });
@@ -613,12 +615,14 @@ describe("Orchestration Client", () => {
                 )
                 .reply(202);
 
-            const result = await client.raiseEvent({
-                instanceId: defaultInstanceId,
-                eventName: defaultTestEvent,
-                eventData: defaultTestData,
-                connectionName: testConnection,
-            });
+            const result = await client.raiseEvent(
+                defaultInstanceId,
+                defaultTestEvent,
+                defaultTestData,
+                {
+                    connectionName: testConnection,
+                }
+            );
             expect(scope.isDone()).to.be.equal(true);
             expect(result).to.be.equal(undefined);
         });
@@ -640,11 +644,7 @@ describe("Orchestration Client", () => {
                 .reply(404, undefined);
 
             await expect(
-                client.raiseEvent({
-                    instanceId: id,
-                    eventName: defaultTestEvent,
-                    eventData: defaultTestData,
-                })
+                client.raiseEvent(id, defaultTestEvent, defaultTestData)
             ).to.be.rejectedWith(`No instance with ID '${id}' found.`);
             expect(scope.isDone()).to.be.equal(true);
         });

--- a/test/unit/orchestrationclient-spec.ts
+++ b/test/unit/orchestrationclient-spec.ts
@@ -874,10 +874,11 @@ describe("Orchestration Client", () => {
                 )
                 .reply(202);
 
-            const result = await client.signalEntity(defaultEntityId, {
-                operationName: defaultEntityOp,
-                operationContent: testSignalData,
-            });
+            const result = await client.signalEntity(
+                defaultEntityId,
+                defaultEntityOp,
+                testSignalData
+            );
             expect(scope.isDone()).to.be.equal(true);
             expect(result).to.be.equal(undefined);
         });
@@ -900,12 +901,15 @@ describe("Orchestration Client", () => {
                 )
                 .reply(202);
 
-            const result = await client.signalEntity(defaultEntityId, {
-                operationName: defaultEntityOp,
-                operationContent: testSignalData,
-                taskHubName: testTaskHub,
-                connectionName: testConn,
-            });
+            const result = await client.signalEntity(
+                defaultEntityId,
+                defaultEntityOp,
+                testSignalData,
+                {
+                    taskHubName: testTaskHub,
+                    connectionName: testConn,
+                }
+            );
             expect(scope.isDone()).to.be.equal(true);
             expect(result).to.be.equal(undefined);
         });
@@ -926,9 +930,7 @@ describe("Orchestration Client", () => {
                 )
                 .reply(202);
 
-            const result = await client.signalEntity(defaultEntityId, {
-                operationContent: testSignalData,
-            });
+            const result = await client.signalEntity(defaultEntityId, undefined, testSignalData);
             expect(scope.isDone()).to.be.equal(true);
             expect(result).to.be.equal(undefined);
         });

--- a/types/durableClient.d.ts
+++ b/types/durableClient.d.ts
@@ -41,17 +41,9 @@ export declare class DurableClient {
     /**
      * Gets the status of the specified orchestration instance.
      * @param instanceId The ID of the orchestration instance to query.
-     * @param showHistory Boolean marker for including execution history in the
-     *  response.
-     * @param showHistoryOutput Boolean marker for including input and output
-     *  in the execution history response.
+     * @param options options object specifying optional extra configuration options
      */
-    getStatus(
-        instanceId: string,
-        showHistory?: boolean,
-        showHistoryOutput?: boolean,
-        showInput?: boolean
-    ): Promise<DurableOrchestrationStatus>;
+    getStatus(instanceId: string, options?: GetStatusOptions): Promise<DurableOrchestrationStatus>;
 
     /**
      * Gets the status of all orchestration instances.
@@ -61,18 +53,11 @@ export declare class DurableClient {
     /**
      * Gets the status of all orchestration instances that match the specified
      * conditions.
-     * @param createdTimeFrom Return orchestration instances which were created
-     *  after this Date.
-     * @param createdTimeTo Return orchestration instances which were created
-     *  before this DateTime.
-     * @param runtimeStatus Return orchestration instances which match any of
-     *  the runtimeStatus values in this array.
+     *
+     * @param selectionOptions the SelectionOptions object specifying which
+     * orchestrations to retrieve.
      */
-    getStatusBy(
-        createdTimeFrom: Date | undefined,
-        createdTimeTo: Date | undefined,
-        runtimeStatus: OrchestrationRuntimeStatus[]
-    ): Promise<DurableOrchestrationStatus[]>;
+    getStatusBy(selectionOptions: SelectionOptions): Promise<DurableOrchestrationStatus[]>;
 
     /**
      * Purge the history for a specific orchestration instance.
@@ -82,29 +67,17 @@ export declare class DurableClient {
 
     /**
      * Purge the orchestration history for instances that match the conditions.
-     * @param createdTimeFrom Start creation time for querying instances for
-     *  purging.
-     * @param createdTimeTo End creation time for querying instances for
-     *  purging.
-     * @param runtimeStatus List of runtime statuses for querying instances for
-     *  purging. Only Completed, Terminated or Failed will be processed.
+     * @param selectionOptions the SelectionsOptions object specifying which
+     * orchestrations to purge.
      */
-    purgeInstanceHistoryBy(
-        createdTimeFrom: Date,
-        createdTimeTo?: Date,
-        runtimeStatus?: OrchestrationRuntimeStatus[]
-    ): Promise<PurgeHistoryResult>;
+    purgeInstanceHistoryBy(selectionOptions: SelectionOptions): Promise<PurgeHistoryResult>;
 
     /**
      * Sends an event notification message to a waiting orchestration instance.
-     * @param instanceId The ID of the orchestration instance that will handle
-     *  the event.
-     * @param eventName The name of the event.
-     * @param eventData The JSON-serializable data associated with the event.
-     * @param taskHubName The TaskHubName of the orchestration that will handle
-     *  the event.
-     * @param connectionName The name of the connection string associated with
-     *  `taskHubName.`
+     *
+     * @param options RaiseEventOptions object specifying which orchestration to
+     * send event to and the event data.
+     *
      * @returns A promise that resolves when the event notification message has
      *  been enqueued.
      *
@@ -115,61 +88,46 @@ export declare class DurableClient {
      * If the specified instance is not found or not running, this operation
      * will have no effect.
      */
-    raiseEvent(
-        instanceId: string,
-        eventName: string,
-        eventData: unknown,
-        taskHubName?: string,
-        connectionName?: string
-    ): Promise<void>;
+    raiseEvent(options: RaiseEventOptions): Promise<void>;
 
     /**
-     * Tries to read the current state of an entity. Returnes undefined if the
+     * Tries to read the current state of an entity. Returns undefined if the
      * entity does not exist, or if the JSON-serialized state of the entity is
      * larger than 16KB.
-     * @param T The JSON-serializable type of the entity.
+     *
+     * @param T The JSON-serializable type of the entity state.
      * @param entityId The target entity.
-     * @param taskHubName The TaskHubName of the target entity.
-     * @param connectionName The name of the connection string associated with
-     * [taskHubName].
+     * @param options optional object providing the TaskHubName of the target entity
+     *  and the name of its associated connection string
+     *
      * @returns A response containing the current state of the entity.
      */
     readEntityState<T>(
         entityId: EntityId,
-        taskHubName?: string,
-        connectionName?: string
+        options?: TaskHubOptions
     ): Promise<EntityStateResponse<T>>;
 
     /**
      * Rewinds the specified failed orchestration instance with a reason.
+     *
      * @param instanceId The ID of the orchestration instance to rewind.
      * @param reason The reason for rewinding the orchestration instance.
+     * @param options object providing TaskHubName of the orchestration instance and
+     *  the name of its associated connection string
+     *
      * @returns A promise that resolves when the rewind message is enqueued.
      *
      * This feature is currently in preview.
      */
-    rewind(
-        instanceId: string,
-        reason: string,
-        taskHubName?: string,
-        connectionName?: string
-    ): Promise<void>;
+    rewind(instanceId: string, reason: string, options?: TaskHubOptions): Promise<void>;
 
     /**
      * Signals an entity to perform an operation.
+     *
      * @param entityId The target entity.
-     * @param operationName The name of the operation.
-     * @param operationContent The content for the operation.
-     * @param taskHubName The TaskHubName of the target entity.
-     * @param connectionName The name of the connection string associated with [taskHubName].
+     * @param options options object providing configurations the signal to the entity
      */
-    signalEntity(
-        entityId: EntityId,
-        operationName?: string,
-        operationContent?: unknown,
-        taskHubName?: string,
-        connectionName?: string
-    ): Promise<void>;
+    signalEntity(entityId: EntityId, options?: SignalEntityOptions): Promise<void>;
 
     /**
      * Starts a new instance of the specified orchestrator function.
@@ -205,16 +163,13 @@ export declare class DurableClient {
      *
      * @param request The HTTP request that triggered the current function.
      * @param instanceId The unique ID of the instance to check.
-     * @param timeoutInMilliseconds Total allowed timeout for output from the
-     *  durable function. The default value is 10 seconds.
-     * @param retryIntervalInMilliseconds The timeout between checks for output
-     *  from the durable function. The default value is 1 second.
+     * @param waitOptions options object specifying the timeouts for how long
+     * to wait for output from the durable function and how often to check for output.
      */
     waitForCompletionOrCreateCheckStatusResponse(
         request: HttpRequest,
         instanceId: string,
-        timeoutInMilliseconds: number,
-        retryIntervalInMilliseconds: number
+        waitOptions?: WaitForCompletionOptions
     ): Promise<HttpResponse>;
 }
 
@@ -351,4 +306,49 @@ export interface TaskHubOptions {
      * The name of the connection string associated with `taskHubName.`
      */
     connectionName?: string;
+}
+
+/**
+ * Options object passed to DurableClient APIs
+ * to select certain orchestrations on which to perform
+ * actions
+ */
+export interface SelectionOptions {
+    /**
+     * Select orchestration instances which were created
+     * after this Date.
+     */
+    createdTimeFrom: Date | undefined;
+    /**
+     * Select orchestration instances which were created
+     * before this DateTime.
+     */
+    createdTimeTo: Date | undefined;
+    /**
+     * Select orchestration instances which match any of
+     * the runtimeStatus values in this array
+     */
+    runtimeStatus?: OrchestrationRuntimeStatus[];
+}
+
+/**
+ * Options object passed to the `durableClient.waitForCompletionOrCreateCheckStatusResponse()`
+ * method to specify timeouts for how long to wait for output from the durable function
+ *  and how often to check for output.
+ */
+export interface WaitForCompletionOptions {
+    /**
+     * Total allowed timeout for output from the
+     * durable function.
+     *
+     * @default 10000 (10 seconds)
+     */
+    timeoutInMilliseconds?: number;
+    /**
+     * The timeout between checks for output
+     * from the durable function.
+     *
+     * @default 1000 (1 second)
+     */
+    retryIntervalInMilliseconds?: number;
 }

--- a/types/durableClient.d.ts
+++ b/types/durableClient.d.ts
@@ -280,3 +280,75 @@ export declare class HttpManagementPayload {
      */
     readonly purgeHistoryDeleteUri: string;
 }
+
+/**
+ * Options object passed to client `getStatus()` method
+ */
+export interface GetStatusOptions {
+    /**
+     * Specifies whether execution history should be included in the response.
+     */
+    showHistory?: boolean;
+    /**
+     * Specifies whether input and output should be included in the execution history response.
+     */
+    showHistoryOutput?: boolean;
+    /**
+     * Specifies whether orchestration input should be included in the response.
+     */
+    showInput?: boolean;
+}
+
+/**
+ * Interface to hold statistics about this execution of purge history.
+ * The return type of DurableClient.purgeHistory()
+ */
+export interface PurgeHistoryResult {
+    /**
+     * The number of deleted instances.
+     */
+    readonly instancesDeleted: number;
+}
+
+/**
+ * Options object passed to DurableClient.raiseEvent()
+ */
+export interface RaiseEventOptions extends TaskHubOptions {
+    /**
+     * The ID of the orchestration instance that will handle the event.
+     */
+    instanceId: string;
+    /**
+     * The name of the event.
+     */
+    eventName: string;
+    /**
+     * The JSON-serializable data associated with the event.
+     */
+    eventData: unknown;
+}
+
+export interface SignalEntityOptions extends TaskHubOptions {
+    /**
+     * The name of the operation.
+     */
+    operationName?: string;
+    /**
+     * The content for the operation
+     */
+    operationContent?: unknown;
+}
+
+/**
+ * Options object passed to DurableClient APIs to specify task hub properties
+ */
+export interface TaskHubOptions {
+    /**
+     * The TaskHubName of the orchestration
+     */
+    taskHubName?: string;
+    /**
+     * The name of the connection string associated with `taskHubName.`
+     */
+    connectionName?: string;
+}

--- a/types/durableClient.d.ts
+++ b/types/durableClient.d.ts
@@ -75,8 +75,12 @@ export declare class DurableClient {
     /**
      * Sends an event notification message to a waiting orchestration instance.
      *
-     * @param options RaiseEventOptions object specifying which orchestration to
-     * send event to and the event data.
+     * @param instanceId The ID of the orchestration instance that will handle
+     *  the event.
+     * @param eventName The name of the event.
+     * @param eventData The JSON-serializable data associated with the event.
+     * @param options object providing TaskHubName of the orchestration instance and
+     *  the name of its associated connection string
      *
      * @returns A promise that resolves when the event notification message has
      *  been enqueued.
@@ -88,7 +92,12 @@ export declare class DurableClient {
      * If the specified instance is not found or not running, this operation
      * will have no effect.
      */
-    raiseEvent(options: RaiseEventOptions): Promise<void>;
+    raiseEvent(
+        instanceId: string,
+        eventName: string,
+        eventData: unknown,
+        options?: TaskHubOptions
+    ): Promise<void>;
 
     /**
      * Tries to read the current state of an entity. Returns undefined if the
@@ -252,24 +261,6 @@ export interface GetStatusOptions {
      * Specifies whether orchestration input should be included in the response.
      */
     showInput?: boolean;
-}
-
-/**
- * Options object passed to DurableClient.raiseEvent()
- */
-export interface RaiseEventOptions extends TaskHubOptions {
-    /**
-     * The ID of the orchestration instance that will handle the event.
-     */
-    instanceId: string;
-    /**
-     * The name of the event.
-     */
-    eventName: string;
-    /**
-     * The JSON-serializable data associated with the event.
-     */
-    eventData: unknown;
 }
 
 export interface SignalEntityOptions extends TaskHubOptions {

--- a/types/durableClient.d.ts
+++ b/types/durableClient.d.ts
@@ -41,7 +41,7 @@ export declare class DurableClient {
     /**
      * Gets the status of the specified orchestration instance.
      * @param instanceId The ID of the orchestration instance to query.
-     * @param options options object specifying optional extra configuration options
+     * @param options options object specifying extra configuration
      */
     getStatus(instanceId: string, options?: GetStatusOptions): Promise<DurableOrchestrationStatus>;
 

--- a/types/durableClient.d.ts
+++ b/types/durableClient.d.ts
@@ -134,9 +134,17 @@ export declare class DurableClient {
      * Signals an entity to perform an operation.
      *
      * @param entityId The target entity.
-     * @param options options object providing configurations the signal to the entity
+     * @param operationName The name of the operation.
+     * @param operationContent The content for the operation.
+     * @param options object providing TaskHubName of the entity instance and
+     *  the name of its associated connection string
      */
-    signalEntity(entityId: EntityId, options?: SignalEntityOptions): Promise<void>;
+    signalEntity(
+        entityId: EntityId,
+        operationName?: string,
+        operationContent?: unknown,
+        options?: TaskHubOptions
+    ): Promise<void>;
 
     /**
      * Starts a new instance of the specified orchestrator function.
@@ -261,17 +269,6 @@ export interface GetStatusOptions {
      * Specifies whether orchestration input should be included in the response.
      */
     showInput?: boolean;
-}
-
-export interface SignalEntityOptions extends TaskHubOptions {
-    /**
-     * The name of the operation.
-     */
-    operationName?: string;
-    /**
-     * The content for the operation
-     */
-    operationContent?: unknown;
 }
 
 /**

--- a/types/durableClient.d.ts
+++ b/types/durableClient.d.ts
@@ -54,10 +54,10 @@ export declare class DurableClient {
      * Gets the status of all orchestration instances that match the specified
      * conditions.
      *
-     * @param filterOptions the OrchestrationFilter object specifying which
+     * @param filter the OrchestrationFilter object specifying which
      * orchestrations to retrieve.
      */
-    getStatusBy(filterOptions: OrchestrationFilter): Promise<DurableOrchestrationStatus[]>;
+    getStatusBy(filter: OrchestrationFilter): Promise<DurableOrchestrationStatus[]>;
 
     /**
      * Purge the history for a specific orchestration instance.
@@ -67,10 +67,10 @@ export declare class DurableClient {
 
     /**
      * Purge the orchestration history for instances that match the conditions.
-     * @param filterOptions the OrchestrationFilter object specifying which
+     * @param filter the OrchestrationFilter object specifying which
      * orchestrations to purge.
      */
-    purgeInstanceHistoryBy(filterOptions: OrchestrationFilter): Promise<PurgeHistoryResult>;
+    purgeInstanceHistoryBy(filter: OrchestrationFilter): Promise<PurgeHistoryResult>;
 
     /**
      * Sends an event notification message to a waiting orchestration instance.

--- a/types/durableClient.d.ts
+++ b/types/durableClient.d.ts
@@ -255,17 +255,6 @@ export interface GetStatusOptions {
 }
 
 /**
- * Interface to hold statistics about this execution of purge history.
- * The return type of DurableClient.purgeHistory()
- */
-export interface PurgeHistoryResult {
-    /**
-     * The number of deleted instances.
-     */
-    readonly instancesDeleted: number;
-}
-
-/**
  * Options object passed to DurableClient.raiseEvent()
  */
 export interface RaiseEventOptions extends TaskHubOptions {

--- a/types/durableClient.d.ts
+++ b/types/durableClient.d.ts
@@ -54,10 +54,10 @@ export declare class DurableClient {
      * Gets the status of all orchestration instances that match the specified
      * conditions.
      *
-     * @param selectionOptions the SelectionOptions object specifying which
+     * @param filterOptions the OrchestrationFilter object specifying which
      * orchestrations to retrieve.
      */
-    getStatusBy(selectionOptions: SelectionOptions): Promise<DurableOrchestrationStatus[]>;
+    getStatusBy(filterOptions: OrchestrationFilter): Promise<DurableOrchestrationStatus[]>;
 
     /**
      * Purge the history for a specific orchestration instance.
@@ -67,10 +67,10 @@ export declare class DurableClient {
 
     /**
      * Purge the orchestration history for instances that match the conditions.
-     * @param selectionOptions the SelectionsOptions object specifying which
+     * @param filterOptions the OrchestrationFilter object specifying which
      * orchestrations to purge.
      */
-    purgeInstanceHistoryBy(selectionOptions: SelectionOptions): Promise<PurgeHistoryResult>;
+    purgeInstanceHistoryBy(filterOptions: OrchestrationFilter): Promise<PurgeHistoryResult>;
 
     /**
      * Sends an event notification message to a waiting orchestration instance.
@@ -290,10 +290,10 @@ export interface TaskHubOptions {
 
 /**
  * Options object passed to DurableClient APIs
- * to select certain orchestrations on which to perform
+ * to filter orchestrations on which to perform
  * actions
  */
-export interface SelectionOptions {
+export interface OrchestrationFilter {
     /**
      * Select orchestration instances which were created
      * after this Date.

--- a/types/durableClient.d.ts
+++ b/types/durableClient.d.ts
@@ -318,12 +318,12 @@ export interface SelectionOptions {
      * Select orchestration instances which were created
      * after this Date.
      */
-    createdTimeFrom: Date | undefined;
+    createdTimeFrom?: Date;
     /**
      * Select orchestration instances which were created
      * before this DateTime.
      */
-    createdTimeTo: Date | undefined;
+    createdTimeTo?: Date;
     /**
      * Select orchestration instances which match any of
      * the runtimeStatus values in this array

--- a/types/orchestration.d.ts
+++ b/types/orchestration.d.ts
@@ -48,45 +48,6 @@ export interface OrchestrationTrigger extends FunctionTrigger {
 }
 
 /**
- * Options object provided to `callHttp()` methods on orchestration contexts
- */
-export interface CallHttpOptions {
-    /**
-     * The HTTP request method.
-     */
-    method: string;
-    /**
-     * The HTTP request URL.
-     */
-    url: string;
-    /**
-     * The HTTP request body.
-     */
-    body?: string | object;
-    /**
-     * The HTTP request headers.
-     */
-    headers?: { [key: string]: string };
-    /**
-     * The source of the OAuth token to add to the request.
-     */
-    tokenSource?: TokenSource;
-    /**
-     * Specifies whether to continue polling the request after receiving a 202 response.
-     * This replaces `asynchronousPatternEnabled`. If both are specified,
-     * `enablePolling` takes precedence.
-     *
-     * @default true
-     */
-    enablePolling?: boolean;
-    /**
-     * @deprecated use `enablePolling` instead. If both are specified,
-     * `enablePolling` takes precedence.
-     */
-    asynchronousPatternEnabled?: boolean;
-}
-
-/**
  * Provides functionality for application code implementing an orchestration operation.
  */
 export declare class DurableOrchestrationContext {
@@ -414,4 +375,59 @@ export declare enum OrchestrationRuntimeStatus {
      * running.
      */
     Pending = "Pending",
+}
+
+/**
+ * Options object passed to the `context.df.callSubOrchestrator()` method
+ */
+export interface CallSubOrchestratorOptions {
+    /**
+     * The JSON-serializable input to pass to the orchestrator function.
+     */
+    input?: unknown;
+    /**
+     * A unique ID to use for the sub-orchestration instance.
+     * If `instanceId` is not specified, the extension will generate an id in
+     * the format `<calling orchestrator instance ID>:<#>`
+     */
+    instanceId?: string;
+}
+
+/**
+ * Options object provided to `callHttp()` methods on orchestration contexts
+ */
+export interface CallHttpOptions {
+    /**
+     * The HTTP request method.
+     */
+    method: string;
+    /**
+     * The HTTP request URL.
+     */
+    url: string;
+    /**
+     * The HTTP request body.
+     */
+    body?: string | object;
+    /**
+     * The HTTP request headers.
+     */
+    headers?: { [key: string]: string };
+    /**
+     * The source of the OAuth token to add to the request.
+     */
+    tokenSource?: TokenSource;
+    /**
+     * Specifies whether to continue polling the request after receiving a 202 response.
+     * This replaces `asynchronousPatternEnabled`. If both are specified,
+     * `enablePolling` takes precedence.
+     *
+     * @default true
+     */
+    enablePolling?: boolean;
+    /**
+     * @deprecated use `enablePolling` instead. If both are specified,
+     * `enablePolling` takes precedence.
+     */
+    asynchronousPatternEnabled?: boolean;
 }

--- a/types/orchestration.d.ts
+++ b/types/orchestration.d.ts
@@ -166,9 +166,13 @@ export declare class DurableOrchestrationContext {
      * Schedules an orchestration function named `name` for execution.
      *
      * @param name The name of the orchestrator function to call.
-     * @param options optional object to control the scheduled orchestrator (e.g provide input, instanceID)
+     * @param input The JSON-serializable input to pass to the orchestrator
+     * function.
+     * @param instanceId A unique ID to use for the sub-orchestration instance.
+     * If `instanceId` is not specified, the extension will generate an id in
+     * the format `<calling orchestrator instance ID>:<#>`
      */
-    callSubOrchestrator(name: string, options?: CallSubOrchestratorOptions): Task;
+    callSubOrchestrator(name: string, input?: unknown, instanceId?: string): Task;
 
     /**
      * Schedules an orchestrator function named `name` for execution with retry
@@ -176,12 +180,15 @@ export declare class DurableOrchestrationContext {
      *
      * @param name The name of the orchestrator function to call.
      * @param retryOptions The retry options for the orchestrator function.
-     * @param options optional object to control the scheduled orchestrator (e.g provide input, instanceID)
+     * @param input The JSON-serializable input to pass to the orchestrator
+     * function.
+     * @param instanceId A unique ID to use for the sub-orchestration instance.
      */
     callSubOrchestratorWithRetry(
         name: string,
         retryOptions: RetryOptions,
-        options?: CallSubOrchestratorOptions
+        input?: unknown,
+        instanceId?: string
     ): Task;
 
     /**
@@ -368,22 +375,6 @@ export declare enum OrchestrationRuntimeStatus {
      * running.
      */
     Pending = "Pending",
-}
-
-/**
- * Options object passed to the `context.df.callSubOrchestrator()` method
- */
-export interface CallSubOrchestratorOptions {
-    /**
-     * The JSON-serializable input to pass to the orchestrator function.
-     */
-    input?: unknown;
-    /**
-     * A unique ID to use for the sub-orchestration instance.
-     * If `instanceId` is not specified, the extension will generate an id in
-     * the format `<calling orchestrator instance ID>:<#>`
-     */
-    instanceId?: string;
 }
 
 /**

--- a/types/orchestration.d.ts
+++ b/types/orchestration.d.ts
@@ -166,13 +166,9 @@ export declare class DurableOrchestrationContext {
      * Schedules an orchestration function named `name` for execution.
      *
      * @param name The name of the orchestrator function to call.
-     * @param input The JSON-serializable input to pass to the orchestrator
-     * function.
-     * @param instanceId A unique ID to use for the sub-orchestration instance.
-     * If `instanceId` is not specified, the extension will generate an id in
-     * the format `<calling orchestrator instance ID>:<#>`
+     * @param options optional object to control the scheduled orchestrator (e.g provide input, instanceID)
      */
-    callSubOrchestrator(name: string, input?: unknown, instanceId?: string): Task;
+    callSubOrchestrator(name: string, options?: CallSubOrchestratorOptions): Task;
 
     /**
      * Schedules an orchestrator function named `name` for execution with retry
@@ -180,15 +176,12 @@ export declare class DurableOrchestrationContext {
      *
      * @param name The name of the orchestrator function to call.
      * @param retryOptions The retry options for the orchestrator function.
-     * @param input The JSON-serializable input to pass to the orchestrator
-     * function.
-     * @param instanceId A unique ID to use for the sub-orchestration instance.
+     * @param options optional object to control the scheduled orchestrator (e.g provide input, instanceID)
      */
     callSubOrchestratorWithRetry(
         name: string,
         retryOptions: RetryOptions,
-        input?: unknown,
-        instanceId?: string
+        options?: CallSubOrchestratorOptions
     ): Task;
 
     /**


### PR DESCRIPTION
Resolves #441. Switch from using concrete optional arguments to an options object where applicable.

I've broken this PR into small steps in commits to aid with PR review.

APIs changed in this PR (notice this list is slightly different than the one in the issue):

**In DurableOrchestrationClient:**

<table>
<tr>
<th> Before </th>
<th> After </th>
</tr>
<tr>
<td>

```TS
getStatus(
    instanceId: string,
    showHistory?: boolean,
    showHistoryOutput?: boolean,
    showInput?: boolean
): Promise<DurableOrchestrationStatus>
```
</td>
<td>

```TS
getStatus(
    instanceId: string, 
    options?: GetStatusOptions
): Promise<DurableOrchestrationStatus>
```
</td>
</tr>
<tr>
<td>

```TS
getStatusBy(
    createdTimeFrom: Date | undefined,
    createdTimeTo: Date | undefined,
    runtimeStatus: OrchestrationRuntimeStatus[]
): Promise<DurableOrchestrationStatus[]>
```

</td>
<td>

```TS
getStatusBy(
    options: SelectionOptions
): Promise<DurableOrchestrationStatus[]>
```

</td>
</tr>
<tr>
<td>

```TS
purgeInstanceHistoryBy(
    createdTimeFrom: Date,
    createdTimeTo?: Date,
    runtimeStatus?: OrchestrationRuntimeStatus[]
): Promise<PurgeHistoryResult>
```

</td>
<td>

```TS
purgeInstanceHistoryBy(
    options: SelectionOptions
): Promise<PurgeHistoryResult>
```

</td>
</tr>
<tr>
<td>

```TS
raiseEvent(
    instanceId: string,
    eventName: string,
    eventData: unknown,
    taskHubName?: string,
    connectionName?: string
): Promise<void>
```

</td>
<td>

```TS
raiseEvent(options: RaiseEventOptions): Promise<void>
```

</td>
</tr>
<tr>
<td>

```TS
readEntityState<T>(
    entityId: EntityId,
    taskHubName?: string,
    connectionName?: string
): Promise<EntityStateResponse<T>>
```

</td>
<td>

```TS
readEntityState<T>(
    entityId: EntityId,
    options?: TaskHubOptions
): Promise<EntityStateResponse<T>>
```

</td>
</tr>
<tr>
<td>

```TS
rewind(
    instanceId: string,
    reason: string,
    taskHubName?: string,
    connectionName?: string
): Promise<void>`
```

</td>
<td>

```TS
rewind(
    instanceId: string, 
    reason: string, 
    options?: TaskHubOptions
): Promise<void>
```

</td>
</tr>
<tr>
<td>

```TS
signalEntity(
    entityId: EntityId,
    operationName?: string,
    operationContent?: unknown,
    taskHubName?: string,
    connectionName?: string
): Promise<void>
```
</td>
<td>

```TS
signalEntity(
    entityId: EntityId, 
    options?: SignalEntityContext
): Promise<void>
```
</td>
</tr>
<tr>
<td>

```TS
waitForCompletionOrCreateCheckStatusResponse(
    request: HttpRequest,
    instanceId: string,
    timeoutInMilliseconds?: number,
    retryIntervalInMilliseconds?: number
): Promise<HttpResponse>;
```

</td>
<td>

```TS
waitForCompletionOrCreateCheckStatusResponse(
    request: HttpRequest,
    instanceId: string,
    waitOptions?: WaitForCompletionOptions
): Promise<HttpResponse>;
```

</td>
</tr>
</table>

**In DurableOrchestrationContext:**

<table>
<tr>
<th> Before </th>
<th> After </th>
</tr>

<tr>
<td>

```TS
callSubOrchestrator(
    name: string,
    input?: unknown, 
    instanceId?: string
): Task
```

</td>
<td>

```TS
// This is effectively equivalent
// to the startNew() change
callSubOrchestrator(
    name: string, 
    options?: CallSubOrchestratorOptions
): Task
```

</td>
</tr>
<tr>
<td>

```TS
callSubOrchestratorWithRetry(
    name: string,
    retryOptions: RetryOptions,
    input?: unknown,
    instanceId?: string
): Task
```

</td>
<td>

```TS
callSubOrchestratorWithRetry(
    name: string,
    retryOptions: RetryOptions,
    options?: CallSubOrchestratorOptions
): Task
```

</td>
</tr>
</table>

