### PR TITLE
Complete updating v2.x to 2.1.4

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 variables:
     {
-        MODULE_VERSION: "2.1.3",
+        MODULE_VERSION: "2.1.4",
         NODE_12: "12.x",
         NODE_14: "14.x",
         NODE_16: "16.x",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,13 +1,4 @@
-variables:
-    {
-        MODULE_VERSION: "2.1.4",
-        NODE_12: "12.x",
-        NODE_14: "14.x",
-        NODE_16: "16.x",
-        NODE_18: "18.x",
-        NODE_20: "20.x",
-    }
-name: $(MODULE_VERSION)-$(Date:yyyyMMdd)$(Rev:.r)
+variables: { NODE_12: "12.x", NODE_14: "14.x", NODE_16: "16.x", NODE_18: "18.x", NODE_20: "20.x" }
 
 pr:
     branches:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "durable-functions",
-    "version": "2.1.3",
+    "version": "2.1.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "durable-functions",
-            "version": "2.1.3",
+            "version": "2.1.4",
             "license": "MIT",
             "dependencies": {
                 "@azure/functions": "^1.2.3",


### PR DESCRIPTION
The [release pipeline](https://azfunc.visualstudio.com/Azure%20Functions/_build/results?buildId=161001&view=results) did not successfully complete with the previous PR: https://github.com/Azure/azure-functions-durable-js/pull/576.

By comparing the above PR with the [last PR to update the v2.x branch](https://github.com/Azure/azure-functions-durable-js/pull/522/files), it was clear that we forgot to update the `package-lock.json` and `azure-pipelines.yml`.