### PR TITLE
Update connection in release pipeline

### DIFF
--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -58,4 +58,4 @@ extends:
                               workingDir: "$(Pipeline.Workspace)/DurableJSCI/drop"
                               verbose: true
                               customCommand: "publish package.tgz --tag ${{ parameters.NpmPublishTag }} --dry-run ${{ lower(parameters.NpmPublishDryRun) }}"
-                              customEndpoint: "durable-functions npm (valid until Jan 1st 2025)"
+                              customEndpoint: "durable-functions npm (valid until Aug 4th 2026)"


### PR DESCRIPTION
This PR updates the npm connection in our release pipeline since the old one expired on 1/1/2025.