### PR TITLE
Update exports to match types contract

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,4 @@
 import {
-    DurableHttpRequest,
-    DurableHttpResponse,
     EntityId,
     EntityStateResponse,
     OrchestrationRuntimeStatus,
@@ -9,11 +7,10 @@ import {
 } from "./classes";
 import { getClient } from "./durableorchestrationclient";
 import { app, input, trigger } from "./shim";
+import { DummyEntityContext } from "./testingUtils";
 import { ManagedIdentityTokenSource } from "./tokensource";
 
 export {
-    DurableHttpRequest,
-    DurableHttpResponse,
     EntityId,
     EntityStateResponse,
     getClient,
@@ -21,6 +18,7 @@ export {
     OrchestrationRuntimeStatus,
     RetryOptions,
     DummyOrchestrationContext,
+    DummyEntityContext,
     app,
     input,
     trigger,

--- a/src/task.ts
+++ b/src/task.ts
@@ -1,5 +1,5 @@
-import { DurableHttpResponse, RetryOptions } from ".";
-import { IAction, CreateTimerAction, CallHttpAction } from "./classes";
+import { RetryOptions } from ".";
+import { IAction, CreateTimerAction, CallHttpAction, DurableHttpResponse } from "./classes";
 import { TaskOrchestrationExecutor } from "./taskorchestrationexecutor";
 import moment = require("moment");
 import { DurableOrchestrationContext } from "./durableorchestrationcontext";

--- a/test/testobjects/TestOrchestrations.ts
+++ b/test/testobjects/TestOrchestrations.ts
@@ -1,6 +1,7 @@
 import * as df from "../../src";
 import { OrchestrationContext } from "durable-functions";
 import { createOrchestrator } from "../../src/shim";
+import { DurableHttpRequest } from "src/classes";
 
 export class TestOrchestrations {
     public static NotGenerator: any = createOrchestrator(function* () {
@@ -351,7 +352,7 @@ export class TestOrchestrations {
     });
 
     public static SendHttpRequest: any = createOrchestrator(function* (context) {
-        const input = context.df.getInput() as df.DurableHttpRequest;
+        const input = context.df.getInput() as DurableHttpRequest;
         const output = yield context.df.callHttp({
             method: input.method,
             url: input.uri,


### PR DESCRIPTION
Update the classes we export from the root of the package to match the publicly declared types. Specifically:

* Don't export `DurableHttpResponse` and `DurableHttpRequest`, which are not public facing and should not be used by customers
* Export the `DummyEntityContext` class