### PR TITLE
Add es-metadata.yml (schema 1.0.0)

### DIFF
--- a/es-metadata.yml
+++ b/es-metadata.yml
@@ -1,0 +1,12 @@
+schemaVersion: 1.0.0
+providers:
+- provider: InventoryAsCode
+  version: 1.0.0
+  metadata:
+    isProduction: true
+    accountableOwners:
+      service: c5281ccb-b379-4acf-9099-95a37f9805f3
+    routing:
+      defaultAreaPath:
+        org: azfunc
+        path: internal\DurableTask


### PR DESCRIPTION
Adds `es-metadata.yml` using the InventoryAsCode schema 1.0.0 format with the **Durable Task Scheduler** service tree ID.