### PR TITLE
Replace lodash cloneDeep with structuredClone

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
                 "@azure/functions": "^4.0.0",
                 "axios": "^1.6.1",
                 "debug": "~2.6.9",
-                "lodash": "^4.17.15",
                 "moment": "^2.29.2",
                 "uuid": "^9.0.1",
                 "validator": "~13.7.0"
@@ -38,6 +37,7 @@
                 "eslint": "^7.32.0",
                 "eslint-config-prettier": "^6.15.0",
                 "eslint-plugin-prettier": "^3.4.1",
+                "lodash": "^4.17.15",
                 "mocha": "^9.1.3",
                 "nock": "^10.0.6",
                 "prettier": "^2.0.5",
@@ -369,7 +369,9 @@
             "license": "MIT"
         },
         "node_modules/@types/lodash": {
-            "version": "4.14.119",
+            "version": "4.17.14",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.14.tgz",
+            "integrity": "sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A==",
             "dev": true,
             "license": "MIT"
         },
@@ -1992,6 +1994,7 @@
         },
         "node_modules/lodash": {
             "version": "4.17.21",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/lodash.get": {
@@ -3418,7 +3421,9 @@
             "dev": true
         },
         "@types/lodash": {
-            "version": "4.14.119",
+            "version": "4.17.14",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.14.tgz",
+            "integrity": "sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A==",
             "dev": true
         },
         "@types/mocha": {
@@ -4422,7 +4427,8 @@
             }
         },
         "lodash": {
-            "version": "4.17.21"
+            "version": "4.17.21",
+            "dev": true
         },
         "lodash.get": {
             "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
         "@azure/functions": "^4.0.0",
         "axios": "^1.6.1",
         "debug": "~2.6.9",
-        "lodash": "^4.17.15",
         "moment": "^2.29.2",
         "uuid": "^9.0.1",
         "validator": "~13.7.0"
@@ -71,6 +70,7 @@
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^6.15.0",
         "eslint-plugin-prettier": "^3.4.1",
+        "lodash": "^4.17.15",
         "mocha": "^9.1.3",
         "nock": "^10.0.6",
         "prettier": "^2.0.5",

--- a/src/durableClient/getClient.ts
+++ b/src/durableClient/getClient.ts
@@ -3,8 +3,6 @@ import { DurableClientInput } from "durable-functions";
 import { DurableClient } from "./DurableClient";
 import { OrchestrationClientInputData } from "./OrchestrationClientInputData";
 /** @hidden */
-import cloneDeep = require("lodash/cloneDeep");
-/** @hidden */
 import url = require("url");
 import { HttpCreationPayload } from "../http/HttpCreationPayload";
 import { HttpManagementPayload } from "../http/HttpManagementPayload";
@@ -53,7 +51,7 @@ function getClientData(
 
 /** @hidden */
 function correctClientData(clientData: OrchestrationClientInputData): OrchestrationClientInputData {
-    const returnValue = cloneDeep(clientData);
+    const returnValue = structuredClone(clientData);
 
     returnValue.creationUrls = correctUrls(clientData.creationUrls) as HttpCreationPayload;
     returnValue.managementUrls = correctUrls(clientData.managementUrls) as HttpManagementPayload;
@@ -62,7 +60,7 @@ function correctClientData(clientData: OrchestrationClientInputData): Orchestrat
 }
 
 function correctUrls(obj: { [key: string]: string }): { [key: string]: string } {
-    const returnValue = cloneDeep(obj);
+    const returnValue = structuredClone(obj);
 
     const keys = Object.getOwnPropertyNames(obj);
     keys.forEach((key) => {


### PR DESCRIPTION
structuredClone is available in Node.js since version 17.0.0. As this package supports Node.js 18.0.0 and up, we're able to drop production dependency on lodash, making the package footprint smaller and install times faster.