### PR TITLE
Fix Node 24 incompatibility in CreateTimerAction (replace util.isDate with util.types.isDate)

### DIFF
--- a/azure-pipelines/templates/test.yml
+++ b/azure-pipelines/templates/test.yml
@@ -7,6 +7,10 @@ jobs:
                   NODE_VERSION: "18.x"
               Node20:
                   NODE_VERSION: "20.x"
+              Node22:
+                  NODE_VERSION: "22.x"
+              Node24:
+                  NODE_VERSION: "24.x"
 
       steps:
           - task: NodeTool@0

--- a/src/actions/CreateTimerAction.ts
+++ b/src/actions/CreateTimerAction.ts
@@ -1,4 +1,4 @@
-import { isDate } from "util";
+import { types } from "util";
 import { ActionType } from "./ActionType";
 import { IAction } from "./IAction";
 
@@ -7,7 +7,7 @@ export class CreateTimerAction implements IAction {
     public readonly actionType: ActionType = ActionType.CreateTimer;
 
     constructor(public readonly fireAt: Date, public isCanceled: boolean = false) {
-        if (!isDate(fireAt)) {
+        if (!types.isDate(fireAt)) {
             throw new TypeError(`fireAt: Expected valid Date object but got ${fireAt}`);
         }
     }

--- a/test/unit/createtimeraction-spec.ts
+++ b/test/unit/createtimeraction-spec.ts
@@ -20,14 +20,14 @@ describe("CreateTimerAction", () => {
     });
 
     it("throws TypeError when fireAt is not a Date", () => {
-        expect(() => new CreateTimerAction("not-a-date" as unknown as Date)).to.throw(
+        expect(() => new CreateTimerAction(("not-a-date" as unknown) as Date)).to.throw(
             TypeError,
             /Expected valid Date object/
         );
     });
 
     it("throws TypeError when fireAt is undefined", () => {
-        expect(() => new CreateTimerAction(undefined as unknown as Date)).to.throw(
+        expect(() => new CreateTimerAction((undefined as unknown) as Date)).to.throw(
             TypeError,
             /Expected valid Date object/
         );

--- a/test/unit/createtimeraction-spec.ts
+++ b/test/unit/createtimeraction-spec.ts
@@ -1,0 +1,35 @@
+import { expect } from "chai";
+import "mocha";
+import { ActionType } from "../../src/actions/ActionType";
+import { CreateTimerAction } from "../../src/actions/CreateTimerAction";
+
+describe("CreateTimerAction", () => {
+    it("constructs successfully when given a valid Date", () => {
+        const fireAt = new Date();
+
+        const action = new CreateTimerAction(fireAt);
+
+        expect(action.actionType).to.equal(ActionType.CreateTimer);
+        expect(action.fireAt).to.equal(fireAt);
+        expect(action.isCanceled).to.equal(false);
+    });
+
+    it("respects the isCanceled flag passed to the constructor", () => {
+        const action = new CreateTimerAction(new Date(), true);
+        expect(action.isCanceled).to.equal(true);
+    });
+
+    it("throws TypeError when fireAt is not a Date", () => {
+        expect(() => new CreateTimerAction("not-a-date" as unknown as Date)).to.throw(
+            TypeError,
+            /Expected valid Date object/
+        );
+    });
+
+    it("throws TypeError when fireAt is undefined", () => {
+        expect(() => new CreateTimerAction(undefined as unknown as Date)).to.throw(
+            TypeError,
+            /Expected valid Date object/
+        );
+    });
+});


### PR DESCRIPTION
## Summary

On Node 24, any orchestration that uses `context.df.createTimer(...)` (and any
API that depends on it internally, e.g. `callActivityWithRetry`,
`waitForExternalEvent` with timeout) fails with:

```
System.Private.CoreLib: Exception while executing function:
Microsoft.Azure.WebJobs.Extensions.DurableTask: Orchestrator function 'example' failed:
(0 , util_1.isDate) is not a function.
```

Root cause: `CreateTimerAction` imports `isDate` from Node's `util` module.
`util.isDate` was deprecated in Node 4 (`DEP0046`) and removed in Node 24.

## Fix

Switch to `util.types.isDate`, which has been stable since Node 10 and is the
documented replacement. One import change, one call-site change.

```diff
-import { isDate } from "util";
+import { types } from "util";
 ...
-if (!isDate(fireAt)) {
+if (!types.isDate(fireAt)) {
```

`util.types.isDate` is realm-safe (preserving the original intent of the check)
and works on every supported Node version (the package declares
`"engines": { "node": ">=18.0" }`).

## Tests

Added `test/unit/createtimeraction-spec.ts` with focused constructor coverage:

- Accepts a valid `Date`
- Respects the `isCanceled` flag
- Rejects non-`Date` values with `TypeError`
- Rejects `undefined` with `TypeError`

Without the fix, all 4 new tests (and the existing `TimerTask` tests, which
construct `CreateTimerAction` as a dependency) fail with the exact error from
the issue. With the fix, all 237 tests pass locally on Node 26 (which exhibits
the same `util.isDate` removal as Node 24).

Also extended `azure-pipelines/templates/test.yml` to add Node 22 and Node 24
to the CI matrix (previously only Node 18 and Node 20).

Resolves #667 
