### PR TITLE
Update inaccurate comment in samples

### DIFF
--- a/samples-js/functions/backupSiteContent.js
+++ b/samples-js/functions/backupSiteContent.js
@@ -16,7 +16,7 @@ df.app.orchestration("backupSiteContent", function* (context) {
     const rootDirAbs = path.resolve(rootDir);
     const files = yield context.df.callActivity(getFileListActivityName, rootDirAbs);
 
-    // Backup Files and save Promises into array
+    // Backup Files and save Tasks into array
     const tasks = [];
     for (const file of files) {
         const input = {

--- a/samples-ts/functions/backupSiteContent.ts
+++ b/samples-ts/functions/backupSiteContent.ts
@@ -25,7 +25,7 @@ const backupSiteContentOrchestration: OrchestrationHandler = function* (
     const rootDirAbs: string = path.resolve(rootDir);
     const files: string[] = yield context.df.callActivity(getFileListActivityName, rootDirAbs);
 
-    // Backup Files and save Promises into array
+    // Backup Files and save Tasks into array
     const tasks: Task[] = [];
     for (const file of files) {
         const input = {


### PR DESCRIPTION
Technically, they aren't Promises, but `Task`s. They shouldn't be awaited for example. Even though they're similar, we shouldn't confuse users by referring to them as Promises. These samples are used in our docs.