### PR TITLE
fix: replace deprecate utils.isDate() with utils.types.isDate()

### DIFF
--- a/src/actions/CreateTimerAction.ts
+++ b/src/actions/CreateTimerAction.ts
@@ -1,4 +1,4 @@
-import { isDate } from "util";
+import { isDate } from "util/types";
 import { ActionType } from "./ActionType";
 import { IAction } from "./IAction";
 


### PR DESCRIPTION
utils.isDate() have been removed in Node.js v24