### PR TITLE
Run official build on v3.x branch

### DIFF
--- a/azure-pipelines/official-build.yml
+++ b/azure-pipelines/official-build.yml
@@ -15,7 +15,7 @@ schedules:
   displayName: Nightly Build
   branches:
     include:
-    - main
+    - v3.x
   always: true
 
 resources:


### PR DESCRIPTION
As in title. The official build pipeline (which reports CodeQL results) needs to run on the main branch, which is called `v3.x`, not `main`. This PR fixes that naming accident on the pipeline definition