### PR TITLE
Remove support for node versions 10 and 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 | Branch | Status                                                                                                                                                                                                                                    | Support level | Programming model | Node.js versions |
 | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- | ----------------- | ---------------- |
-| v2.x   | [![Build Status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/Azure.azure-functions-durable-js?branchName=v2.x)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=13&branchName=v2.x) | GA            | V1, V2, V3        | 14.x+            |
+| v2.x   | [![Build Status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/Azure.azure-functions-durable-js?branchName=v2.x)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=13&branchName=v2.x) | GA            | V3                | 14.x+            |
 | v3.x   | [![Build Status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/Azure.azure-functions-durable-js?branchName=v3.x)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=13&branchName=v3.x) | Preview       | V4 (preview)      | 18.x+            |
 
 # Durable Functions for Node.js
@@ -33,7 +33,7 @@ You can follow the [Visual Studio Code quickstart](https://docs.microsoft.com/en
 
 1. Install prerequisites:
 
-    - [Azure Functions Core Tools version 2.x](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local#install-the-azure-functions-core-tools)
+    - [Azure Functions Core Tools version 4.x](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local#install-the-azure-functions-core-tools)
     - [Azure Storage Emulator](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-emulator) (Windows) or an actual Azure storage account (Mac or Linux)
     - Node.js 14.x or later
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 | Branch | Status                                                                                                                                                                                                                                    | Support level | Programming model | Node.js versions |
 | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- | ----------------- | ---------------- |
-| v2.x   | [![Build Status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/Azure.azure-functions-durable-js?branchName=v2.x)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=13&branchName=v2.x) | GA            | V1, V2, V3        | 8.x+             |
+| v2.x   | [![Build Status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/Azure.azure-functions-durable-js?branchName=v2.x)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=13&branchName=v2.x) | GA            | V1, V2, V3        | 14.x+            |
 | v3.x   | [![Build Status](https://azfunc.visualstudio.com/Azure%20Functions/_apis/build/status/Azure.azure-functions-durable-js?branchName=v3.x)](https://azfunc.visualstudio.com/Azure%20Functions/_build/latest?definitionId=13&branchName=v3.x) | Preview       | V4 (preview)      | 18.x+            |
 
 # Durable Functions for Node.js
@@ -35,7 +35,7 @@ You can follow the [Visual Studio Code quickstart](https://docs.microsoft.com/en
 
     - [Azure Functions Core Tools version 2.x](https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local#install-the-azure-functions-core-tools)
     - [Azure Storage Emulator](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-emulator) (Windows) or an actual Azure storage account (Mac or Linux)
-    - Node.js 8.6.0 or later
+    - Node.js 14.x or later
 
 2. [Create an Azure Functions app.](https://docs.microsoft.com/en-us/azure/azure-functions/functions-create-first-function-vs-code) [Visual Studio Code's Azure Functions plugin](https://code.visualstudio.com/tutorials/functions-extension/getting-started) is recommended.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,13 @@
 variables:
-    { MODULE_VERSION: "2.1.2", NODE_14: "14.x", NODE_16: "16.x", NODE_18: "18.x", NODE_20: "20.x" }
+    {
+        MODULE_VERSION: "2.1.2",
+        NODE_10: "10.x",
+        NODE_12: "12.x",
+        NODE_14: "14.x",
+        NODE_16: "16.x",
+        NODE_18: "18.x",
+        NODE_20: "20.x",
+    }
 name: $(MODULE_VERSION)-$(Date:yyyyMMdd)$(Rev:.r)
 
 pr:
@@ -14,6 +22,12 @@ jobs:
     - job: Test
       strategy:
           matrix:
+              UBUNTU_NODE10:
+                  IMAGE_TYPE: "ubuntu-latest"
+                  NODE_VERSION: $(NODE_10)
+              UBUNTU_NODE12:
+                  IMAGE_TYPE: "ubuntu-latest"
+                  NODE_VERSION: $(NODE_12)
               UBUNTU_NODE14:
                   IMAGE_TYPE: "ubuntu-latest"
                   NODE_VERSION: $(NODE_14)
@@ -26,6 +40,12 @@ jobs:
               UBUNTU_NODE20:
                   IMAGE_TYPE: "ubuntu-latest"
                   NODE_VERSION: $(NODE_20)
+              WINDOWS_NODE10:
+                  IMAGE_TYPE: "windows-latest"
+                  NODE_VERSION: $(NODE_10)
+              WINDOWS_NODE12:
+                  IMAGE_TYPE: "windows-latest"
+                  NODE_VERSION: $(NODE_12)
               WINDOWS_NODE14:
                   IMAGE_TYPE: "windows-latest"
                   NODE_VERSION: $(NODE_14)
@@ -38,6 +58,12 @@ jobs:
               WINDOWS_NODE20:
                   IMAGE_TYPE: "windows-latest"
                   NODE_VERSION: $(NODE_20)
+              MAC_NODE10:
+                  IMAGE_TYPE: "macOS-latest"
+                  NODE_VERSION: $(NODE_10)
+              MAC_NODE12:
+                  IMAGE_TYPE: "macOS-latest"
+                  NODE_VERSION: $(NODE_12)
               MAC_NODE14:
                   IMAGE_TYPE: "macOS-latest"
                   NODE_VERSION: $(NODE_14)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,13 +1,5 @@
 variables:
-    {
-        MODULE_VERSION: "2.1.2",
-        NODE_10: "10.x",
-        NODE_12: "12.x",
-        NODE_14: "14.x",
-        NODE_16: "16.x",
-        NODE_18: "18.x",
-        NODE_20: "20.x",
-    }
+    { MODULE_VERSION: "2.1.2", NODE_14: "14.x", NODE_16: "16.x", NODE_18: "18.x", NODE_20: "20.x" }
 name: $(MODULE_VERSION)-$(Date:yyyyMMdd)$(Rev:.r)
 
 pr:
@@ -22,12 +14,6 @@ jobs:
     - job: Test
       strategy:
           matrix:
-              UBUNTU_NODE10:
-                  IMAGE_TYPE: "ubuntu-latest"
-                  NODE_VERSION: $(NODE_10)
-              UBUNTU_NODE12:
-                  IMAGE_TYPE: "ubuntu-latest"
-                  NODE_VERSION: $(NODE_12)
               UBUNTU_NODE14:
                   IMAGE_TYPE: "ubuntu-latest"
                   NODE_VERSION: $(NODE_14)
@@ -40,12 +26,6 @@ jobs:
               UBUNTU_NODE20:
                   IMAGE_TYPE: "ubuntu-latest"
                   NODE_VERSION: $(NODE_20)
-              WINDOWS_NODE10:
-                  IMAGE_TYPE: "windows-latest"
-                  NODE_VERSION: $(NODE_10)
-              WINDOWS_NODE12:
-                  IMAGE_TYPE: "windows-latest"
-                  NODE_VERSION: $(NODE_12)
               WINDOWS_NODE14:
                   IMAGE_TYPE: "windows-latest"
                   NODE_VERSION: $(NODE_14)
@@ -58,12 +38,6 @@ jobs:
               WINDOWS_NODE20:
                   IMAGE_TYPE: "windows-latest"
                   NODE_VERSION: $(NODE_20)
-              MAC_NODE10:
-                  IMAGE_TYPE: "macOS-latest"
-                  NODE_VERSION: $(NODE_10)
-              MAC_NODE12:
-                  IMAGE_TYPE: "macOS-latest"
-                  NODE_VERSION: $(NODE_12)
               MAC_NODE14:
                   IMAGE_TYPE: "macOS-latest"
                   NODE_VERSION: $(NODE_14)


### PR DESCRIPTION
Those versions have reached EOL and are no longer supported by the Functions runtime