### PR TITLE
Update DurableOrchestrationStatus to reference correct history data key from init argument

### DIFF
--- a/src/orchestrations/DurableOrchestrationStatus.ts
+++ b/src/orchestrations/DurableOrchestrationStatus.ts
@@ -10,7 +10,7 @@ export class DurableOrchestrationStatus implements types.DurableOrchestrationSta
     public readonly output: unknown;
     public readonly runtimeStatus: OrchestrationRuntimeStatus;
     public readonly customStatus?: unknown;
-    public readonly history?: Array<unknown>;
+    public readonly historyEvents?: Array<unknown>;
 
     /** @hidden */
     constructor(init: unknown) {
@@ -30,7 +30,7 @@ export class DurableOrchestrationStatus implements types.DurableOrchestrationSta
         this.output = init.output;
         this.runtimeStatus = init.runtimeStatus as OrchestrationRuntimeStatus;
         this.customStatus = init.customStatus;
-        this.history = init.history;
+        this.historyEvents = init.historyEvents;
     }
 
     private isDurableOrchestrationStatusInit(obj: unknown): obj is DurableOrchestrationStatusInit {
@@ -58,5 +58,5 @@ interface DurableOrchestrationStatusInit {
     output: unknown;
     runtimeStatus: string;
     customStatus?: unknown;
-    history?: Array<unknown>;
+    historyEvents?: Array<unknown>;
 }

--- a/src/orchestrations/DurableOrchestrationStatus.ts
+++ b/src/orchestrations/DurableOrchestrationStatus.ts
@@ -49,7 +49,7 @@ export class DurableOrchestrationStatus implements types.DurableOrchestrationSta
     }
 }
 
-interface DurableOrchestrationStatusInit {
+export interface DurableOrchestrationStatusInit {
     name: string;
     instanceId: string;
     createdTime: string | Date;


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-functions-durable-js/issues/620

# What's new?

According to [official docs](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-http-api#response-1), orchestration history data is returned on the `historyEvents` key inside the response.

Current implementation prior to these changes are referencing the `history` key from the response, which doesn't exist leading to setting `undefined` on the `DurableOrchestrationStatus`'s `history` attribute.

This PR updates the `DurableORchestrationStatus`'s constructor to pluck the history data from the `historyEvents` key from the `init` constructor argument and also update the class attribute `history` name to `historyEvents` for consistency and match the official docs.
