### PR TITLE
Move the `taskOrchestrationExecutor` from RetryableTask constructor to `trySetValue()`

### DIFF
--- a/src/orchestrations/DurableOrchestrationContext.ts
+++ b/src/orchestrations/DurableOrchestrationContext.ts
@@ -162,7 +162,7 @@ export class DurableOrchestrationContext implements types.DurableOrchestrationCo
     ): Task {
         const newAction = new CallActivityWithRetryAction(name, retryOptions, input);
         const backingTask = new AtomicTask(false, newAction);
-        const task = new RetryableTask(backingTask, retryOptions, this.taskOrchestratorExecutor);
+        const task = new RetryableTask(backingTask, retryOptions);
         return task;
     }
 
@@ -215,7 +215,7 @@ export class DurableOrchestrationContext implements types.DurableOrchestrationCo
             instanceId
         );
         const backingTask = new AtomicTask(false, newAction);
-        const task = new RetryableTask(backingTask, retryOptions, this.taskOrchestratorExecutor);
+        const task = new RetryableTask(backingTask, retryOptions);
         return task;
     }
 

--- a/src/orchestrations/TaskOrchestrationExecutor.ts
+++ b/src/orchestrations/TaskOrchestrationExecutor.ts
@@ -344,7 +344,7 @@ export class TaskOrchestrationExecutor {
 
         // Set result to the task, and update it's isPlayed flag.
         task.isPlayed = event.IsPlayed;
-        task.setValue(!isSuccess, taskResult);
+        task.setValue(!isSuccess, taskResult, this);
     }
 
     /**

--- a/src/task/CompoundTask.ts
+++ b/src/task/CompoundTask.ts
@@ -1,3 +1,4 @@
+import { TaskOrchestrationExecutor } from "src/orchestrations/TaskOrchestrationExecutor";
 import { IAction } from "../actions/IAction";
 import { DFTask } from "./DFTask";
 import { TaskBase } from "./TaskBase";
@@ -40,11 +41,11 @@ export abstract class CompoundTask extends DFTask {
      * @param child
      *  A sub-task of this task.
      */
-    public handleCompletion(child: TaskBase): void {
+    public handleCompletion(child: TaskBase, executor?: TaskOrchestrationExecutor): void {
         if (!this.isPlayed) {
             this.isPlayed = child.isPlayed;
         }
-        this.trySetValue(child);
+        this.trySetValue(child, executor);
     }
 
     /**
@@ -55,5 +56,5 @@ export abstract class CompoundTask extends DFTask {
      * @param child
      *  A sub-task
      */
-    abstract trySetValue(child: TaskBase): void;
+    abstract trySetValue(child: TaskBase, executor?: TaskOrchestrationExecutor): void;
 }

--- a/src/task/CompoundTask.ts
+++ b/src/task/CompoundTask.ts
@@ -39,6 +39,8 @@ export abstract class CompoundTask extends DFTask {
      * @hidden
      * Tries to set this task's result based on the completion of a sub-task
      * @param child
+     * @param executor The TaskOrchestrationExecutor instance that is managing the replay
+     *      This argument is optional, and mostly passed to the RetryableTask trySetValue() method
      *  A sub-task of this task.
      */
     public handleCompletion(child: TaskBase, executor?: TaskOrchestrationExecutor): void {

--- a/src/task/RetryableTask.ts
+++ b/src/task/RetryableTask.ts
@@ -47,7 +47,7 @@ export class RetryableTask extends WhenAllTask {
     public trySetValue(child: TaskBase, executor?: TaskOrchestrationExecutor): void {
         if (!executor) {
             throw new Error(
-                "Ne executor passed to RetryableTask.trySetValue. " +
+                "No executor passed to RetryableTask.trySetValue. " +
                     "A TaskOrchestrationExecutor is required to schedule new tasks."
             );
         }

--- a/src/task/RetryableTask.ts
+++ b/src/task/RetryableTask.ts
@@ -5,6 +5,7 @@ import { DFTask } from "./DFTask";
 import { NoOpTask } from "./NoOpTask";
 import { TaskBase } from "./TaskBase";
 import { WhenAllTask } from "./WhenAllTask";
+import { DurableError } from "../error/DurableError";
 
 /**
  * @hidden
@@ -46,9 +47,12 @@ export class RetryableTask extends WhenAllTask {
      */
     public trySetValue(child: TaskBase, executor?: TaskOrchestrationExecutor): void {
         if (!executor) {
-            throw new Error(
-                "No executor passed to RetryableTask.trySetValue. " +
-                    "A TaskOrchestrationExecutor is required to schedule new tasks."
+            throw new DurableError(
+                "A framework-internal error was detected: " +
+                    "No executor passed to RetryableTask.trySetValue. " +
+                    "A TaskOrchestrationExecutor is required to schedule new tasks. " +
+                    "If this issue persists, please report it here: " +
+                    "https://github.com/Azure/azure-functions-durable-js/issues"
             );
         }
 

--- a/src/task/TaskBase.ts
+++ b/src/task/TaskBase.ts
@@ -1,3 +1,4 @@
+import { TaskOrchestrationExecutor } from "src/orchestrations/TaskOrchestrationExecutor";
 import { BackingAction, TaskID, TaskState } from ".";
 import { CompoundTask } from "./CompoundTask";
 
@@ -56,7 +57,7 @@ export abstract class TaskBase {
     }
 
     /** Attempt to set a result for this task, and notifies parents, if any */
-    public setValue(isError: boolean, value: unknown): void {
+    public setValue(isError: boolean, value: unknown, executor?: TaskOrchestrationExecutor): void {
         let newState: TaskState;
 
         if (isError) {
@@ -71,17 +72,17 @@ export abstract class TaskBase {
 
         this.changeState(newState);
         this.result = value;
-        this.propagate();
+        this.propagate(executor);
     }
 
     /**
      * @hidden
      * Notifies this task's parents about its state change.
      */
-    private propagate(): void {
+    private propagate(executor?: TaskOrchestrationExecutor): void {
         const hasCompleted = this.state !== TaskState.Running;
         if (hasCompleted && this.parent !== undefined) {
-            this.parent.handleCompletion(this);
+            this.parent.handleCompletion(this, executor);
         }
     }
 }


### PR DESCRIPTION
This doesn't change any functionality of the `RetryableTask`. Rather, this means that a `TaskOrchestrationExecutor` is not required in the constructor for `RetryableTask`, but can be passed as in argument when it's really needed: in the `trySetValue()` function. This means that a `RetryableTask` can be constructed _outside_ the context of a `DurableOrchestrationContext` (where the `TaskOrchestrationExecutor` is available), unblocking #418 

The reason all these changes are required is because this is the new flow of the `TaskOrchestrationExecutor`:

`TaskOrchestrationExecutor.execute()` calls `TaskBase.setValue()` with a reference of itself -> `TaskBase.setValue()` calls `TaskBase.propagate()` -> calls `CompoundTask.handleCompletion()` -> calls `CompoundTask.trySetValue()`