### PR TITLE
Add convenience methods to register durable client functions

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -62,3 +62,5 @@ export function activity(functionName: string, options: ActivityOptions): Regist
 
     return result;
 }
+
+export * as client from "./client";

--- a/src/client.ts
+++ b/src/client.ts
@@ -7,6 +7,7 @@ import {
 } from "durable-functions";
 import {
     FunctionHandler,
+    FunctionInput,
     FunctionResult,
     InvocationContext,
     app as azFuncApp,
@@ -39,11 +40,15 @@ export function generic(functionName: string, options: DurableClientOptions): vo
 }
 
 function addClientInput(options: Partial<DurableClientOptions>): void {
-    if (options.extraInputs) {
+    if (options.extraInputs && !options.extraInputs.find(isDurableClientInput)) {
         options.extraInputs.push(input.durableClient());
     } else {
         options.extraInputs = [input.durableClient()];
     }
+}
+
+function isDurableClientInput(inputOptions: FunctionInput): boolean {
+    return inputOptions.type === "durableClient" || inputOptions.type === "orchestrationClient";
 }
 
 function convertToFunctionHandler(clientHandler: DurableClientHandler): FunctionHandler {

--- a/src/client.ts
+++ b/src/client.ts
@@ -7,13 +7,12 @@ import {
 } from "durable-functions";
 import {
     FunctionHandler,
-    FunctionInput,
     FunctionResult,
     InvocationContext,
     app as azFuncApp,
 } from "@azure/functions";
 import { DurableClient } from "./durableClient/DurableClient";
-import { getClient } from "./durableClient/getClient";
+import { getClient, isDurableClientInput } from "./durableClient/getClient";
 
 export function http(functionName: string, options: HttpDurableClientOptions): void {
     addClientInput(options);
@@ -45,10 +44,6 @@ function addClientInput(options: Partial<DurableClientOptions>): void {
     } else {
         options.extraInputs = [input.durableClient()];
     }
-}
-
-function isDurableClientInput(inputOptions: FunctionInput): boolean {
-    return inputOptions.type === "durableClient" || inputOptions.type === "orchestrationClient";
 }
 
 function convertToFunctionHandler(clientHandler: DurableClientHandler): FunctionHandler {

--- a/src/client.ts
+++ b/src/client.ts
@@ -39,10 +39,9 @@ export function generic(functionName: string, options: DurableClientOptions): vo
 }
 
 function addClientInput(options: Partial<DurableClientOptions>): void {
-    if (options.extraInputs && !options.extraInputs.find(isDurableClientInput)) {
+    options.extraInputs = options.extraInputs ?? [];
+    if (!options.extraInputs.find(isDurableClientInput)) {
         options.extraInputs.push(input.durableClient());
-    } else {
-        options.extraInputs = [input.durableClient()];
     }
 }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,54 @@
+import * as input from "./input";
+import {
+    DurableClientHandler,
+    DurableClientOptions,
+    HttpDurableClientOptions,
+    TimerDurableClientOptions,
+} from "durable-functions";
+import {
+    FunctionHandler,
+    FunctionResult,
+    InvocationContext,
+    app as azFuncApp,
+} from "@azure/functions";
+import { DurableClient } from "./durableClient/DurableClient";
+import { getClient } from "./durableClient/getClient";
+
+export function http(functionName: string, options: HttpDurableClientOptions): void {
+    addClientInput(options);
+    azFuncApp.http(functionName, {
+        ...options,
+        handler: convertToFunctionHandler(options.handler),
+    });
+}
+
+export function timer(functionName: string, options: TimerDurableClientOptions): void {
+    addClientInput(options);
+    azFuncApp.timer(functionName, {
+        ...options,
+        handler: convertToFunctionHandler(options.handler),
+    });
+}
+
+export function generic(functionName: string, options: DurableClientOptions): void {
+    addClientInput(options);
+    azFuncApp.generic(functionName, {
+        ...options,
+        handler: convertToFunctionHandler(options.handler),
+    });
+}
+
+function addClientInput(options: Partial<DurableClientOptions>): void {
+    if (options.extraInputs) {
+        options.extraInputs.push(input.durableClient());
+    } else {
+        options.extraInputs = [input.durableClient()];
+    }
+}
+
+function convertToFunctionHandler(clientHandler: DurableClientHandler): FunctionHandler {
+    return (trigger: unknown, context: InvocationContext): FunctionResult<any> => {
+        const client: DurableClient = getClient(context);
+        return clientHandler(trigger, client, context);
+    };
+}

--- a/src/durableClient/getClient.ts
+++ b/src/durableClient/getClient.ts
@@ -32,7 +32,7 @@ export function getClient(context: InvocationContext): DurableClient {
 }
 
 /** @hidden */
-function isDurableClientInput(input: FunctionInput): boolean {
+export function isDurableClientInput(input: FunctionInput): boolean {
     return input.type === "durableClient" || input.type === "orchestrationClient";
 }
 

--- a/types/app.client.d.ts
+++ b/types/app.client.d.ts
@@ -1,0 +1,33 @@
+import {
+    DurableClientOptions,
+    HttpDurableClientOptions,
+    TimerDurableClientOptions,
+} from "./durableClient";
+
+/**
+ * Registers an HTTP-triggered durable client function for your Function App.
+ * This function can be triggered as a normal HTTP function, but will receive
+ * a Durable Client instance as its second argument.
+ *
+ * @param functionName The name of the function. The name must be unique within your app and will mostly be used for your own tracking purposes
+ * @param options Configuration options describing the inputs, outputs, and handler for this function
+ */
+export function http(functionName: string, options: HttpDurableClientOptions): void;
+
+/**
+ * Registered a timer-triggered durable client function for your Function App.
+ * This function will be triggered as a normal timer function, but will receive
+ * a Durable Client instance as its second argument.
+ *
+ * @param functionName The name of the function. The name must be unique within your app and will mostly be used for your own tracking purposes
+ * @param options Configuration options describing the inputs, outputs, and handler for this function
+ */
+export function timer(functionName: string, options: TimerDurableClientOptions): void;
+
+/**
+ * Registers a generic function for your Function App with a Durable Client input.
+ *
+ * @param functionName The name of the function. The name must be unique within your app and will mostly be used for your own tracking purposes
+ * @param options Configuration options describing the inputs, outputs, and handler for this function
+ */
+export function generic(functionName: string, options: DurableClientOptions): void;

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -55,3 +55,5 @@ export function entity<T = unknown>(functionName: string, options: EntityOptions
  * @param options the configuration options for this activity, specifying the handler and the inputs and outputs
  */
 export function activity(functionName: string, options: ActivityOptions): RegisteredActivity;
+
+export * as client from "./app.client";

--- a/types/durableClient.d.ts
+++ b/types/durableClient.d.ts
@@ -1,9 +1,63 @@
-import { FunctionInput, HttpRequest, HttpResponse } from "@azure/functions";
+import {
+    FunctionInput,
+    FunctionOptions,
+    FunctionResult,
+    HttpFunctionOptions,
+    HttpRequest,
+    HttpResponse,
+    HttpResponseInit,
+    InvocationContext,
+    Timer,
+    TimerFunctionOptions,
+} from "@azure/functions";
 import { EntityId, EntityStateResponse } from "./entity";
 import { DurableOrchestrationStatus, OrchestrationRuntimeStatus } from "./orchestration";
 
 export interface DurableClientInput extends FunctionInput {
     type: "durableClient";
+}
+
+/**
+ * Type of a handler function that is triggered by some trigger
+ * and receives a [[DurableClient]] instance as an input.
+ */
+export type DurableClientHandler = (
+    triggerInput: any,
+    durableClient: DurableClient,
+    context: InvocationContext
+) => FunctionResult<any>;
+
+/**
+ * Configures the inputs, outputs, and handler for a Durable Client function.
+ */
+export interface DurableClientOptions extends Omit<FunctionOptions, "handler"> {
+    handler: DurableClientHandler;
+}
+
+export type HttpDurableClientHandler = (
+    request: HttpRequest,
+    client: DurableClient,
+    context: InvocationContext
+) => FunctionResult<HttpResponseInit | HttpResponse>;
+
+/**
+ * Configures options for an HTTP-triggered Durable Client function.
+ */
+export interface HttpDurableClientOptions extends Omit<HttpFunctionOptions, "handler"> {
+    handler: DurableClientHandler;
+}
+
+export type TimerDurableClientHandler = (
+    myTimer: Timer,
+    client: DurableClient,
+    context: InvocationContext
+) => FunctionResult;
+
+/**
+ * Configures options for a timer-triggered Durable Client function.
+ */
+export interface TimerDurableClientOptions extends Omit<TimerFunctionOptions, "handler"> {
+    handler: DurableClientHandler;
 }
 
 /**

--- a/types/durableClient.d.ts
+++ b/types/durableClient.d.ts
@@ -44,7 +44,7 @@ export type HttpDurableClientHandler = (
  * Configures options for an HTTP-triggered Durable Client function.
  */
 export interface HttpDurableClientOptions extends Omit<HttpFunctionOptions, "handler"> {
-    handler: DurableClientHandler;
+    handler: HttpDurableClientHandler;
 }
 
 export type TimerDurableClientHandler = (
@@ -57,7 +57,7 @@ export type TimerDurableClientHandler = (
  * Configures options for a timer-triggered Durable Client function.
  */
 export interface TimerDurableClientOptions extends Omit<TimerFunctionOptions, "handler"> {
-    handler: DurableClientHandler;
+    handler: TimerDurableClientHandler;
 }
 
 /**


### PR DESCRIPTION
Partially resolves #414. This PR adds a namespace `client`, under `df.app`, which provides methods to quickly register durable client functions. These functions receive three arguments instead of the regular two: the trigger, the durable client, and the `InvocationContext`, in this order. This allows users to quickly and easily register durable client functions, without having to manually configure the `durableClient` input binding and calling the `getClient` method. This PR starts out with three methods: `http` to register HTTP-triggered durable client functions, `timer`, and `generic`. These behave exactly the same as the equivalent from `@azure/functions`, except accepting the additional `DurableClient` argument.

Example usage:

### HTTP-triggered client function

```TS
const httpStart: HttpDurableClientHandler = async (
    request: HttpRequest,
    client: DurableClient,
    context: InvocationContext
): Promise<HttpResponse> => {
    const body: unknown = await request.json();
    const instanceId: string = await client.startNew(request.params.orchestratorName, {
        input: body,
    });

    context.log(`Started orchestration with ID = '${instanceId}'.`);

    return client.createCheckStatusResponse(request, instanceId);
};

df.app.client.http("httpStart", {
    route: "orchestrators/{orchestratorName}",
    handler: httpStart,
});
```

### Timer-triggered client function

```TS
const timerStart: TimerDurableClientHandler = async (
    _timer: Timer,
    client: DurableClient,
    context: InvocationContext
): Promise<void> => {
    const instanceId: string = await client.startNew("helloSequence");
    context.log(`Started orchestration with ID = '${instanceId}'.`);
};

df.app.client.timer("timerStart", {
    schedule: "0 */1 * * * *",
    handler: timerStart,
});
```

### Storage Queue-triggered client function (using generic)

```TS
const storageQueueStart: DurableClientHandler = async (
    message: string,
    client: DurableClient,
    context: InvocationContext
): Promise<void> => {
    const instanceId: string = await client.startNew(message);
    context.log(`Started orchestration with ID = '${instanceId}'.`);
};

df.app.client.generic("storageQueueStart", {
    trigger: trigger.storageQueue({ queueName: "orchestrations", connection: "StorageConnString" }),
    handler: storageQueueStart,  
})
```
