### PR TITLE
Update build labels on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 |Branch|Status|
 |---|---|
 |v2.x|[![Build Status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/Azure.azure-functions-durable-js?branchName=v2.x)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=13&branchName=v2.x)|
-|v3.x[![Build Status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/Azure.azure-functions-durable-js?branchName=v3.x)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=13&branchName=v3.x)|
+|v3.x|[![Build Status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/Azure.azure-functions-durable-js?branchName=v3.x)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=13&branchName=v3.x)|
 
 # Durable Functions for Node.js
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 |Branch|Status|
 |---|---|
-|main|[![Build Status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/Azure.azure-functions-durable-js?branchName=main)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=13&branchName=main)|
-|dev|[![Build Status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/Azure.azure-functions-durable-js?branchName=dev)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=13&branchName=dev)|
+|v2.x|[![Build Status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/Azure.azure-functions-durable-js?branchName=v2.x)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=13&branchName=v2.x)|
+|v3.x[![Build Status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/Azure.azure-functions-durable-js?branchName=v3.x)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=13&branchName=v3.x)|
 
 # Durable Functions for Node.js
 


### PR DESCRIPTION
Update labels to reference `v2.x` and `v3.x` branches instead of old `main` and `dev`