### PR TITLE
Incorrect ReturnType of `DurableOrchestrationClient.getStatus`

### DIFF
--- a/samples/UnitTesting/DurableFunctionsHttpStart/index.ts
+++ b/samples/UnitTesting/DurableFunctionsHttpStart/index.ts
@@ -1,5 +1,5 @@
-﻿import * as df from "durable-functions"
-import { AzureFunction, Context, HttpRequest } from "@azure/functions"
+﻿import * as df from "durable-functions";
+import { AzureFunction, Context, HttpRequest } from "@azure/functions";
 
 const httpStart: AzureFunction = async function (context: Context, req: HttpRequest): Promise<any> {
     const client = df.getClient(context);

--- a/samples/UnitTesting/Hello/index.ts
+++ b/samples/UnitTesting/Hello/index.ts
@@ -1,7 +1,7 @@
 ﻿/*
  * This function is not intended to be invoked directly. Instead it will be
  * triggered by an orchestrator function.
- * 
+ *
  * Before running this sample, please:
  * - create a Durable orchestration function
  * - create a Durable HTTP starter function
@@ -9,7 +9,7 @@
  *   function app in Kudu
  */
 
-import { AzureFunction, Context } from "@azure/functions"
+import { AzureFunction, Context } from "@azure/functions";
 
 const activityFunction: AzureFunction = async function (context: Context): Promise<string> {
     return `Hello ${context.bindings.name}!`;

--- a/src/durableorchestrationclient.ts
+++ b/src/durableorchestrationclient.ts
@@ -211,7 +211,7 @@ export class DurableOrchestrationClient {
         showHistory?: boolean,
         showHistoryOutput?: boolean,
         showInput?: boolean
-    ): Promise<DurableOrchestrationStatus> {
+    ): Promise<DurableOrchestrationStatus | undefined> {
         const options: GetStatusOptions = {
             instanceId,
             showHistory,
@@ -226,6 +226,9 @@ export class DurableOrchestrationClient {
             case 400: // instance failed or terminated
             case 404: // instance not found or pending
             case 500: // instance failed with unhandled exception
+                if (!response.data || !Object.keys(response.data).length) {
+                    return undefined;
+                }
                 return response.data as DurableOrchestrationStatus;
             default:
                 return Promise.reject(this.createGenericError(response));

--- a/src/durableorchestrationclient.ts
+++ b/src/durableorchestrationclient.ts
@@ -211,7 +211,7 @@ export class DurableOrchestrationClient {
         showHistory?: boolean,
         showHistoryOutput?: boolean,
         showInput?: boolean
-    ): Promise<DurableOrchestrationStatus | undefined> {
+    ): Promise<DurableOrchestrationStatus> {
         const options: GetStatusOptions = {
             instanceId,
             showHistory,
@@ -223,13 +223,10 @@ export class DurableOrchestrationClient {
         switch (response.status) {
             case 200: // instance completed
             case 202: // instance in progress
+                return response.data as DurableOrchestrationStatus;
             case 400: // instance failed or terminated
             case 404: // instance not found or pending
             case 500: // instance failed with unhandled exception
-                if (!response.data || !Object.keys(response.data).length) {
-                    return undefined;
-                }
-                return response.data as DurableOrchestrationStatus;
             default:
                 return Promise.reject(this.createGenericError(response));
         }

--- a/test/unit/durableclient-spec.ts
+++ b/test/unit/durableclient-spec.ts
@@ -211,20 +211,6 @@ describe("Durable client RPC endpoint", () => {
             expect(scope.isDone()).to.be.equal(true);
             expect(result).to.be.an("object");
         });
-        it("returns undefined for a purged instance", async () => {
-            const input = JSON.parse(durableClientBindingInputJson) as OrchestrationClientInputData;
-            const client = new DurableOrchestrationClient(input);
-
-            // The getStatus() method should do a GET to http://127.0.0.1:17071/durabletask/instances/abc123?showInput=true&showHistory=true&showHistoryOutput=true
-            const instanceId = "abc123";
-            const expectedUrl = new URL(`${testRpcOrigin}/durabletask/instances/${instanceId}`);
-
-            const scope = nock(expectedUrl.origin).get(expectedUrl.pathname).reply(404, "");
-
-            const result = await client.getStatus(instanceId);
-            expect(scope.isDone()).to.be.equal(true);
-            expect(result).to.be.an("undefined");
-        });
     });
 
     describe("getStatusBy()", () => {

--- a/test/unit/durableclient-spec.ts
+++ b/test/unit/durableclient-spec.ts
@@ -211,6 +211,20 @@ describe("Durable client RPC endpoint", () => {
             expect(scope.isDone()).to.be.equal(true);
             expect(result).to.be.an("object");
         });
+        it("returns undefined for a purged instance", async () => {
+            const input = JSON.parse(durableClientBindingInputJson) as OrchestrationClientInputData;
+            const client = new DurableOrchestrationClient(input);
+
+            // The getStatus() method should do a GET to http://127.0.0.1:17071/durabletask/instances/abc123?showInput=true&showHistory=true&showHistoryOutput=true
+            const instanceId = "abc123";
+            const expectedUrl = new URL(`${testRpcOrigin}/durabletask/instances/${instanceId}`);
+
+            const scope = nock(expectedUrl.origin).get(expectedUrl.pathname).reply(404, "");
+
+            const result = await client.getStatus(instanceId);
+            expect(scope.isDone()).to.be.equal(true);
+            expect(result).to.be.an("undefined");
+        });
     });
 
     describe("getStatusBy()", () => {


### PR DESCRIPTION
- Fixes the ReturnType of `DurableOrchestrationClient.getStatus` when no `response.data` is sent back by the client e.g. no instance found or instance is purged

Resolves #486 