### PR TITLE
Ensure tasks are scheduled only once

### DIFF
--- a/src/task.ts
+++ b/src/task.ts
@@ -212,6 +212,7 @@ export class NoOpTask extends TaskBase {
  */
 export class DFTask extends TaskBase implements Task {
     protected action: IAction;
+    public alreadyScheduled = false;
 
     /** Get this task's backing action */
     get actionObj(): IAction {

--- a/src/taskorchestrationexecutor.ts
+++ b/src/taskorchestrationexecutor.ts
@@ -507,7 +507,7 @@ export class TaskOrchestrationExecutor {
 
     /**
      * @hidden
-     * Marks the current task (and all its children, if compound task) as already scheduled.
+     * Marks the current task (and all its children if it is a compound task) as already scheduled.
      * If a task is already scheduled, its backing action should not be added to the actions array
      *
      * @param task The task to mark as already scheduled.


### PR DESCRIPTION
Fixes #485. This PR adds a flag, `alreadyScheduled`, to `DFTask` objects. This flag is checked before adding the backing action to the `actions` array that is sent back to the extension. This ensures that actions are scheduled only once.