### PR TITLE
Fix error log when executing any entities

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -67,6 +67,7 @@ export class Entity<T> {
             }
         }
 
+        context.suppressAsyncDoneError = true;
         context.done(null, returnState);
     }
 

--- a/src/ientityfunctioncontext.ts
+++ b/src/ientityfunctioncontext.ts
@@ -3,4 +3,5 @@ import { DurableEntityContext } from "./classes";
 
 export interface IEntityFunctionContext<T> extends Context {
     df: DurableEntityContext<T>;
+    suppressAsyncDoneError: boolean;
 }

--- a/src/iorchestrationfunctioncontext.ts
+++ b/src/iorchestrationfunctioncontext.ts
@@ -3,4 +3,5 @@ import { DurableOrchestrationContext } from "./classes";
 
 export interface IOrchestrationFunctionContext extends Context {
     df: DurableOrchestrationContext;
+    suppressAsyncDoneError: boolean;
 }

--- a/src/taskorchestrationexecutor.ts
+++ b/src/taskorchestrationexecutor.ts
@@ -132,6 +132,7 @@ export class TaskOrchestrationExecutor {
         }
 
         // Communicate the orchestration's current state
+        context.suppressAsyncDoneError = true;
         context.done(error, result);
         return;
     }

--- a/src/testingUtils.ts
+++ b/src/testingUtils.ts
@@ -81,6 +81,7 @@ export class DummyOrchestrationContext implements IOrchestrationFunctionContext 
     traceContext: TraceContext;
     bindingDefinitions: BindingDefinition[];
     log: Logger;
+    suppressAsyncDoneError: boolean;
     done(err?: string | Error, result?: any): void {
         this.doneValue = result;
         this.err = err;

--- a/test/integration/entity-spec.ts
+++ b/test/integration/entity-spec.ts
@@ -100,6 +100,7 @@ class MockContext<T> implements IEntityFunctionContext<T> {
     public req?: HttpRequest | undefined;
     public res?: { [key: string]: any } | undefined;
     public df: DurableEntityContext<T>;
+    public suppressAsyncDoneError: boolean;
 
     public done(err?: Error | string | null, result?: EntityState): void {
         this.doneValue = result;

--- a/test/integration/orchestrator-spec.ts
+++ b/test/integration/orchestrator-spec.ts
@@ -2969,6 +2969,7 @@ class MockContext implements IOrchestrationFunctionContext {
     log: Logger;
     req?: HttpRequest;
     res?: { [key: string]: any };
+    suppressAsyncDoneError: boolean;
 
     public done(err?: Error | string | null, result?: IOrchestratorState): void {
         this.doneValue = result;


### PR DESCRIPTION
Fixes #373. Updates the entity logic and the task executor to set `suppressAsyncDoneError` to `true` before calling `context.done()`, therefore the error isn't thrown out by the node worker anymore.