### PR TITLE
Refactor "shim" file into modules

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -6,7 +6,7 @@ import {
     OrchestrationOptions,
 } from "durable-functions";
 import * as trigger from "./trigger";
-import { createOrchestrator, createEntityFunction } from "./testingUtils";
+import { createOrchestrator, createEntityFunction } from "./util/testingUtils";
 import { app as azFuncApp } from "@azure/functions";
 
 export function orchestration(

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,45 @@
+import {
+    ActivityOptions,
+    EntityHandler,
+    EntityOptions,
+    OrchestrationHandler,
+    OrchestrationOptions,
+} from "durable-functions";
+import * as trigger from "./trigger";
+import { createOrchestrator, createEntityFunction } from "./testingUtils";
+import { app as azFuncApp } from "@azure/functions";
+
+export function orchestration(
+    functionName: string,
+    handlerOrOptions: OrchestrationHandler | OrchestrationOptions
+): void {
+    const options: OrchestrationOptions =
+        typeof handlerOrOptions === "function" ? { handler: handlerOrOptions } : handlerOrOptions;
+
+    azFuncApp.generic(functionName, {
+        trigger: trigger.orchestration(),
+        ...options,
+        handler: createOrchestrator(options.handler),
+    });
+}
+
+export function entity<T = unknown>(
+    functionName: string,
+    handlerOrOptions: EntityHandler<T> | EntityOptions<T>
+): void {
+    const options: EntityOptions<T> =
+        typeof handlerOrOptions === "function" ? { handler: handlerOrOptions } : handlerOrOptions;
+
+    azFuncApp.generic(functionName, {
+        trigger: trigger.entity(),
+        ...options,
+        handler: createEntityFunction(options.handler),
+    });
+}
+
+export function activity(functionName: string, options: ActivityOptions): void {
+    azFuncApp.generic(functionName, {
+        trigger: trigger.activity(),
+        ...options,
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,12 @@ import {
     DummyOrchestrationContext,
 } from "./classes";
 import { getClient } from "./durableorchestrationclient";
-import { app, input, trigger } from "./shim";
-import { DummyEntityContext } from "./util/testingUtils";
+import { DummyEntityContext, createEntityFunction, createOrchestrator } from "./util/testingUtils";
 import { ManagedIdentityTokenSource } from "./tokensource";
+
+export * as app from "./app";
+export * as trigger from "./trigger";
+export * as input from "./input";
 
 export {
     EntityId,
@@ -19,7 +22,6 @@ export {
     RetryOptions,
     DummyOrchestrationContext,
     DummyEntityContext,
-    app,
-    input,
-    trigger,
+    createOrchestrator,
+    createEntityFunction,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import {
     DummyOrchestrationContext,
 } from "./classes";
 import { getClient } from "./durableorchestrationclient";
-import { DummyEntityContext, createEntityFunction, createOrchestrator } from "./util/testingUtils";
+import { DummyEntityContext } from "./util/testingUtils";
 import { ManagedIdentityTokenSource } from "./tokensource";
 
 export * as app from "./app";
@@ -22,6 +22,4 @@ export {
     RetryOptions,
     DummyOrchestrationContext,
     DummyEntityContext,
-    createOrchestrator,
-    createEntityFunction,
 };

--- a/src/input.ts
+++ b/src/input.ts
@@ -1,0 +1,8 @@
+import { DurableClientInput } from "durable-functions";
+import { input as azFuncInput } from "@azure/functions";
+
+export function durableClient(): DurableClientInput {
+    return azFuncInput.generic({
+        type: "durableClient",
+    }) as DurableClientInput;
+}

--- a/src/trigger.ts
+++ b/src/trigger.ts
@@ -1,0 +1,20 @@
+import { ActivityTrigger, EntityTrigger, OrchestrationTrigger } from "durable-functions";
+import { trigger as azFuncTrigger } from "@azure/functions";
+
+export function activity(): ActivityTrigger {
+    return azFuncTrigger.generic({
+        type: "activityTrigger",
+    }) as ActivityTrigger;
+}
+
+export function orchestration(): OrchestrationTrigger {
+    return azFuncTrigger.generic({
+        type: "orchestrationTrigger",
+    }) as OrchestrationTrigger;
+}
+
+export function entity(): EntityTrigger {
+    return azFuncTrigger.generic({
+        type: "entityTrigger",
+    }) as EntityTrigger;
+}

--- a/src/util/testingUtils.ts
+++ b/src/util/testingUtils.ts
@@ -14,6 +14,7 @@ import {
     HistoryEventOptions,
     Orchestrator,
     OrchestratorStartedEvent,
+    OrchestratorState,
 } from "../classes";
 import { ReplaySchema } from "../replaySchema";
 import * as uuidv1 from "uuid/v1";

--- a/src/util/testingUtils.ts
+++ b/src/util/testingUtils.ts
@@ -1,15 +1,30 @@
-import { InvocationContext, InvocationContextInit, LogHandler } from "@azure/functions";
 import {
+    FunctionHandler,
+    InvocationContext,
+    InvocationContextInit,
+    LogHandler,
+} from "@azure/functions";
+import {
+    DurableEntityBindingInfo,
     DurableOrchestrationBindingInfo,
     DurableOrchestrationContext,
+    Entity,
+    EntityState,
     HistoryEvent,
     HistoryEventOptions,
+    Orchestrator,
     OrchestratorStartedEvent,
 } from "../classes";
 import { ReplaySchema } from "../replaySchema";
 import * as uuidv1 from "uuid/v1";
-import { DurableEntityContext, EntityContext, OrchestrationContext } from "durable-functions";
+import {
+    DurableEntityContext,
+    EntityContext,
+    OrchestrationContext,
+    OrchestrationHandler,
+} from "durable-functions";
 import * as types from "durable-functions";
+import { EntityHandler } from "durable-functions";
 
 export class DummyOrchestrationContext extends InvocationContext
     implements OrchestrationContext, types.DummyOrchestrationContext {
@@ -99,4 +114,45 @@ export class DummyEntityContext<T> extends InvocationContext
     }
 
     df: DurableEntityContext<T>;
+}
+
+type EntityFunction<T> = FunctionHandler &
+    ((entityTrigger: DurableEntityBindingInfo, context: EntityContext<T>) => Promise<EntityState>);
+
+type OrchestrationFunction = FunctionHandler &
+    ((
+        orchestrationTrigger: DurableOrchestrationInput,
+        context: OrchestrationContext
+    ) => Promise<OrchestratorState>);
+
+/**
+ * Enables a generator function to act as an orchestrator function.
+ *
+ * @param fn the generator function that should act as an orchestrator
+ */
+export function createOrchestrator(fn: OrchestrationHandler): OrchestrationFunction {
+    const listener = new Orchestrator(fn).listen();
+
+    return async (
+        orchestrationTrigger: DurableOrchestrationInput,
+        context: OrchestrationContext
+    ): Promise<OrchestratorState> => {
+        return await listener(orchestrationTrigger, context);
+    };
+}
+
+/**
+ * Enables an entity handler function to act as a Durable Entity Azure Function.
+ *
+ * @param fn the handler function that should act as a durable entity
+ */
+export function createEntityFunction<T = unknown>(fn: EntityHandler<T>): EntityFunction<T> {
+    const listener = new Entity<T>(fn).listen();
+
+    return async (
+        entityTrigger: DurableEntityBindingInfo,
+        context: EntityContext<T>
+    ): Promise<EntityState> => {
+        return await listener(entityTrigger, context);
+    };
 }

--- a/test/testobjects/TestOrchestrations.ts
+++ b/test/testobjects/TestOrchestrations.ts
@@ -1,7 +1,7 @@
 import * as df from "../../src";
 import { OrchestrationContext } from "durable-functions";
-import { createOrchestrator } from "../../src/shim";
 import { DurableHttpRequest } from "src/classes";
+import { createOrchestrator } from "../../src/testingUtils";
 
 export class TestOrchestrations {
     public static NotGenerator: any = createOrchestrator(function* () {

--- a/test/testobjects/TestOrchestrations.ts
+++ b/test/testobjects/TestOrchestrations.ts
@@ -1,7 +1,7 @@
 import * as df from "../../src";
 import { OrchestrationContext } from "durable-functions";
 import { DurableHttpRequest } from "src/classes";
-import { createOrchestrator } from "../../src/testingUtils";
+import { createOrchestrator } from "../../src/util/testingUtils";
 
 export class TestOrchestrations {
     public static NotGenerator: any = createOrchestrator(function* () {

--- a/test/testobjects/testentities.ts
+++ b/test/testobjects/testentities.ts
@@ -1,4 +1,4 @@
-import { createEntityFunction } from "../../src/testingUtils";
+import { createEntityFunction } from "../../src/util/testingUtils";
 
 export class TestEntities {
     public static StringStore = createEntityFunction<string>((context): void => {

--- a/test/testobjects/testentities.ts
+++ b/test/testobjects/testentities.ts
@@ -1,4 +1,4 @@
-import { createEntityFunction } from "../../src/shim";
+import { createEntityFunction } from "../../src/testingUtils";
 
 export class TestEntities {
     public static StringStore = createEntityFunction<string>((context): void => {


### PR DESCRIPTION
Similar to https://github.com/Azure/azure-functions-nodejs-library/pull/50 on the node library. This PR doesn't make any code or functionality changes, just reorganizes code. It removes the use of namespaces, and gets rid of the "shim.ts" file in favor of exporting modules for each "namespace"