### PR TITLE
Add all triggers to `app.client` namespace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,9 +61,15 @@
             }
         },
         "node_modules/@azure/functions": {
+<<<<<<< HEAD
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.0.0.tgz",
             "integrity": "sha512-NsL1vbYtsh19eA6d3Syo9bP8d1JAguE9nRd9AFBTcK+lhbRzKvKQ98efiGz21ug2Cm526SMet0imxUSykviEHA==",
+=======
+            "version": "4.0.0-alpha.13",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.0.0-alpha.13.tgz",
+            "integrity": "sha512-zSxBgnTt+sGsF8f38XX8PyiRZ+Inr9PjOSfStyn48ppGyel1bp45AyRvR91DisCvkdnOjCLFcRydsbfikkXWaA==",
+>>>>>>> 892e5c0 (update @azure/functions package)
             "dependencies": {
                 "long": "^4.0.0",
                 "undici": "^5.13.0"
@@ -3120,9 +3126,15 @@
             "dev": true
         },
         "@azure/functions": {
+<<<<<<< HEAD
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.0.0.tgz",
             "integrity": "sha512-NsL1vbYtsh19eA6d3Syo9bP8d1JAguE9nRd9AFBTcK+lhbRzKvKQ98efiGz21ug2Cm526SMet0imxUSykviEHA==",
+=======
+            "version": "4.0.0-alpha.13",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.0.0-alpha.13.tgz",
+            "integrity": "sha512-zSxBgnTt+sGsF8f38XX8PyiRZ+Inr9PjOSfStyn48ppGyel1bp45AyRvR91DisCvkdnOjCLFcRydsbfikkXWaA==",
+>>>>>>> 892e5c0 (update @azure/functions package)
             "requires": {
                 "long": "^4.0.0",
                 "undici": "^5.13.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         },
         "node_modules/@azure/functions": {
 <<<<<<< HEAD
+<<<<<<< HEAD
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.0.0.tgz",
             "integrity": "sha512-NsL1vbYtsh19eA6d3Syo9bP8d1JAguE9nRd9AFBTcK+lhbRzKvKQ98efiGz21ug2Cm526SMet0imxUSykviEHA==",
@@ -70,6 +71,11 @@
             "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.0.0-alpha.13.tgz",
             "integrity": "sha512-zSxBgnTt+sGsF8f38XX8PyiRZ+Inr9PjOSfStyn48ppGyel1bp45AyRvR91DisCvkdnOjCLFcRydsbfikkXWaA==",
 >>>>>>> 892e5c0 (update @azure/functions package)
+=======
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.0.1.tgz",
+            "integrity": "sha512-Ol38b4XOlu6IDkLnO91HaYeo2utMixG0LIA1NR9Qehu17U/cGjNx+bAcOEdNlSJWNYh5ChhzjxA/uFB5dQJtmg==",
+>>>>>>> d362fc5 (update version of @azure/functions)
             "dependencies": {
                 "long": "^4.0.0",
                 "undici": "^5.13.0"
@@ -3127,6 +3133,7 @@
         },
         "@azure/functions": {
 <<<<<<< HEAD
+<<<<<<< HEAD
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.0.0.tgz",
             "integrity": "sha512-NsL1vbYtsh19eA6d3Syo9bP8d1JAguE9nRd9AFBTcK+lhbRzKvKQ98efiGz21ug2Cm526SMet0imxUSykviEHA==",
@@ -3135,6 +3142,11 @@
             "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.0.0-alpha.13.tgz",
             "integrity": "sha512-zSxBgnTt+sGsF8f38XX8PyiRZ+Inr9PjOSfStyn48ppGyel1bp45AyRvR91DisCvkdnOjCLFcRydsbfikkXWaA==",
 >>>>>>> 892e5c0 (update @azure/functions package)
+=======
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.0.1.tgz",
+            "integrity": "sha512-Ol38b4XOlu6IDkLnO91HaYeo2utMixG0LIA1NR9Qehu17U/cGjNx+bAcOEdNlSJWNYh5ChhzjxA/uFB5dQJtmg==",
+>>>>>>> d362fc5 (update version of @azure/functions)
             "requires": {
                 "long": "^4.0.0",
                 "undici": "^5.13.0"

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,8 +1,15 @@
 import * as input from "./input";
 import {
+    CosmosDBDurableClientOptions,
     DurableClientHandler,
     DurableClientOptions,
+    EventGridDurableClientOptions,
+    EventHubDurableClientOptions,
     HttpDurableClientOptions,
+    ServiceBusQueueDurableClientOptions,
+    ServiceBusTopicDurableClientOptions,
+    StorageBlobDurableClientOptions,
+    StorageQueueDurableClientOptions,
     TimerDurableClientOptions,
 } from "durable-functions";
 import {
@@ -25,6 +32,71 @@ export function http(functionName: string, options: HttpDurableClientOptions): v
 export function timer(functionName: string, options: TimerDurableClientOptions): void {
     addClientInput(options);
     azFuncApp.timer(functionName, {
+        ...options,
+        handler: convertToFunctionHandler(options.handler),
+    });
+}
+
+export function storageBlob(functionName: string, options: StorageBlobDurableClientOptions): void {
+    addClientInput(options);
+    azFuncApp.storageBlob(functionName, {
+        ...options,
+        handler: convertToFunctionHandler(options.handler),
+    });
+}
+
+export function storageQueue(
+    functionName: string,
+    options: StorageQueueDurableClientOptions
+): void {
+    addClientInput(options);
+    azFuncApp.storageQueue(functionName, {
+        ...options,
+        handler: convertToFunctionHandler(options.handler),
+    });
+}
+
+export function serviceBusQueue(
+    functionName: string,
+    options: ServiceBusQueueDurableClientOptions
+): void {
+    addClientInput(options);
+    azFuncApp.serviceBusQueue(functionName, {
+        ...options,
+        handler: convertToFunctionHandler(options.handler),
+    });
+}
+
+export function serviceBusTopic(
+    functionName: string,
+    options: ServiceBusTopicDurableClientOptions
+): void {
+    addClientInput(options);
+    azFuncApp.serviceBusTopic(functionName, {
+        ...options,
+        handler: convertToFunctionHandler(options.handler),
+    });
+}
+
+export function eventHub(functionName: string, options: EventHubDurableClientOptions): void {
+    addClientInput(options);
+    azFuncApp.eventHub(functionName, {
+        ...options,
+        handler: convertToFunctionHandler(options.handler),
+    });
+}
+
+export function eventGrid(functionName: string, options: EventGridDurableClientOptions): void {
+    addClientInput(options);
+    azFuncApp.eventGrid(functionName, {
+        ...options,
+        handler: convertToFunctionHandler(options.handler),
+    });
+}
+
+export function cosmosDB(functionName: string, options: CosmosDBDurableClientOptions): void {
+    addClientInput(options);
+    azFuncApp.cosmosDB(functionName, {
         ...options,
         handler: convertToFunctionHandler(options.handler),
     });

--- a/types/app.client.d.ts
+++ b/types/app.client.d.ts
@@ -1,6 +1,13 @@
 import {
+    CosmosDBDurableClientOptions,
     DurableClientOptions,
+    EventGridDurableClientOptions,
+    EventHubDurableClientOptions,
     HttpDurableClientOptions,
+    ServiceBusQueueDurableClientOptions,
+    ServiceBusTopicDurableClientOptions,
+    StorageBlobDurableClientOptions,
+    StorageQueueDurableClientOptions,
     TimerDurableClientOptions,
 } from "./durableClient";
 
@@ -23,6 +30,75 @@ export function http(functionName: string, options: HttpDurableClientOptions): v
  * @param options Configuration options describing the inputs, outputs, and handler for this function
  */
 export function timer(functionName: string, options: TimerDurableClientOptions): void;
+
+/**
+ * Registers a storage blob-triggered Durable Client function for your app.
+ * This function will be triggered whenever an item is added to a storage blob path,
+ *   and receives a DurableClient instance as its second argument.
+ * @param functionName The name of the function. The name must be unique within your app and will mostly be used for your own tracking purposes
+ * @param options Configuration options describing the inputs, outputs, and handler for this function
+ */
+export function storageBlob(functionName: string, options: StorageBlobDurableClientOptions): void;
+
+/**
+ * Registers a storage queue-triggered durable client function in  your app.
+ * This function will be triggered whenever an item is added to a storage queue,
+ *   and receives a DurableClient instance as its second argument.
+ * @param functionName The name of the function. The name must be unique within your app and will mostly be used for your own tracking purposes
+ * @param options Configuration options describing the inputs, outputs, and handler for this function
+ */
+export function storageQueue(functionName: string, options: StorageQueueDurableClientOptions): void;
+
+/**
+ * Registers a service bus queue-triggered durable client function in your app.
+ * This function will be triggered whenever a message is added to a service bus queue,
+ *   and receives a DurableClient instance as its second argument.
+ * @param functionName The name of the function. The name must be unique within your app and will mostly be used for your own tracking purposes
+ * @param options Configuration options describing the inputs, outputs, and handler for this function
+ */
+export function serviceBusQueue(
+    functionName: string,
+    options: ServiceBusQueueDurableClientOptions
+): void;
+
+/**
+ * Registers a service bus topic-triggered durable client function in your app.
+ * This function will be triggered whenever a message is added to a service bus topic,
+ *  and receives a DurableClient instance as its second argument.
+ * @param functionName The name of the function. The name must be unique within your app and will mostly be used for your own tracking purposes
+ * @param options Configuration options describing the inputs, outputs, and handler for this function
+ */
+export function serviceBusTopic(
+    functionName: string,
+    options: ServiceBusTopicDurableClientOptions
+): void;
+
+/**
+ * Registers an EventHub-triggered durable client function in your app.
+ * This function will be triggered whenever a message is added to an event hub,
+ *   and receives a DurableClient instance as its second argument.
+ * @param functionName The name of the function. The name must be unique within your app and will mostly be used for your own tracking purposes
+ * @param options Configuration options describing the inputs, outputs, and handler for this function
+ */
+export function eventHub(functionName: string, options: EventHubDurableClientOptions): void;
+
+/**
+ * Registers an EventGrid-triggered durable client function in your app.
+ * This function will be triggered whenever an event is sent by an event grid source,
+ *  and receives a DurableClient instance as its second argument.
+ * @param functionName The name of the function. The name must be unique within your app and will mostly be used for your own tracking purposes
+ * @param options Configuration options describing the inputs, outputs, and handler for this function
+ */
+export function eventGrid(functionName: string, options: EventGridDurableClientOptions): void;
+
+/**
+ * Registers a CosmosDB-triggered durable client function in your app.
+ * This function will be triggered whenever inserts and updates occur (not deletions),
+ *  and receives a DurableClient instance as its second argument.
+ * @param name The name of the function. The name must be unique within your app and will mostly be used for your own tracking purposes
+ * @param options Configuration options describing the inputs, outputs, and handler for this function
+ */
+export function cosmosDB(functionName: string, options: CosmosDBDurableClientOptions): void;
 
 /**
  * Registers a generic function for your Function App with a Durable Client input.

--- a/types/durableClient.d.ts
+++ b/types/durableClient.d.ts
@@ -1,4 +1,9 @@
 import {
+    CosmosDBv3FunctionOptions,
+    CosmosDBv4FunctionOptions,
+    EventGridEvent,
+    EventGridFunctionOptions,
+    EventHubFunctionOptions,
     FunctionInput,
     FunctionOptions,
     FunctionResult,
@@ -7,6 +12,10 @@ import {
     HttpResponse,
     HttpResponseInit,
     InvocationContext,
+    ServiceBusQueueFunctionOptions,
+    ServiceBusTopicFunctionOptions,
+    StorageBlobFunctionOptions,
+    StorageQueueFunctionOptions,
     Timer,
     TimerFunctionOptions,
 } from "@azure/functions";
@@ -58,6 +67,88 @@ export type TimerDurableClientHandler = (
  */
 export interface TimerDurableClientOptions extends Omit<TimerFunctionOptions, "handler"> {
     handler: TimerDurableClientHandler;
+}
+
+export type StorageBlobDurableClientHandler = (
+    blob: unknown,
+    client: DurableClient,
+    context: InvocationContext
+) => FunctionResult;
+
+export interface StorageBlobDurableClientOptions
+    extends Omit<StorageBlobFunctionOptions, "handler"> {
+    handler: StorageBlobDurableClientHandler;
+}
+
+export type StorageQueueDurableClientHandler = (
+    queueEntry: unknown,
+    client: DurableClient,
+    context: InvocationContext
+) => FunctionResult;
+
+export interface StorageQueueDurableClientOptions
+    extends Omit<StorageQueueFunctionOptions, "handler"> {
+    handler: StorageQueueDurableClientHandler;
+}
+
+export type ServiceBusQueueDurableClientHandler = (
+    message: unknown,
+    client: DurableClient,
+    context: InvocationContext
+) => FunctionResult;
+
+export interface ServiceBusQueueDurableClientOptions
+    extends Omit<ServiceBusQueueFunctionOptions, "handler"> {
+    handler: ServiceBusQueueDurableClientHandler;
+}
+
+export type ServiceBusTopicDurableClientHandler = (
+    message: unknown,
+    client: DurableClient,
+    context: InvocationContext
+) => FunctionResult;
+
+export interface ServiceBusTopicDurableClientOptions
+    extends Omit<ServiceBusTopicFunctionOptions, "handler"> {
+    handler: ServiceBusTopicDurableClientHandler;
+}
+
+export type EventHubDurableClientHandler = (
+    messages: unknown,
+    client: DurableClient,
+    context: InvocationContext
+) => FunctionResult;
+
+export interface EventHubDurableClientOptions extends Omit<EventHubFunctionOptions, "handler"> {
+    handler: EventHubDurableClientHandler;
+}
+
+export type EventGridDurableClientHandler = (
+    event: EventGridEvent,
+    client: DurableClient,
+    context: InvocationContext
+) => FunctionResult;
+
+export interface EventGridDurableClientOptions extends Omit<EventGridFunctionOptions, "handler"> {
+    handler: EventGridDurableClientHandler;
+}
+
+export type CosmosDBDurableClientHandler = (
+    documents: unknown[],
+    client: DurableClient,
+    context: InvocationContext
+) => FunctionResult;
+
+export type CosmosDBDurableClientOptions =
+    | CosmosDBv3DurableClientOptions
+    | CosmosDBv4DurableClientOptions;
+
+export interface CosmosDBv3DurableClientOptions extends Omit<CosmosDBv3FunctionOptions, "handler"> {
+    handler: CosmosDBDurableClientHandler;
+}
+
+export interface CosmosDBv4DurableClientOptions extends Omit<CosmosDBv4FunctionOptions, "handler"> {
+    handler: CosmosDBDurableClientHandler;
 }
 
 /**


### PR DESCRIPTION
Builds on #536, resolves #414. Adds convenience methods to register Durable Client functions using all supported `@azure/functions` triggers. After this change, `df.app.client` matches all triggers in `app.` from `@azure/functions`, with the exception of HTTP convenience methods (`get`, `post`, etc.), that I excluded from this PR.

Also updates `@azure/functions` to the latest version to get the latest CosmosDB types