### PR TITLE
Changing the Exception Handling for Rewind

### DIFF
--- a/src/durableClient/DurableClient.ts
+++ b/src/durableClient/DurableClient.ts
@@ -398,17 +398,21 @@ export class DurableClient implements types.DurableClient {
             case 202:
                 return;
             case 404:
-                return Promise.reject(new Error(`No instance with ID '${instanceId}' found.`));
+                return Promise.reject(
+                    new Error(response.data || `No instance with ID '${instanceId}' found.`)
+                );
             case 412:
                 return Promise.reject(
                     new Error(
-                        "The rewind operation is only supported on failed orchestration instances."
+                        response.data ||
+                            "The rewind operation is only supported on failed orchestration instances."
                     )
                 );
             case 501:
                 return Promise.reject(
                     new Error(
-                        "The rewind operation is not supported by the underlying storage provider."
+                        response.data ||
+                            "The rewind operation is not supported by the underlying storage provider."
                     )
                 );
             default:

--- a/src/durableClient/DurableClient.ts
+++ b/src/durableClient/DurableClient.ts
@@ -399,10 +399,16 @@ export class DurableClient implements types.DurableClient {
                 return;
             case 404:
                 return Promise.reject(new Error(`No instance with ID '${instanceId}' found.`));
-            case 410:
+            case 412:
                 return Promise.reject(
                     new Error(
                         "The rewind operation is only supported on failed orchestration instances."
+                    )
+                );
+            case 501:
+                return Promise.reject(
+                    new Error(
+                        "The rewind operation is not supported by the underlying storage provider."
                     )
                 );
             default:

--- a/test/unit/orchestrationclient-spec.ts
+++ b/test/unit/orchestrationclient-spec.ts
@@ -1019,6 +1019,29 @@ describe("Orchestration Client", () => {
             expect(result).to.be.equal(undefined);
         });
 
+        it(`throws when webhook returns invalid status code 404 with webhook error message`, async () => {
+            const client = new DurableClient(defaultClientInputData);
+
+            const testId = "badId";
+            const testReason = "test";
+            const expectedWebhookUrl = new url.URL(
+                defaultClientInputData.managementUrls.rewindPostUri
+                    .replace(TestConstants.idPlaceholder, testId)
+                    .replace(TestConstants.reasonPlaceholder, testReason)
+            );
+            const scope = nock(expectedWebhookUrl.origin, requiredPostHeaders)
+                .post(expectedWebhookUrl.pathname)
+                .query((actualQueryObject: object) =>
+                    urlQueryEqualsQueryObject(expectedWebhookUrl, actualQueryObject)
+                )
+                .reply(404, "No instance ID found!");
+
+            await expect(client.rewind(testId, testReason)).to.be.rejectedWith(
+                "No instance ID found!"
+            );
+            expect(scope.isDone()).to.be.equal(true);
+        });
+
         it(`throws when webhook returns invalid status code 404`, async () => {
             const client = new DurableClient(defaultClientInputData);
 
@@ -1036,8 +1059,32 @@ describe("Orchestration Client", () => {
                 )
                 .reply(404);
 
+            // Since the webhook did not provide a response body, use our own custom error message
             await expect(client.rewind(testId, testReason)).to.be.rejectedWith(
-                `No instance with ID '${testId}' found.`
+                "No instance with ID '${testId}' found."
+            );
+            expect(scope.isDone()).to.be.equal(true);
+        });
+
+        it(`throws when webhook returns invalid status code 412 with webhook error message`, async () => {
+            const client = new DurableClient(defaultClientInputData);
+
+            const testId = "badId";
+            const testReason = "test";
+            const expectedWebhookUrl = new url.URL(
+                defaultClientInputData.managementUrls.rewindPostUri
+                    .replace(TestConstants.idPlaceholder, testId)
+                    .replace(TestConstants.reasonPlaceholder, testReason)
+            );
+            const scope = nock(expectedWebhookUrl.origin, requiredPostHeaders)
+                .post(expectedWebhookUrl.pathname)
+                .query((actualQueryObject: object) =>
+                    urlQueryEqualsQueryObject(expectedWebhookUrl, actualQueryObject)
+                )
+                .reply(412, "Precondition failed!");
+
+            await expect(client.rewind(testId, testReason)).to.be.rejectedWith(
+                "Precondition failed!"
             );
             expect(scope.isDone()).to.be.equal(true);
         });
@@ -1059,6 +1106,7 @@ describe("Orchestration Client", () => {
                 )
                 .reply(412);
 
+            // Since the webhook did not provide a response body, use our own custom error message
             await expect(client.rewind(testId, testReason)).to.be.rejectedWith(
                 "The rewind operation is only supported on failed orchestration instances."
             );
@@ -1080,8 +1128,32 @@ describe("Orchestration Client", () => {
                 .query((actualQueryObject: object) =>
                     urlQueryEqualsQueryObject(expectedWebhookUrl, actualQueryObject)
                 )
+                .reply(501, "Invalid storage provider!");
+
+            await expect(client.rewind(testId, testReason)).to.be.rejectedWith(
+                "Invalid storage provider!"
+            );
+            expect(scope.isDone()).to.be.equal(true);
+        });
+
+        it(`throws when webhook returns invalid status code 501`, async () => {
+            const client = new DurableClient(defaultClientInputData);
+
+            const testId = "badId";
+            const testReason = "test";
+            const expectedWebhookUrl = new url.URL(
+                defaultClientInputData.managementUrls.rewindPostUri
+                    .replace(TestConstants.idPlaceholder, testId)
+                    .replace(TestConstants.reasonPlaceholder, testReason)
+            );
+            const scope = nock(expectedWebhookUrl.origin, requiredPostHeaders)
+                .post(expectedWebhookUrl.pathname)
+                .query((actualQueryObject: object) =>
+                    urlQueryEqualsQueryObject(expectedWebhookUrl, actualQueryObject)
+                )
                 .reply(501);
 
+            // Since the webhook did not provide a response body, use our own custom error message
             await expect(client.rewind(testId, testReason)).to.be.rejectedWith(
                 "The rewind operation is not supported by the underlying storage provider."
             );

--- a/test/unit/orchestrationclient-spec.ts
+++ b/test/unit/orchestrationclient-spec.ts
@@ -1061,7 +1061,7 @@ describe("Orchestration Client", () => {
 
             // Since the webhook did not provide a response body, use our own custom error message
             await expect(client.rewind(testId, testReason)).to.be.rejectedWith(
-                "No instance with ID '${testId}' found."
+                `No instance with ID '${testId}' found.`
             );
             expect(scope.isDone()).to.be.equal(true);
         });

--- a/test/unit/orchestrationclient-spec.ts
+++ b/test/unit/orchestrationclient-spec.ts
@@ -1042,7 +1042,7 @@ describe("Orchestration Client", () => {
             expect(scope.isDone()).to.be.equal(true);
         });
 
-        it(`throws when webhook returns invalid status code 410`, async () => {
+        it(`throws when webhook returns invalid status code 412`, async () => {
             const client = new DurableClient(defaultClientInputData);
 
             const testId = "badId";
@@ -1057,10 +1057,33 @@ describe("Orchestration Client", () => {
                 .query((actualQueryObject: object) =>
                     urlQueryEqualsQueryObject(expectedWebhookUrl, actualQueryObject)
                 )
-                .reply(410);
+                .reply(412);
 
             await expect(client.rewind(testId, testReason)).to.be.rejectedWith(
                 "The rewind operation is only supported on failed orchestration instances."
+            );
+            expect(scope.isDone()).to.be.equal(true);
+        });
+
+        it(`throws when webhook returns invalid status code 501`, async () => {
+            const client = new DurableClient(defaultClientInputData);
+
+            const testId = "badId";
+            const testReason = "test";
+            const expectedWebhookUrl = new url.URL(
+                defaultClientInputData.managementUrls.rewindPostUri
+                    .replace(TestConstants.idPlaceholder, testId)
+                    .replace(TestConstants.reasonPlaceholder, testReason)
+            );
+            const scope = nock(expectedWebhookUrl.origin, requiredPostHeaders)
+                .post(expectedWebhookUrl.pathname)
+                .query((actualQueryObject: object) =>
+                    urlQueryEqualsQueryObject(expectedWebhookUrl, actualQueryObject)
+                )
+                .reply(501);
+
+            await expect(client.rewind(testId, testReason)).to.be.rejectedWith(
+                "The rewind operation is not supported by the underlying storage provider."
             );
             expect(scope.isDone()).to.be.equal(true);
         });


### PR DESCRIPTION
This [PR](https://github.com/Azure/azure-functions-durable-extension/pull/3227) in the WebJobs repo changes the HTTP Status codes that are returned when rewind fails, so this PR updates error handling in this repo accordingly.