### PR TITLE
Fix public builds from forks

### DIFF
--- a/azure-pipelines/public-build.yml
+++ b/azure-pipelines/public-build.yml
@@ -24,6 +24,10 @@ extends:
             image: 1es-windows-2022
             os: windows
 
+        settings:
+            # PR's from forks do not have sufficient permissions to set tags.
+            skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+
         stages:
             - stage: WindowsUnitTests
               dependsOn: []


### PR DESCRIPTION
Based on https://github.com/Azure/azure-functions-host/pull/10256

Example failure: https://azfunc.visualstudio.com/public/_build/results?buildId=176771&view=results