### PR TITLE
Fix bug where outputs are serialized twice if using `client.waitForCompletionOrCreateCheckStatusResponse`

### DIFF
--- a/src/durableorchestrationclient.ts
+++ b/src/durableorchestrationclient.ts
@@ -644,10 +644,9 @@ export class DurableOrchestrationClient implements DurableClient {
     }
 
     private createHttpResponse(statusCode: number, body: unknown): HttpResponse {
-        const bodyAsJson = JSON.stringify(body);
         return new HttpResponse({
             status: statusCode,
-            jsonBody: bodyAsJson,
+            jsonBody: body,
             headers: {
                 "Content-Type": "application/json",
             },

--- a/test/unit/orchestrationclient-spec.ts
+++ b/test/unit/orchestrationclient-spec.ts
@@ -1157,7 +1157,7 @@ describe("Orchestration Client", () => {
                 }
             );
 
-            const body = await res.json();
+            const body = await res.text();
             expect(res.status).to.equal(200);
             expect(body).to.equal(JSON.stringify(expectedOutput));
             expect(res.headers.get("Content-Type")).to.equal("application/json");
@@ -1189,7 +1189,7 @@ describe("Orchestration Client", () => {
                 }
             );
 
-            const body = await res.json();
+            const body = await res.text();
             expect(res.status).to.equal(200);
             expect(body).to.equal(expectedStatusAsJson);
             expect(res.headers.get("Content-Type")).to.equal("application/json");
@@ -1221,7 +1221,7 @@ describe("Orchestration Client", () => {
                 }
             );
 
-            const body = await res.json();
+            const body = await res.text();
             expect(res.status).to.equal(200);
             expect(body).to.equal(expectedStatusAsJson);
             expect(res.headers.get("Content-Type")).to.equal("application/json");
@@ -1253,7 +1253,7 @@ describe("Orchestration Client", () => {
                 }
             );
 
-            const body = await res.json();
+            const body = await res.text();
             expect(res.status).to.equal(500);
             expect(body).to.equal(expectedStatusAsJson);
             expect(res.headers.get("Content-Type")).to.equal("application/json");
@@ -1310,7 +1310,7 @@ describe("Orchestration Client", () => {
                 }
             );
 
-            const body = await res.json();
+            const body = await res.text();
             expect(res.status).to.equal(200);
             expect(body).to.equal(JSON.stringify(expectedOutput));
             expect(res.headers.get("Content-Type")).to.equal("application/json");


### PR DESCRIPTION
When fixing #454 (in #462), a bug was introduced whereby outputs of orchestrations would be serialized twice if using `client.waitForCompletionOrCreateCheckStatusResponse`. This is because the `createHttpResponse` method used by `waitForCompletionOrCreateCheckStatusResponse` was serializing the output before passing it to the `HttpResponse` constructor, but the constructor itself also serializes the output. This PR fixes this bug.