### PR TITLE
Consolidate compatible Dependabot dependency updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
             "version": "3.3.1",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions": "^4.14.0",
+                "@azure/functions": "^4.8.2",
                 "@opentelemetry/api": "^1.9.0",
-                "axios": "^1.16.1",
+                "axios": "^1.17.0",
                 "debug": "~2.6.9",
                 "lodash": "^4.18.1",
                 "moment": "^2.29.2",
@@ -62,23 +62,15 @@
             }
         },
         "node_modules/@azure/functions": {
-            "version": "4.14.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
-            "integrity": "sha512-13LsitEHNe09qmpEf6eX1ajyI9Cn9syJ8p3ord40h9+08Qk72Yg8X7FNkrgvidJqr9bPwCkcRup2yyIq1mSa6w==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.2.tgz",
+            "integrity": "sha512-MrIvgseTdfMX7uZRL2Lrv8BjAe5lXtJFA5CSdSyhMAKPu3fIJdaJCLc4NhdbXj3hEiVugr5D699f1QkpaQ8wTg==",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions-extensions-base": "0.2.0",
-                "cookie": "^0.7.0"
+                "cookie": "^0.7.0",
+                "long": "^4.0.0",
+                "undici": "^5.29.0"
             },
-            "engines": {
-                "node": ">=20.0"
-            }
-        },
-        "node_modules/@azure/functions-extensions-base": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
-            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ==",
-            "license": "MIT",
             "engines": {
                 "node": ">=18.0"
             }
@@ -229,6 +221,15 @@
             "version": "2.1.2",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@fastify/busboy": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            }
         },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.5.0",
@@ -942,9 +943,9 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.16.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-            "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+            "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.16.0",
@@ -2370,6 +2371,12 @@
             "dev": true,
             "license": "BSD-3-Clause"
         },
+        "node_modules/long": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+            "license": "Apache-2.0"
+        },
         "node_modules/lru-cache": {
             "version": "6.0.0",
             "dev": true,
@@ -3582,6 +3589,18 @@
             },
             "engines": {
                 "node": ">=4.2.0"
+            }
+        },
+        "node_modules/undici": {
+            "version": "5.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+            "license": "MIT",
+            "dependencies": {
+                "@fastify/busboy": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.0"
             }
         },
         "node_modules/uri-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
     "name": "durable-functions",
-    "version": "3.3.1",
+    "version": "3.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "durable-functions",
-            "version": "3.3.1",
+            "version": "3.4.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/functions": "4.8.2",
                 "@opentelemetry/api": "^1.9.0",
-                "axios": "^1.18.0",
+                "axios": "1.17.0",
                 "debug": "~2.6.9",
                 "lodash": "^4.18.1",
                 "moment": "^2.29.2",
-                "uuid": "^10.0.0",
-                "validator": "~13.15.35"
+                "uuid": "^9.0.1",
+                "validator": "~13.15.20"
             },
             "devDependencies": {
                 "@types/chai": "~4.1.6",
@@ -36,7 +36,7 @@
                 "chai": "~4.2.0",
                 "chai-as-promised": "~7.1.1",
                 "chai-string": "~1.5.0",
-                "eslint": "^7.32.0",
+                "eslint": "^8.57.1",
                 "eslint-config-prettier": "^6.15.0",
                 "eslint-plugin-prettier": "^3.4.1",
                 "mocha": "^11.2.2",
@@ -75,124 +75,67 @@
                 "node": ">=18.0"
             }
         },
-        "node_modules/@babel/code-frame": {
-            "version": "7.12.11",
+        "node_modules/@eslint-community/eslint-utils": {
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+            "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/highlight": "^7.10.4"
-            }
-        },
-        "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.15.7",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/highlight": {
-            "version": "7.16.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-validator-identifier": "^7.15.7",
-                "chalk": "^2.0.0",
-                "js-tokens": "^4.0.0"
+                "eslint-visitor-keys": "^3.4.3"
             },
             "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/ansi-styles": {
-            "version": "3.2.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-convert": "^1.9.0"
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/chalk": {
-            "version": "2.4.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             },
-            "engines": {
-                "node": ">=4"
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
             }
         },
-        "node_modules/@babel/highlight/node_modules/color-convert": {
-            "version": "1.9.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/color-name": {
-            "version": "1.1.3",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
+        "node_modules/@eslint-community/regexpp": {
+            "version": "4.12.2",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+            "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/supports-color": {
-            "version": "5.5.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
+                "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "0.4.3",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+            "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ajv": "^6.12.4",
-                "debug": "^4.1.1",
-                "espree": "^7.3.0",
-                "globals": "^13.9.0",
-                "ignore": "^4.0.6",
+                "debug": "^4.3.2",
+                "espree": "^9.6.0",
+                "globals": "^13.19.0",
+                "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
-                "js-yaml": "^3.13.1",
-                "minimatch": "^3.0.4",
+                "js-yaml": "^4.1.0",
+                "minimatch": "^3.1.2",
                 "strip-json-comments": "^3.1.1"
             },
             "engines": {
-                "node": "^10.12.0 || >=12.0.0"
-            }
-        },
-        "node_modules/@eslint/eslintrc/node_modules/argparse": {
-            "version": "1.0.10",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/debug": {
-            "version": "4.3.2",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -203,24 +146,22 @@
                 }
             }
         },
-        "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
-        },
         "node_modules/@eslint/eslintrc/node_modules/ms": {
-            "version": "2.1.2",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@eslint/js": {
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+            "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            }
         },
         "node_modules/@fastify/busboy": {
             "version": "2.1.0",
@@ -231,24 +172,29 @@
             }
         },
         "node_modules/@humanwhocodes/config-array": {
-            "version": "0.5.0",
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+            "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+            "deprecated": "Use @eslint/config-array instead",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@humanwhocodes/object-schema": "^1.2.0",
-                "debug": "^4.1.1",
-                "minimatch": "^3.0.4"
+                "@humanwhocodes/object-schema": "^2.0.3",
+                "debug": "^4.3.1",
+                "minimatch": "^3.0.5"
             },
             "engines": {
                 "node": ">=10.10.0"
             }
         },
         "node_modules/@humanwhocodes/config-array/node_modules/debug": {
-            "version": "4.3.2",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -260,12 +206,31 @@
             }
         },
         "node_modules/@humanwhocodes/config-array/node_modules/ms": {
-            "version": "2.1.2",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@humanwhocodes/module-importer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+            "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.22"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
+            }
+        },
         "node_modules/@humanwhocodes/object-schema": {
-            "version": "1.2.1",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+            "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+            "deprecated": "Use @eslint/object-schema instead",
             "dev": true,
             "license": "BSD-3-Clause"
         },
@@ -587,14 +552,6 @@
                 }
             }
         },
-        "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-            "version": "5.1.9",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
-            }
-        },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/ms": {
             "version": "2.1.2",
             "dev": true,
@@ -755,17 +712,6 @@
                 }
             }
         },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/is-glob": {
-            "version": "4.0.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-extglob": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/ms": {
             "version": "2.1.2",
             "dev": true,
@@ -802,8 +748,17 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
+        "node_modules/@ungap/structured-clone": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+            "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/acorn": {
-            "version": "7.4.1",
+            "version": "8.17.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+            "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -815,6 +770,8 @@
         },
         "node_modules/acorn-jsx": {
             "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
@@ -857,7 +814,9 @@
             "license": "MIT"
         },
         "node_modules/ajv": {
-            "version": "6.12.6",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -869,14 +828,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/ansi-colors": {
-            "version": "4.1.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/ansi-regex": {
@@ -927,14 +878,6 @@
                 "node": "*"
             }
         },
-        "node_modules/astral-regex": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -942,9 +885,9 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
-            "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+            "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.16.0",
@@ -1023,6 +966,8 @@
         },
         "node_modules/callsites": {
             "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1314,17 +1259,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/enquirer": {
-            "version": "2.3.6",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-colors": "^4.1.1"
-            },
-            "engines": {
-                "node": ">=8.6"
-            }
-        },
         "node_modules/es-define-property": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -1392,56 +1326,57 @@
             }
         },
         "node_modules/eslint": {
-            "version": "7.32.0",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+            "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+            "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "7.12.11",
-                "@eslint/eslintrc": "^0.4.3",
-                "@humanwhocodes/config-array": "^0.5.0",
-                "ajv": "^6.10.0",
+                "@eslint-community/eslint-utils": "^4.2.0",
+                "@eslint-community/regexpp": "^4.6.1",
+                "@eslint/eslintrc": "^2.1.4",
+                "@eslint/js": "8.57.1",
+                "@humanwhocodes/config-array": "^0.13.0",
+                "@humanwhocodes/module-importer": "^1.0.1",
+                "@nodelib/fs.walk": "^1.2.8",
+                "@ungap/structured-clone": "^1.2.0",
+                "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
-                "debug": "^4.0.1",
+                "debug": "^4.3.2",
                 "doctrine": "^3.0.0",
-                "enquirer": "^2.3.5",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^5.1.1",
-                "eslint-utils": "^2.1.0",
-                "eslint-visitor-keys": "^2.0.0",
-                "espree": "^7.3.1",
-                "esquery": "^1.4.0",
+                "eslint-scope": "^7.2.2",
+                "eslint-visitor-keys": "^3.4.3",
+                "espree": "^9.6.1",
+                "esquery": "^1.4.2",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
                 "file-entry-cache": "^6.0.1",
-                "functional-red-black-tree": "^1.0.1",
-                "glob-parent": "^5.1.2",
-                "globals": "^13.6.0",
-                "ignore": "^4.0.6",
-                "import-fresh": "^3.0.0",
+                "find-up": "^5.0.0",
+                "glob-parent": "^6.0.2",
+                "globals": "^13.19.0",
+                "graphemer": "^1.4.0",
+                "ignore": "^5.2.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
-                "js-yaml": "^3.13.1",
+                "is-path-inside": "^3.0.3",
+                "js-yaml": "^4.1.0",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.4.1",
                 "lodash.merge": "^4.6.2",
-                "minimatch": "^3.0.4",
+                "minimatch": "^3.1.2",
                 "natural-compare": "^1.4.0",
-                "optionator": "^0.9.1",
-                "progress": "^2.0.0",
-                "regexpp": "^3.1.0",
-                "semver": "^7.2.1",
-                "strip-ansi": "^6.0.0",
-                "strip-json-comments": "^3.1.0",
-                "table": "^6.0.9",
-                "text-table": "^0.2.0",
-                "v8-compile-cache": "^2.0.3"
+                "optionator": "^0.9.3",
+                "strip-ansi": "^6.0.1",
+                "text-table": "^0.2.0"
             },
             "bin": {
                 "eslint": "bin/eslint.js"
             },
             "engines": {
-                "node": "^10.12.0 || >=12.0.0"
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
@@ -1519,19 +1454,16 @@
             }
         },
         "node_modules/eslint-visitor-keys": {
-            "version": "3.1.0",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            }
-        },
-        "node_modules/eslint/node_modules/argparse": {
-            "version": "1.0.10",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/eslint/node_modules/debug": {
@@ -1550,48 +1482,44 @@
                 }
             }
         },
-        "node_modules/eslint/node_modules/eslint-utils": {
-            "version": "2.1.0",
+        "node_modules/eslint/node_modules/eslint-scope": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+            "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
             "dev": true,
-            "license": "MIT",
+            "license": "BSD-2-Clause",
             "dependencies": {
-                "eslint-visitor-keys": "^1.1.0"
+                "esrecurse": "^4.3.0",
+                "estraverse": "^5.2.0"
             },
             "engines": {
-                "node": ">=6"
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             },
             "funding": {
-                "url": "https://github.com/sponsors/mysticatea"
+                "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/eslint/node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-            "version": "1.3.0",
+        "node_modules/eslint/node_modules/estraverse": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "dev": true,
-            "license": "Apache-2.0",
+            "license": "BSD-2-Clause",
             "engines": {
-                "node": ">=4"
+                "node": ">=4.0"
             }
         },
-        "node_modules/eslint/node_modules/eslint-visitor-keys": {
-            "version": "2.1.0",
+        "node_modules/eslint/node_modules/glob-parent": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+            "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
             "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/eslint/node_modules/js-yaml": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-            "dev": true,
-            "license": "MIT",
+            "license": "ISC",
             "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
+                "is-glob": "^4.0.3"
             },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
+            "engines": {
+                "node": ">=10.13.0"
             }
         },
         "node_modules/eslint/node_modules/ms": {
@@ -1599,56 +1527,28 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/eslint/node_modules/semver": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-            "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/espree": {
-            "version": "7.3.1",
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+            "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "acorn": "^7.4.0",
-                "acorn-jsx": "^5.3.1",
-                "eslint-visitor-keys": "^1.3.0"
+                "acorn": "^8.9.0",
+                "acorn-jsx": "^5.3.2",
+                "eslint-visitor-keys": "^3.4.1"
             },
             "engines": {
-                "node": "^10.12.0 || >=12.0.0"
-            }
-        },
-        "node_modules/espree/node_modules/eslint-visitor-keys": {
-            "version": "1.3.0",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/esprima": {
-            "version": "4.0.1",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "bin": {
-                "esparse": "bin/esparse.js",
-                "esvalidate": "bin/esvalidate.js"
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             },
-            "engines": {
-                "node": ">=4"
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/esquery": {
-            "version": "1.4.0",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+            "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -1660,6 +1560,8 @@
         },
         "node_modules/esquery/node_modules/estraverse": {
             "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
@@ -1703,6 +1605,8 @@
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -1728,6 +1632,8 @@
         },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
             "dev": true,
             "license": "MIT"
         },
@@ -1817,7 +1723,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.2.4",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
             "dev": true,
             "license": "ISC"
         },
@@ -1989,7 +1897,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "13.12.0",
+            "version": "13.24.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+            "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2021,14 +1931,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/globby/node_modules/ignore": {
-            "version": "5.1.9",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
-            }
-        },
         "node_modules/gopd": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2040,6 +1942,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/graphemer": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+            "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/has-flag": {
             "version": "3.0.0",
@@ -2133,7 +2042,9 @@
             "license": "MIT"
         },
         "node_modules/ignore": {
-            "version": "4.0.6",
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2141,7 +2052,9 @@
             }
         },
         "node_modules/import-fresh": {
-            "version": "3.3.0",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+            "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2194,7 +2107,9 @@
             }
         },
         "node_modules/is-glob": {
-            "version": "4.0.1",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2211,6 +2126,16 @@
             "dev": true,
             "engines": {
                 "node": ">=0.12.0"
+            }
+        },
+        "node_modules/is-path-inside": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/is-plain-obj": {
@@ -2258,16 +2183,21 @@
                 "@pkgjs/parseargs": "^0.11.0"
             }
         },
-        "node_modules/js-tokens": {
-            "version": "4.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -2278,6 +2208,8 @@
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
             "license": "MIT"
         },
@@ -2340,11 +2272,6 @@
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/lodash.truncate": {
-            "version": "4.4.2",
             "dev": true,
             "license": "MIT"
         },
@@ -2458,10 +2385,11 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -2591,13 +2519,13 @@
             }
         },
         "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -2607,9 +2535,9 @@
             }
         },
         "node_modules/mocha/node_modules/minimatch": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2776,6 +2704,8 @@
         },
         "node_modules/parent-module": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2909,14 +2839,6 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/progress": {
-            "version": "2.0.3",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
         "node_modules/propagate": {
             "version": "1.0.0",
             "dev": true,
@@ -2935,7 +2857,9 @@
             }
         },
         "node_modules/punycode": {
-            "version": "2.1.1",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3022,16 +2946,10 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/require-from-string": {
-            "version": "2.0.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/resolve-from": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3273,22 +3191,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/slice-ansi": {
-            "version": "4.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "astral-regex": "^2.0.0",
-                "is-fullwidth-code-point": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-            }
-        },
         "node_modules/source-map": {
             "version": "0.6.1",
             "dev": true,
@@ -3305,11 +3207,6 @@
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
             }
-        },
-        "node_modules/sprintf-js": {
-            "version": "1.0.3",
-            "dev": true,
-            "license": "BSD-3-Clause"
         },
         "node_modules/string-width": {
             "version": "4.2.3",
@@ -3397,41 +3294,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/table": {
-            "version": "6.7.3",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "ajv": "^8.0.1",
-                "lodash.truncate": "^4.4.2",
-                "slice-ansi": "^4.0.0",
-                "string-width": "^4.2.3",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
-        "node_modules/table/node_modules/ajv": {
-            "version": "8.8.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/table/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/text-encoding": {
             "version": "0.6.4",
@@ -3544,6 +3406,8 @@
         },
         "node_modules/type-fest": {
             "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "engines": {
@@ -3600,6 +3464,8 @@
         },
         "node_modules/uri-js": {
             "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -3607,9 +3473,9 @@
             }
         },
         "node_modules/uuid": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-            "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
             "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
             "funding": [
                 "https://github.com/sponsors/broofa",
@@ -3619,11 +3485,6 @@
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
-        },
-        "node_modules/v8-compile-cache": {
-            "version": "2.3.0",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/validator": {
             "version": "13.15.35",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "debug": "~2.6.9",
                 "lodash": "^4.18.1",
                 "moment": "^2.29.2",
-                "uuid": "^11.1.1",
+                "uuid": "^10.0.0",
                 "validator": "~13.15.35"
             },
             "devDependencies": {
@@ -3607,16 +3607,17 @@
             }
         },
         "node_modules/uuid": {
-            "version": "11.1.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+            "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
             "funding": [
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"
             ],
             "license": "MIT",
             "bin": {
-                "uuid": "dist/esm/bin/uuid"
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/v8-compile-cache": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
     "name": "durable-functions",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "durable-functions",
-            "version": "3.3.0",
+            "version": "3.3.1",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions": "^4.0.0",
+                "@azure/functions": "^4.14.0",
                 "@opentelemetry/api": "^1.9.0",
-                "axios": "^1.11.0",
+                "axios": "^1.16.1",
                 "debug": "~2.6.9",
-                "lodash": "^4.17.15",
+                "lodash": "^4.18.1",
                 "moment": "^2.29.2",
                 "uuid": "^9.0.1",
                 "validator": "~13.15.20"
@@ -62,13 +62,23 @@
             }
         },
         "node_modules/@azure/functions": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.0.1.tgz",
-            "integrity": "sha512-Ol38b4XOlu6IDkLnO91HaYeo2utMixG0LIA1NR9Qehu17U/cGjNx+bAcOEdNlSJWNYh5ChhzjxA/uFB5dQJtmg==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
+            "integrity": "sha512-13LsitEHNe09qmpEf6eX1ajyI9Cn9syJ8p3ord40h9+08Qk72Yg8X7FNkrgvidJqr9bPwCkcRup2yyIq1mSa6w==",
+            "license": "MIT",
             "dependencies": {
-                "long": "^4.0.0",
-                "undici": "^5.13.0"
+                "@azure/functions-extensions-base": "0.2.0",
+                "cookie": "^0.7.0"
             },
+            "engines": {
+                "node": ">=20.0"
+            }
+        },
+        "node_modules/@azure/functions-extensions-base": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
+            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=18.0"
             }
@@ -219,14 +229,6 @@
             "version": "2.1.2",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@fastify/busboy": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
-            "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
-            "engines": {
-                "node": ">=14"
-            }
         },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.5.0",
@@ -819,6 +821,41 @@
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
+        "node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/agent-base/node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/agent-base/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
+        },
         "node_modules/ajv": {
             "version": "6.12.6",
             "dev": true,
@@ -901,17 +938,19 @@
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
-            "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+            "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
             "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.4",
-                "proxy-from-env": "^1.1.0"
+                "follow-redirects": "^1.16.0",
+                "form-data": "^4.0.5",
+                "https-proxy-agent": "^5.0.1",
+                "proxy-from-env": "^2.1.0"
             }
         },
         "node_modules/balanced-match": {
@@ -1129,6 +1168,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "license": "MIT",
             "dependencies": {
                 "delayed-stream": "~1.0.0"
             },
@@ -1140,6 +1180,15 @@
             "version": "0.0.1",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/cookie": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
         "node_modules/create-require": {
             "version": "1.1.1",
@@ -1204,6 +1253,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -1767,20 +1817,23 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.2.4",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.6",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "funding": [
                 {
                     "type": "individual",
                     "url": "https://github.com/sponsors/RubenVerborgh"
                 }
             ],
+            "license": "MIT",
             "engines": {
                 "node": ">=4.0"
             },
@@ -1808,9 +1861,9 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
@@ -2045,6 +2098,42 @@
                 "he": "bin/he"
             }
         },
+        "node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/https-proxy-agent/node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/https-proxy-agent/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
+        },
         "node_modules/ignore": {
             "version": "4.0.6",
             "dev": true,
@@ -2241,7 +2330,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.21",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "license": "MIT"
         },
         "node_modules/lodash.get": {
@@ -2278,11 +2369,6 @@
             "version": "3.0.0",
             "dev": true,
             "license": "BSD-3-Clause"
-        },
-        "node_modules/long": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
         },
         "node_modules/lru-cache": {
             "version": "6.0.0",
@@ -2351,6 +2437,7 @@
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -2359,6 +2446,7 @@
             "version": "2.1.35",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "license": "MIT",
             "dependencies": {
                 "mime-db": "1.52.0"
             },
@@ -2367,10 +2455,11 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -2500,13 +2589,13 @@
             }
         },
         "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -2516,9 +2605,9 @@
             }
         },
         "node_modules/mocha/node_modules/minimatch": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2776,9 +2865,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2835,9 +2924,13 @@
             "license": "MIT"
         },
         "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/punycode": {
             "version": "2.1.1",
@@ -2848,9 +2941,9 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.14.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-            "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+            "version": "6.15.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+            "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -3489,18 +3582,6 @@
             },
             "engines": {
                 "node": ">=4.2.0"
-            }
-        },
-        "node_modules/undici": {
-            "version": "5.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-            "license": "MIT",
-            "dependencies": {
-                "@fastify/busboy": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.0"
             }
         },
         "node_modules/uri-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
             "version": "3.3.1",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions": "^4.14.0",
+                "@azure/functions": "^4.16.1",
                 "@opentelemetry/api": "^1.9.0",
                 "axios": "^1.18.0",
                 "debug": "~2.6.9",
                 "lodash": "^4.18.1",
                 "moment": "^2.29.2",
                 "uuid": "^11.1.1",
-                "validator": "~13.15.20"
+                "validator": "~13.15.35"
             },
             "devDependencies": {
                 "@types/chai": "~4.1.6",
@@ -62,12 +62,12 @@
             }
         },
         "node_modules/@azure/functions": {
-            "version": "4.14.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
-            "integrity": "sha512-13LsitEHNe09qmpEf6eX1ajyI9Cn9syJ8p3ord40h9+08Qk72Yg8X7FNkrgvidJqr9bPwCkcRup2yyIq1mSa6w==",
+            "version": "4.16.1",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.16.1.tgz",
+            "integrity": "sha512-A9obwC7IBg4NAmxUfTVfYEd8Xg6Px+o85JRprS3UJZt+GYYzIOmEecnFwTe3rl+aiHDewBk/8fnIVrSjR/fNGQ==",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions-extensions-base": "0.2.0",
+                "@azure/functions-extensions-base": "0.3.0",
                 "cookie": "^0.7.0"
             },
             "engines": {
@@ -75,9 +75,9 @@
             }
         },
         "node_modules/@azure/functions-extensions-base": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
-            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.3.0.tgz",
+            "integrity": "sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.0"
@@ -1861,16 +1861,16 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -2079,9 +2079,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -3611,9 +3611,9 @@
             "license": "MIT"
         },
         "node_modules/validator": {
-            "version": "13.15.26",
-            "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.26.tgz",
-            "integrity": "sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==",
+            "version": "13.15.35",
+            "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
+            "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
             "version": "3.3.1",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions": "^4.8.2",
+                "@azure/functions": "^4.14.0",
                 "@opentelemetry/api": "^1.9.0",
                 "axios": "^1.17.0",
                 "debug": "~2.6.9",
                 "lodash": "^4.18.1",
                 "moment": "^2.29.2",
-                "uuid": "^10.0.0",
+                "uuid": "^11.1.1",
                 "validator": "~13.15.20"
             },
             "devDependencies": {
@@ -62,15 +62,23 @@
             }
         },
         "node_modules/@azure/functions": {
-            "version": "4.8.2",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.2.tgz",
-            "integrity": "sha512-MrIvgseTdfMX7uZRL2Lrv8BjAe5lXtJFA5CSdSyhMAKPu3fIJdaJCLc4NhdbXj3hEiVugr5D699f1QkpaQ8wTg==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
+            "integrity": "sha512-13LsitEHNe09qmpEf6eX1ajyI9Cn9syJ8p3ord40h9+08Qk72Yg8X7FNkrgvidJqr9bPwCkcRup2yyIq1mSa6w==",
             "license": "MIT",
             "dependencies": {
-                "cookie": "^0.7.0",
-                "long": "^4.0.0",
-                "undici": "^5.29.0"
+                "@azure/functions-extensions-base": "0.2.0",
+                "cookie": "^0.7.0"
             },
+            "engines": {
+                "node": ">=20.0"
+            }
+        },
+        "node_modules/@azure/functions-extensions-base": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
+            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=18.0"
             }
@@ -221,15 +229,6 @@
             "version": "2.1.2",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@fastify/busboy": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14"
-            }
         },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.5.0",
@@ -2371,12 +2370,6 @@
             "dev": true,
             "license": "BSD-3-Clause"
         },
-        "node_modules/long": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-            "license": "Apache-2.0"
-        },
         "node_modules/lru-cache": {
             "version": "6.0.0",
             "dev": true,
@@ -3591,18 +3584,6 @@
                 "node": ">=4.2.0"
             }
         },
-        "node_modules/undici": {
-            "version": "5.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-            "license": "MIT",
-            "dependencies": {
-                "@fastify/busboy": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.0"
-            }
-        },
         "node_modules/uri-js": {
             "version": "4.4.1",
             "dev": true,
@@ -3612,17 +3593,16 @@
             }
         },
         "node_modules/uuid": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-            "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
             "funding": [
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"
             ],
             "license": "MIT",
             "bin": {
-                "uuid": "dist/bin/uuid"
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/v8-compile-cache": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@azure/functions": "^4.14.0",
                 "@opentelemetry/api": "^1.9.0",
-                "axios": "^1.17.0",
+                "axios": "^1.18.0",
                 "debug": "~2.6.9",
                 "lodash": "^4.18.1",
                 "moment": "^2.29.2",
@@ -942,9 +942,9 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-            "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+            "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@azure/functions": "^4.14.0",
                 "@opentelemetry/api": "^1.9.0",
-                "axios": "1.17.0",
+                "axios": "1.18.0",
                 "debug": "~2.6.9",
                 "lodash": "^4.18.1",
                 "moment": "^2.29.2",
@@ -885,9 +885,9 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-            "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+            "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.16.0",
@@ -902,9 +902,9 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1204,7 +1204,9 @@
             }
         },
         "node_modules/diff": {
-            "version": "3.5.0",
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.1.tgz",
+            "integrity": "sha512-Z3u54A8qGyqFOSr2pk0ijYs8mOE9Qz8kTvtKeBI+upoG9j04Sq+oI7W8zAJiQybDcESET8/uIdHzs0p3k4fZlw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -2419,29 +2421,30 @@
             }
         },
         "node_modules/mocha": {
-            "version": "11.2.2",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.2.2.tgz",
-            "integrity": "sha512-VlSBxrPYHK4YNOEbFdkCxHQbZMoNzBkoPprqtZRW6311EUF/DlSxoycE2e/2NtRk4WKkIXzyrXDTrlikJMWgbw==",
+            "version": "11.7.6",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.6.tgz",
+            "integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "browser-stdout": "^1.3.1",
                 "chokidar": "^4.0.1",
                 "debug": "^4.3.5",
-                "diff": "^5.2.0",
+                "diff": "^7.0.0",
                 "escape-string-regexp": "^4.0.0",
                 "find-up": "^5.0.0",
                 "glob": "^10.4.5",
                 "he": "^1.2.0",
+                "is-path-inside": "^3.0.3",
                 "js-yaml": "^4.1.0",
                 "log-symbols": "^4.1.0",
-                "minimatch": "^5.1.6",
+                "minimatch": "^9.0.5",
                 "ms": "^2.1.3",
                 "picocolors": "^1.1.1",
                 "serialize-javascript": "^6.0.2",
                 "strip-json-comments": "^3.1.1",
                 "supports-color": "^8.1.1",
-                "workerpool": "^6.5.1",
+                "workerpool": "^9.2.0",
                 "yargs": "^17.7.2",
                 "yargs-parser": "^21.1.1",
                 "yargs-unparser": "^2.0.0"
@@ -2455,9 +2458,9 @@
             }
         },
         "node_modules/mocha/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2483,9 +2486,9 @@
             }
         },
         "node_modules/mocha/node_modules/diff": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-            "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+            "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -2513,7 +2516,7 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
+        "node_modules/mocha/node_modules/minimatch": {
             "version": "9.0.9",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
             "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
@@ -2527,19 +2530,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/mocha/node_modules/minimatch": {
-            "version": "5.1.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/mocha/node_modules/ms": {
@@ -3354,7 +3344,9 @@
             }
         },
         "node_modules/ts-node/node_modules/diff": {
-            "version": "4.0.2",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+            "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -3503,9 +3495,9 @@
             }
         },
         "node_modules/workerpool": {
-            "version": "6.5.1",
-            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
-            "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+            "version": "9.3.4",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
+            "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
             "dev": true,
             "license": "Apache-2.0"
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "debug": "~2.6.9",
                 "lodash": "^4.18.1",
                 "moment": "^2.29.2",
-                "uuid": "^9.0.1",
+                "uuid": "^10.0.0",
                 "validator": "~13.15.20"
             },
             "devDependencies": {
@@ -3593,13 +3593,15 @@
             }
         },
         "node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+            "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
             "funding": [
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"
             ],
+            "license": "MIT",
             "bin": {
                 "uuid": "dist/bin/uuid"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "3.3.1",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions": "^4.16.1",
+                "@azure/functions": "4.8.2",
                 "@opentelemetry/api": "^1.9.0",
                 "axios": "^1.18.0",
                 "debug": "~2.6.9",
@@ -62,23 +62,15 @@
             }
         },
         "node_modules/@azure/functions": {
-            "version": "4.16.1",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.16.1.tgz",
-            "integrity": "sha512-A9obwC7IBg4NAmxUfTVfYEd8Xg6Px+o85JRprS3UJZt+GYYzIOmEecnFwTe3rl+aiHDewBk/8fnIVrSjR/fNGQ==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.2.tgz",
+            "integrity": "sha512-MrIvgseTdfMX7uZRL2Lrv8BjAe5lXtJFA5CSdSyhMAKPu3fIJdaJCLc4NhdbXj3hEiVugr5D699f1QkpaQ8wTg==",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions-extensions-base": "0.3.0",
-                "cookie": "^0.7.0"
+                "cookie": "^0.7.0",
+                "long": "^4.0.0",
+                "undici": "^5.29.0"
             },
-            "engines": {
-                "node": ">=20.0"
-            }
-        },
-        "node_modules/@azure/functions-extensions-base": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.3.0.tgz",
-            "integrity": "sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA==",
-            "license": "MIT",
             "engines": {
                 "node": ">=18.0"
             }
@@ -229,6 +221,14 @@
             "version": "2.1.2",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@fastify/busboy": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
+            "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
+            "engines": {
+                "node": ">=14"
+            }
         },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.5.0",
@@ -1817,9 +1817,7 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+            "version": "3.2.4",
             "dev": true,
             "license": "ISC"
         },
@@ -2370,6 +2368,11 @@
             "dev": true,
             "license": "BSD-3-Clause"
         },
+        "node_modules/long": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+        },
         "node_modules/lru-cache": {
             "version": "6.0.0",
             "dev": true,
@@ -2455,11 +2458,10 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -2589,13 +2591,13 @@
             }
         },
         "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.2"
+                "brace-expansion": "^2.0.1"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -2605,9 +2607,9 @@
             }
         },
         "node_modules/mocha/node_modules/minimatch": {
-            "version": "5.1.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -3582,6 +3584,18 @@
             },
             "engines": {
                 "node": ">=4.2.0"
+            }
+        },
+        "node_modules/undici": {
+            "version": "5.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+            "license": "MIT",
+            "dependencies": {
+                "@fastify/busboy": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.0"
             }
         },
         "node_modules/uri-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "3.4.0",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions": "4.8.2",
+                "@azure/functions": "^4.14.0",
                 "@opentelemetry/api": "^1.9.0",
                 "axios": "1.17.0",
                 "debug": "~2.6.9",
@@ -62,15 +62,23 @@
             }
         },
         "node_modules/@azure/functions": {
-            "version": "4.8.2",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.2.tgz",
-            "integrity": "sha512-MrIvgseTdfMX7uZRL2Lrv8BjAe5lXtJFA5CSdSyhMAKPu3fIJdaJCLc4NhdbXj3hEiVugr5D699f1QkpaQ8wTg==",
+            "version": "4.16.1",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.16.1.tgz",
+            "integrity": "sha512-A9obwC7IBg4NAmxUfTVfYEd8Xg6Px+o85JRprS3UJZt+GYYzIOmEecnFwTe3rl+aiHDewBk/8fnIVrSjR/fNGQ==",
             "license": "MIT",
             "dependencies": {
-                "cookie": "^0.7.0",
-                "long": "^4.0.0",
-                "undici": "^5.29.0"
+                "@azure/functions-extensions-base": "0.3.0",
+                "cookie": "^0.7.0"
             },
+            "engines": {
+                "node": ">=20.0"
+            }
+        },
+        "node_modules/@azure/functions-extensions-base": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.3.0.tgz",
+            "integrity": "sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=18.0"
             }
@@ -161,14 +169,6 @@
             "license": "MIT",
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@fastify/busboy": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
-            "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
-            "engines": {
-                "node": ">=14"
             }
         },
         "node_modules/@humanwhocodes/config-array": {
@@ -2295,11 +2295,6 @@
             "dev": true,
             "license": "BSD-3-Clause"
         },
-        "node_modules/long": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-        },
         "node_modules/lru-cache": {
             "version": "6.0.0",
             "dev": true,
@@ -3448,18 +3443,6 @@
             },
             "engines": {
                 "node": ">=4.2.0"
-            }
-        },
-        "node_modules/undici": {
-            "version": "5.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-            "license": "MIT",
-            "dependencies": {
-                "@fastify/busboy": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.0"
             }
         },
         "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -42,11 +42,11 @@
         "e2etst": "npm run"
     },
     "dependencies": {
-        "@azure/functions": "^4.0.0",
+        "@azure/functions": "^4.14.0",
         "@opentelemetry/api": "^1.9.0",
-        "axios": "^1.11.0",
+        "axios": "^1.16.1",
         "debug": "~2.6.9",
-        "lodash": "^4.17.15",
+        "lodash": "^4.18.1",
         "moment": "^2.29.2",
         "uuid": "^9.0.1",
         "validator": "~13.15.20"
@@ -90,4 +90,3 @@
         "test": "test"
     }
 }
-

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "dependencies": {
         "@azure/functions": "^4.14.0",
         "@opentelemetry/api": "^1.9.0",
-        "axios": "^1.17.0",
+        "axios": "^1.18.0",
         "debug": "~2.6.9",
         "lodash": "^4.18.1",
         "moment": "^2.29.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "e2etst": "npm run"
     },
     "dependencies": {
-        "@azure/functions": "^4.16.1",
+        "@azure/functions": "4.8.2",
         "@opentelemetry/api": "^1.9.0",
         "axios": "^1.18.0",
         "debug": "~2.6.9",

--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
         "e2etst": "npm run"
     },
     "dependencies": {
-        "@azure/functions": "^4.14.0",
+        "@azure/functions": "^4.8.2",
         "@opentelemetry/api": "^1.9.0",
-        "axios": "^1.16.1",
+        "axios": "^1.17.0",
         "debug": "~2.6.9",
         "lodash": "^4.18.1",
         "moment": "^2.29.2",

--- a/package.json
+++ b/package.json
@@ -44,12 +44,12 @@
     "dependencies": {
         "@azure/functions": "4.8.2",
         "@opentelemetry/api": "^1.9.0",
-        "axios": "^1.18.0",
+        "axios": "1.17.0",
         "debug": "~2.6.9",
         "lodash": "^4.18.1",
         "moment": "^2.29.2",
-        "uuid": "^10.0.0",
-        "validator": "~13.15.35"
+        "uuid": "^9.0.1",
+        "validator": "~13.15.20"
     },
     "devDependencies": {
         "@types/chai": "~4.1.6",
@@ -69,7 +69,7 @@
         "chai": "~4.2.0",
         "chai-as-promised": "~7.1.1",
         "chai-string": "~1.5.0",
-        "eslint": "^7.32.0",
+        "eslint": "^8.57.1",
         "eslint-config-prettier": "^6.15.0",
         "eslint-plugin-prettier": "^3.4.1",
         "mocha": "^11.2.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "e2etst": "npm run"
     },
     "dependencies": {
-        "@azure/functions": "4.8.2",
+        "@azure/functions": "^4.14.0",
         "@opentelemetry/api": "^1.9.0",
         "axios": "1.17.0",
         "debug": "~2.6.9",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "dependencies": {
         "@azure/functions": "^4.14.0",
         "@opentelemetry/api": "^1.9.0",
-        "axios": "1.17.0",
+        "axios": "1.18.0",
         "debug": "~2.6.9",
         "lodash": "^4.18.1",
         "moment": "^2.29.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "debug": "~2.6.9",
         "lodash": "^4.18.1",
         "moment": "^2.29.2",
-        "uuid": "^9.0.1",
+        "uuid": "^10.0.0",
         "validator": "~13.15.20"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -42,13 +42,13 @@
         "e2etst": "npm run"
     },
     "dependencies": {
-        "@azure/functions": "^4.8.2",
+        "@azure/functions": "^4.14.0",
         "@opentelemetry/api": "^1.9.0",
         "axios": "^1.17.0",
         "debug": "~2.6.9",
         "lodash": "^4.18.1",
         "moment": "^2.29.2",
-        "uuid": "^10.0.0",
+        "uuid": "^11.1.1",
         "validator": "~13.15.20"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -42,14 +42,14 @@
         "e2etst": "npm run"
     },
     "dependencies": {
-        "@azure/functions": "^4.14.0",
+        "@azure/functions": "^4.16.1",
         "@opentelemetry/api": "^1.9.0",
         "axios": "^1.18.0",
         "debug": "~2.6.9",
         "lodash": "^4.18.1",
         "moment": "^2.29.2",
         "uuid": "^11.1.1",
-        "validator": "~13.15.20"
+        "validator": "~13.15.35"
     },
     "devDependencies": {
         "@types/chai": "~4.1.6",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "debug": "~2.6.9",
         "lodash": "^4.18.1",
         "moment": "^2.29.2",
-        "uuid": "^11.1.1",
+        "uuid": "^10.0.0",
         "validator": "~13.15.35"
     },
     "devDependencies": {

--- a/samples-js/package-lock.json
+++ b/samples-js/package-lock.json
@@ -8,7 +8,7 @@
             "name": "samples-js",
             "version": "1.0.0",
             "dependencies": {
-                "@azure/functions": "^4.16.1",
+                "@azure/functions": "4.8.2",
                 "axios": "^1.18.0",
                 "durable-functions": "file:..",
                 "luxon": "^3.2.1",
@@ -20,7 +20,7 @@
             "version": "3.3.1",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions": "^4.16.1",
+                "@azure/functions": "4.8.2",
                 "@opentelemetry/api": "^1.9.0",
                 "axios": "^1.18.0",
                 "debug": "~2.6.9",
@@ -64,25 +64,25 @@
             }
         },
         "node_modules/@azure/functions": {
-            "version": "4.16.1",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.16.1.tgz",
-            "integrity": "sha512-A9obwC7IBg4NAmxUfTVfYEd8Xg6Px+o85JRprS3UJZt+GYYzIOmEecnFwTe3rl+aiHDewBk/8fnIVrSjR/fNGQ==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.2.tgz",
+            "integrity": "sha512-MrIvgseTdfMX7uZRL2Lrv8BjAe5lXtJFA5CSdSyhMAKPu3fIJdaJCLc4NhdbXj3hEiVugr5D699f1QkpaQ8wTg==",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions-extensions-base": "0.3.0",
-                "cookie": "^0.7.0"
+                "cookie": "^0.7.0",
+                "long": "^4.0.0",
+                "undici": "^5.29.0"
             },
             "engines": {
-                "node": ">=20.0"
+                "node": ">=18.0"
             }
         },
-        "node_modules/@azure/functions-extensions-base": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.3.0.tgz",
-            "integrity": "sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA==",
-            "license": "MIT",
+        "node_modules/@fastify/busboy": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
+            "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
             "engines": {
-                "node": ">=18.0"
+                "node": ">=14"
             }
         },
         "node_modules/agent-base": {
@@ -212,9 +212,9 @@
             }
         },
         "node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
@@ -384,10 +384,12 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/long": {
+            "version": "4.0.0",
+            "license": "Apache-2.0"
+        },
         "node_modules/luxon": {
-            "version": "3.7.2",
-            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
-            "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+            "version": "3.2.1",
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -452,8 +454,6 @@
         },
         "node_modules/readdirp": {
             "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
             "license": "MIT",
             "dependencies": {
                 "picomatch": "^2.2.1"
@@ -461,22 +461,35 @@
             "engines": {
                 "node": ">=8.10.0"
             }
+        },
+        "node_modules/undici": {
+            "version": "5.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+            "license": "MIT",
+            "dependencies": {
+                "@fastify/busboy": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.0"
+            }
         }
     },
     "dependencies": {
         "@azure/functions": {
-            "version": "4.16.1",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.16.1.tgz",
-            "integrity": "sha512-A9obwC7IBg4NAmxUfTVfYEd8Xg6Px+o85JRprS3UJZt+GYYzIOmEecnFwTe3rl+aiHDewBk/8fnIVrSjR/fNGQ==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.2.tgz",
+            "integrity": "sha512-MrIvgseTdfMX7uZRL2Lrv8BjAe5lXtJFA5CSdSyhMAKPu3fIJdaJCLc4NhdbXj3hEiVugr5D699f1QkpaQ8wTg==",
             "requires": {
-                "@azure/functions-extensions-base": "0.3.0",
-                "cookie": "^0.7.0"
+                "cookie": "^0.7.0",
+                "long": "^4.0.0",
+                "undici": "^5.29.0"
             }
         },
-        "@azure/functions-extensions-base": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.3.0.tgz",
-            "integrity": "sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA=="
+        "@fastify/busboy": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
+            "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ=="
         },
         "agent-base": {
             "version": "6.0.2",
@@ -550,7 +563,7 @@
         "durable-functions": {
             "version": "file:..",
             "requires": {
-                "@azure/functions": "^4.16.1",
+                "@azure/functions": "4.8.2",
                 "@opentelemetry/api": "^1.9.0",
                 "@types/chai": "~4.1.6",
                 "@types/chai-as-promised": "~7.1.0",
@@ -599,9 +612,9 @@
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
         },
         "es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
             "requires": {
                 "es-errors": "^1.3.0"
             }
@@ -700,10 +713,11 @@
                 "debug": "4"
             }
         },
+        "long": {
+            "version": "4.0.0"
+        },
         "luxon": {
-            "version": "3.7.2",
-            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
-            "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="
+            "version": "3.2.1"
         },
         "math-intrinsics": {
             "version": "1.1.0",
@@ -740,10 +754,16 @@
         },
         "readdirp": {
             "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
             "requires": {
                 "picomatch": "^2.2.1"
+            }
+        },
+        "undici": {
+            "version": "5.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+            "requires": {
+                "@fastify/busboy": "^2.0.0"
             }
         }
     }

--- a/samples-js/package-lock.json
+++ b/samples-js/package-lock.json
@@ -385,7 +385,9 @@
             }
         },
         "node_modules/luxon": {
-            "version": "3.2.1",
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+            "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -450,6 +452,8 @@
         },
         "node_modules/readdirp": {
             "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
             "license": "MIT",
             "dependencies": {
                 "picomatch": "^2.2.1"
@@ -697,7 +701,9 @@
             }
         },
         "luxon": {
-            "version": "3.2.1"
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+            "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="
         },
         "math-intrinsics": {
             "version": "1.1.0",
@@ -734,6 +740,8 @@
         },
         "readdirp": {
             "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
             "requires": {
                 "picomatch": "^2.2.1"
             }

--- a/samples-js/package-lock.json
+++ b/samples-js/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "dependencies": {
                 "@azure/functions": "^4.14.0",
-                "axios": "1.17.0",
+                "axios": "1.18.0",
                 "durable-functions": "file:..",
                 "luxon": "^3.2.1",
                 "readdirp": "^3.6.0"
@@ -22,7 +22,7 @@
             "dependencies": {
                 "@azure/functions": "^4.14.0",
                 "@opentelemetry/api": "^1.9.0",
-                "axios": "1.17.0",
+                "axios": "1.18.0",
                 "debug": "~2.6.9",
                 "lodash": "^4.18.1",
                 "moment": "^2.29.2",
@@ -104,9 +104,9 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-            "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+            "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.16.0",
@@ -492,9 +492,9 @@
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
         "axios": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-            "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+            "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
             "requires": {
                 "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",
@@ -566,7 +566,7 @@
                 "@types/validator": "^9.4.3",
                 "@typescript-eslint/eslint-plugin": "^5.4.0",
                 "@typescript-eslint/parser": "^5.4.0",
-                "axios": "1.17.0",
+                "axios": "1.18.0",
                 "chai": "~4.2.0",
                 "chai-as-promised": "~7.1.1",
                 "chai-string": "~1.5.0",

--- a/samples-js/package-lock.json
+++ b/samples-js/package-lock.json
@@ -26,7 +26,7 @@
                 "debug": "~2.6.9",
                 "lodash": "^4.18.1",
                 "moment": "^2.29.2",
-                "uuid": "^11.1.1",
+                "uuid": "^10.0.0",
                 "validator": "~13.15.35"
             },
             "devDependencies": {
@@ -597,7 +597,7 @@
                 "ts-node": "^10.0.0",
                 "typedoc": "^0.22.11",
                 "typescript": "~4.5.0",
-                "uuid": "^11.1.1",
+                "uuid": "^10.0.0",
                 "validator": "~13.15.35"
             }
         },

--- a/samples-js/package-lock.json
+++ b/samples-js/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "dependencies": {
                 "@azure/functions": "4.8.2",
-                "axios": "^1.18.0",
+                "axios": "1.17.0",
                 "durable-functions": "file:..",
                 "luxon": "^3.2.1",
                 "readdirp": "^3.6.0"
@@ -17,17 +17,17 @@
         },
         "..": {
             "name": "durable-functions",
-            "version": "3.3.1",
+            "version": "3.4.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/functions": "4.8.2",
                 "@opentelemetry/api": "^1.9.0",
-                "axios": "^1.18.0",
+                "axios": "1.17.0",
                 "debug": "~2.6.9",
                 "lodash": "^4.18.1",
                 "moment": "^2.29.2",
-                "uuid": "^10.0.0",
-                "validator": "~13.15.35"
+                "uuid": "^9.0.1",
+                "validator": "~13.15.20"
             },
             "devDependencies": {
                 "@types/chai": "~4.1.6",
@@ -47,7 +47,7 @@
                 "chai": "~4.2.0",
                 "chai-as-promised": "~7.1.1",
                 "chai-string": "~1.5.0",
-                "eslint": "^7.32.0",
+                "eslint": "^8.57.1",
                 "eslint-config-prettier": "^6.15.0",
                 "eslint-plugin-prettier": "^3.4.1",
                 "mocha": "^11.2.2",
@@ -104,9 +104,9 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
-            "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+            "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.16.0",
@@ -505,9 +505,9 @@
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
         "axios": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
-            "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+            "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
             "requires": {
                 "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",
@@ -579,12 +579,12 @@
                 "@types/validator": "^9.4.3",
                 "@typescript-eslint/eslint-plugin": "^5.4.0",
                 "@typescript-eslint/parser": "^5.4.0",
-                "axios": "^1.18.0",
+                "axios": "1.17.0",
                 "chai": "~4.2.0",
                 "chai-as-promised": "~7.1.1",
                 "chai-string": "~1.5.0",
                 "debug": "~2.6.9",
-                "eslint": "^7.32.0",
+                "eslint": "^8.57.1",
                 "eslint-config-prettier": "^6.15.0",
                 "eslint-plugin-prettier": "^3.4.1",
                 "lodash": "^4.18.1",
@@ -597,8 +597,8 @@
                 "ts-node": "^10.0.0",
                 "typedoc": "^0.22.11",
                 "typescript": "~4.5.0",
-                "uuid": "^10.0.0",
-                "validator": "~13.15.35"
+                "uuid": "^9.0.1",
+                "validator": "~13.15.20"
             }
         },
         "es-define-property": {

--- a/samples-js/package-lock.json
+++ b/samples-js/package-lock.json
@@ -8,7 +8,7 @@
             "name": "samples-js",
             "version": "1.0.0",
             "dependencies": {
-                "@azure/functions": "^4.14.0",
+                "@azure/functions": "^4.16.1",
                 "axios": "^1.18.0",
                 "durable-functions": "file:..",
                 "luxon": "^3.2.1",
@@ -20,14 +20,14 @@
             "version": "3.3.1",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions": "^4.14.0",
+                "@azure/functions": "^4.16.1",
                 "@opentelemetry/api": "^1.9.0",
                 "axios": "^1.18.0",
                 "debug": "~2.6.9",
                 "lodash": "^4.18.1",
                 "moment": "^2.29.2",
                 "uuid": "^11.1.1",
-                "validator": "~13.15.20"
+                "validator": "~13.15.35"
             },
             "devDependencies": {
                 "@types/chai": "~4.1.6",
@@ -64,12 +64,12 @@
             }
         },
         "node_modules/@azure/functions": {
-            "version": "4.14.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
-            "integrity": "sha512-13LsitEHNe09qmpEf6eX1ajyI9Cn9syJ8p3ord40h9+08Qk72Yg8X7FNkrgvidJqr9bPwCkcRup2yyIq1mSa6w==",
+            "version": "4.16.1",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.16.1.tgz",
+            "integrity": "sha512-A9obwC7IBg4NAmxUfTVfYEd8Xg6Px+o85JRprS3UJZt+GYYzIOmEecnFwTe3rl+aiHDewBk/8fnIVrSjR/fNGQ==",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions-extensions-base": "0.2.0",
+                "@azure/functions-extensions-base": "0.3.0",
                 "cookie": "^0.7.0"
             },
             "engines": {
@@ -77,9 +77,9 @@
             }
         },
         "node_modules/@azure/functions-extensions-base": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
-            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.3.0.tgz",
+            "integrity": "sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.0"
@@ -259,16 +259,16 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -360,9 +360,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-            "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -465,18 +465,18 @@
     },
     "dependencies": {
         "@azure/functions": {
-            "version": "4.14.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
-            "integrity": "sha512-13LsitEHNe09qmpEf6eX1ajyI9Cn9syJ8p3ord40h9+08Qk72Yg8X7FNkrgvidJqr9bPwCkcRup2yyIq1mSa6w==",
+            "version": "4.16.1",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.16.1.tgz",
+            "integrity": "sha512-A9obwC7IBg4NAmxUfTVfYEd8Xg6Px+o85JRprS3UJZt+GYYzIOmEecnFwTe3rl+aiHDewBk/8fnIVrSjR/fNGQ==",
             "requires": {
-                "@azure/functions-extensions-base": "0.2.0",
+                "@azure/functions-extensions-base": "0.3.0",
                 "cookie": "^0.7.0"
             }
         },
         "@azure/functions-extensions-base": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
-            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ=="
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.3.0.tgz",
+            "integrity": "sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA=="
         },
         "agent-base": {
             "version": "6.0.2",
@@ -550,7 +550,7 @@
         "durable-functions": {
             "version": "file:..",
             "requires": {
-                "@azure/functions": "^4.14.0",
+                "@azure/functions": "^4.16.1",
                 "@opentelemetry/api": "^1.9.0",
                 "@types/chai": "~4.1.6",
                 "@types/chai-as-promised": "~7.1.0",
@@ -585,7 +585,7 @@
                 "typedoc": "^0.22.11",
                 "typescript": "~4.5.0",
                 "uuid": "^11.1.1",
-                "validator": "~13.15.20"
+                "validator": "~13.15.35"
             }
         },
         "es-define-property": {
@@ -623,15 +623,15 @@
             "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="
         },
         "form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "requires": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             }
         },
         "function-bind": {
@@ -684,9 +684,9 @@
             }
         },
         "hasown": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-            "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "requires": {
                 "function-bind": "^1.1.2"
             }

--- a/samples-js/package-lock.json
+++ b/samples-js/package-lock.json
@@ -8,51 +8,64 @@
             "name": "samples-js",
             "version": "1.0.0",
             "dependencies": {
-                "@azure/functions": "^4.7.0",
-                "axios": "^1.12.0",
+                "@azure/functions": "^4.14.0",
+                "axios": "^1.16.1",
                 "durable-functions": "file:../durable-functions",
                 "luxon": "^3.2.1",
                 "readdirp": "^3.6.0"
             }
         },
-        "../durable-functions": {
-            "version": "0.0.1"
-        },
+        "../durable-functions": {},
         "node_modules/@azure/functions": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.7.0.tgz",
-            "integrity": "sha512-y1caGX6LYrA7msAckQVb/quFOhWHSPiGzWfIML17t0ee2ydpinJTBF+Sti+URfLAH63dtmXJR4meraZkhhK9tw==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
+            "integrity": "sha512-13LsitEHNe09qmpEf6eX1ajyI9Cn9syJ8p3ord40h9+08Qk72Yg8X7FNkrgvidJqr9bPwCkcRup2yyIq1mSa6w==",
             "license": "MIT",
             "dependencies": {
-                "cookie": "^0.7.0",
-                "long": "^4.0.0",
-                "undici": "^5.13.0"
+                "@azure/functions-extensions-base": "0.2.0",
+                "cookie": "^0.7.0"
             },
+            "engines": {
+                "node": ">=20.0"
+            }
+        },
+        "node_modules/@azure/functions-extensions-base": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
+            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=18.0"
             }
         },
-        "node_modules/@fastify/busboy": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
-            "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
+        "node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "4"
+            },
             "engines": {
-                "node": ">=14"
+                "node": ">= 6.0.0"
             }
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
-            "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+            "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
             "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.4",
-                "proxy-from-env": "^1.1.0"
+                "follow-redirects": "^1.16.0",
+                "form-data": "^4.0.5",
+                "https-proxy-agent": "^5.0.1",
+                "proxy-from-env": "^2.1.0"
             }
         },
         "node_modules/call-bind-apply-helpers": {
@@ -70,6 +83,8 @@
         },
         "node_modules/combined-stream": {
             "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
             "license": "MIT",
             "dependencies": {
                 "delayed-stream": "~1.0.0"
@@ -87,8 +102,27 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
@@ -158,15 +192,16 @@
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.6",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "funding": [
                 {
                     "type": "individual",
                     "url": "https://github.com/sponsors/RubenVerborgh"
                 }
             ],
+            "license": "MIT",
             "engines": {
                 "node": ">=4.0"
             },
@@ -177,9 +212,9 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
@@ -278,9 +313,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+            "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -289,12 +324,23 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/long": {
-            "version": "4.0.0",
-            "license": "Apache-2.0"
+        "node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
         },
         "node_modules/luxon": {
-            "version": "3.2.1",
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+            "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -311,6 +357,8 @@
         },
         "node_modules/mime-db": {
             "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -318,6 +366,8 @@
         },
         "node_modules/mime-types": {
             "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
             "license": "MIT",
             "dependencies": {
                 "mime-db": "1.52.0"
@@ -326,8 +376,16 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
+        },
         "node_modules/picomatch": {
-            "version": "2.3.1",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "license": "MIT",
             "engines": {
                 "node": ">=8.6"
@@ -337,11 +395,18 @@
             }
         },
         "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "license": "MIT"
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/readdirp": {
             "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
             "license": "MIT",
             "dependencies": {
                 "picomatch": "^2.2.1"
@@ -349,47 +414,45 @@
             "engines": {
                 "node": ">=8.10.0"
             }
-        },
-        "node_modules/undici": {
-            "version": "5.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-            "license": "MIT",
-            "dependencies": {
-                "@fastify/busboy": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.0"
-            }
         }
     },
     "dependencies": {
         "@azure/functions": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.7.0.tgz",
-            "integrity": "sha512-y1caGX6LYrA7msAckQVb/quFOhWHSPiGzWfIML17t0ee2ydpinJTBF+Sti+URfLAH63dtmXJR4meraZkhhK9tw==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
+            "integrity": "sha512-13LsitEHNe09qmpEf6eX1ajyI9Cn9syJ8p3ord40h9+08Qk72Yg8X7FNkrgvidJqr9bPwCkcRup2yyIq1mSa6w==",
             "requires": {
-                "cookie": "^0.7.0",
-                "long": "^4.0.0",
-                "undici": "^5.13.0"
+                "@azure/functions-extensions-base": "0.2.0",
+                "cookie": "^0.7.0"
             }
         },
-        "@fastify/busboy": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
-            "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ=="
+        "@azure/functions-extensions-base": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
+            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ=="
+        },
+        "agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "requires": {
+                "debug": "4"
+            }
         },
         "asynckit": {
-            "version": "0.4.0"
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
         "axios": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
-            "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+            "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
             "requires": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.4",
-                "proxy-from-env": "^1.1.0"
+                "follow-redirects": "^1.16.0",
+                "form-data": "^4.0.5",
+                "https-proxy-agent": "^5.0.1",
+                "proxy-from-env": "^2.1.0"
             }
         },
         "call-bind-apply-helpers": {
@@ -403,6 +466,8 @@
         },
         "combined-stream": {
             "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
             "requires": {
                 "delayed-stream": "~1.0.0"
             }
@@ -412,8 +477,18 @@
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
             "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
         },
+        "debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "requires": {
+                "ms": "^2.1.3"
+            }
+        },
         "delayed-stream": {
-            "version": "1.0.0"
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
         },
         "dunder-proto": {
             "version": "1.0.1",
@@ -458,14 +533,14 @@
             }
         },
         "follow-redirects": {
-            "version": "1.15.6",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="
         },
         "form-data": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
             "requires": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
@@ -524,18 +599,26 @@
             }
         },
         "hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+            "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
             "requires": {
                 "function-bind": "^1.1.2"
             }
         },
-        "long": {
-            "version": "4.0.0"
+        "https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "requires": {
+                "agent-base": "6",
+                "debug": "4"
+            }
         },
         "luxon": {
-            "version": "3.2.1"
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+            "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="
         },
         "math-intrinsics": {
             "version": "1.1.0",
@@ -543,32 +626,39 @@
             "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
         },
         "mime-db": {
-            "version": "1.52.0"
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
         },
         "mime-types": {
             "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
             "requires": {
                 "mime-db": "1.52.0"
             }
         },
+        "ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        },
         "picomatch": {
-            "version": "2.3.1"
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="
         },
         "proxy-from-env": {
-            "version": "1.1.0"
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="
         },
         "readdirp": {
             "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
             "requires": {
                 "picomatch": "^2.2.1"
-            }
-        },
-        "undici": {
-            "version": "5.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-            "requires": {
-                "@fastify/busboy": "^2.0.0"
             }
         }
     }

--- a/samples-js/package-lock.json
+++ b/samples-js/package-lock.json
@@ -8,7 +8,7 @@
             "name": "samples-js",
             "version": "1.0.0",
             "dependencies": {
-                "@azure/functions": "4.8.2",
+                "@azure/functions": "^4.14.0",
                 "axios": "1.17.0",
                 "durable-functions": "file:..",
                 "luxon": "^3.2.1",
@@ -20,7 +20,7 @@
             "version": "3.4.0",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions": "4.8.2",
+                "@azure/functions": "^4.14.0",
                 "@opentelemetry/api": "^1.9.0",
                 "axios": "1.17.0",
                 "debug": "~2.6.9",
@@ -64,25 +64,25 @@
             }
         },
         "node_modules/@azure/functions": {
-            "version": "4.8.2",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.2.tgz",
-            "integrity": "sha512-MrIvgseTdfMX7uZRL2Lrv8BjAe5lXtJFA5CSdSyhMAKPu3fIJdaJCLc4NhdbXj3hEiVugr5D699f1QkpaQ8wTg==",
+            "version": "4.16.1",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.16.1.tgz",
+            "integrity": "sha512-A9obwC7IBg4NAmxUfTVfYEd8Xg6Px+o85JRprS3UJZt+GYYzIOmEecnFwTe3rl+aiHDewBk/8fnIVrSjR/fNGQ==",
             "license": "MIT",
             "dependencies": {
-                "cookie": "^0.7.0",
-                "long": "^4.0.0",
-                "undici": "^5.29.0"
+                "@azure/functions-extensions-base": "0.3.0",
+                "cookie": "^0.7.0"
             },
             "engines": {
-                "node": ">=18.0"
+                "node": ">=20.0"
             }
         },
-        "node_modules/@fastify/busboy": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
-            "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
+        "node_modules/@azure/functions-extensions-base": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.3.0.tgz",
+            "integrity": "sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA==",
+            "license": "MIT",
             "engines": {
-                "node": ">=14"
+                "node": ">=18.0"
             }
         },
         "node_modules/agent-base": {
@@ -384,10 +384,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/long": {
-            "version": "4.0.0",
-            "license": "Apache-2.0"
-        },
         "node_modules/luxon": {
             "version": "3.2.1",
             "license": "MIT",
@@ -461,35 +457,22 @@
             "engines": {
                 "node": ">=8.10.0"
             }
-        },
-        "node_modules/undici": {
-            "version": "5.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-            "license": "MIT",
-            "dependencies": {
-                "@fastify/busboy": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.0"
-            }
         }
     },
     "dependencies": {
         "@azure/functions": {
-            "version": "4.8.2",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.2.tgz",
-            "integrity": "sha512-MrIvgseTdfMX7uZRL2Lrv8BjAe5lXtJFA5CSdSyhMAKPu3fIJdaJCLc4NhdbXj3hEiVugr5D699f1QkpaQ8wTg==",
+            "version": "4.16.1",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.16.1.tgz",
+            "integrity": "sha512-A9obwC7IBg4NAmxUfTVfYEd8Xg6Px+o85JRprS3UJZt+GYYzIOmEecnFwTe3rl+aiHDewBk/8fnIVrSjR/fNGQ==",
             "requires": {
-                "cookie": "^0.7.0",
-                "long": "^4.0.0",
-                "undici": "^5.29.0"
+                "@azure/functions-extensions-base": "0.3.0",
+                "cookie": "^0.7.0"
             }
         },
-        "@fastify/busboy": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
-            "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ=="
+        "@azure/functions-extensions-base": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.3.0.tgz",
+            "integrity": "sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA=="
         },
         "agent-base": {
             "version": "6.0.2",
@@ -563,7 +546,7 @@
         "durable-functions": {
             "version": "file:..",
             "requires": {
-                "@azure/functions": "4.8.2",
+                "@azure/functions": "^4.14.0",
                 "@opentelemetry/api": "^1.9.0",
                 "@types/chai": "~4.1.6",
                 "@types/chai-as-promised": "~7.1.0",
@@ -713,9 +696,6 @@
                 "debug": "4"
             }
         },
-        "long": {
-            "version": "4.0.0"
-        },
         "luxon": {
             "version": "3.2.1"
         },
@@ -756,14 +736,6 @@
             "version": "3.6.0",
             "requires": {
                 "picomatch": "^2.2.1"
-            }
-        },
-        "undici": {
-            "version": "5.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-            "requires": {
-                "@fastify/busboy": "^2.0.0"
             }
         }
     }

--- a/samples-js/package-lock.json
+++ b/samples-js/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "dependencies": {
                 "@azure/functions": "^4.14.0",
-                "axios": "^1.17.0",
+                "axios": "^1.18.0",
                 "durable-functions": "file:../durable-functions",
                 "luxon": "^3.2.1",
                 "readdirp": "^3.6.0"
@@ -57,9 +57,9 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-            "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+            "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.16.0",
@@ -445,9 +445,9 @@
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
         "axios": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-            "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+            "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
             "requires": {
                 "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",

--- a/samples-js/package-lock.json
+++ b/samples-js/package-lock.json
@@ -8,7 +8,7 @@
             "name": "samples-js",
             "version": "1.0.0",
             "dependencies": {
-                "@azure/functions": "^4.8.2",
+                "@azure/functions": "^4.14.0",
                 "axios": "^1.17.0",
                 "durable-functions": "file:../durable-functions",
                 "luxon": "^3.2.1",
@@ -17,26 +17,25 @@
         },
         "../durable-functions": {},
         "node_modules/@azure/functions": {
-            "version": "4.8.2",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.2.tgz",
-            "integrity": "sha512-MrIvgseTdfMX7uZRL2Lrv8BjAe5lXtJFA5CSdSyhMAKPu3fIJdaJCLc4NhdbXj3hEiVugr5D699f1QkpaQ8wTg==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
+            "integrity": "sha512-13LsitEHNe09qmpEf6eX1ajyI9Cn9syJ8p3ord40h9+08Qk72Yg8X7FNkrgvidJqr9bPwCkcRup2yyIq1mSa6w==",
             "license": "MIT",
             "dependencies": {
-                "cookie": "^0.7.0",
-                "long": "^4.0.0",
-                "undici": "^5.29.0"
+                "@azure/functions-extensions-base": "0.2.0",
+                "cookie": "^0.7.0"
             },
             "engines": {
-                "node": ">=18.0"
+                "node": ">=20.0"
             }
         },
-        "node_modules/@fastify/busboy": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+        "node_modules/@azure/functions-extensions-base": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
+            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ==",
             "license": "MIT",
             "engines": {
-                "node": ">=14"
+                "node": ">=18.0"
             }
         },
         "node_modules/agent-base": {
@@ -338,12 +337,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/long": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-            "license": "Apache-2.0"
-        },
         "node_modules/luxon": {
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
@@ -421,35 +414,22 @@
             "engines": {
                 "node": ">=8.10.0"
             }
-        },
-        "node_modules/undici": {
-            "version": "5.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-            "license": "MIT",
-            "dependencies": {
-                "@fastify/busboy": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.0"
-            }
         }
     },
     "dependencies": {
         "@azure/functions": {
-            "version": "4.8.2",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.2.tgz",
-            "integrity": "sha512-MrIvgseTdfMX7uZRL2Lrv8BjAe5lXtJFA5CSdSyhMAKPu3fIJdaJCLc4NhdbXj3hEiVugr5D699f1QkpaQ8wTg==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
+            "integrity": "sha512-13LsitEHNe09qmpEf6eX1ajyI9Cn9syJ8p3ord40h9+08Qk72Yg8X7FNkrgvidJqr9bPwCkcRup2yyIq1mSa6w==",
             "requires": {
-                "cookie": "^0.7.0",
-                "long": "^4.0.0",
-                "undici": "^5.29.0"
+                "@azure/functions-extensions-base": "0.2.0",
+                "cookie": "^0.7.0"
             }
         },
-        "@fastify/busboy": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
+        "@azure/functions-extensions-base": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
+            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ=="
         },
         "agent-base": {
             "version": "6.0.2",
@@ -635,11 +615,6 @@
                 "debug": "4"
             }
         },
-        "long": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-        },
         "luxon": {
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
@@ -684,14 +659,6 @@
             "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
             "requires": {
                 "picomatch": "^2.2.1"
-            }
-        },
-        "undici": {
-            "version": "5.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-            "requires": {
-                "@fastify/busboy": "^2.0.0"
             }
         }
     }

--- a/samples-js/package-lock.json
+++ b/samples-js/package-lock.json
@@ -8,8 +8,8 @@
             "name": "samples-js",
             "version": "1.0.0",
             "dependencies": {
-                "@azure/functions": "^4.14.0",
-                "axios": "^1.16.1",
+                "@azure/functions": "^4.8.2",
+                "axios": "^1.17.0",
                 "durable-functions": "file:../durable-functions",
                 "luxon": "^3.2.1",
                 "readdirp": "^3.6.0"
@@ -17,25 +17,26 @@
         },
         "../durable-functions": {},
         "node_modules/@azure/functions": {
-            "version": "4.14.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
-            "integrity": "sha512-13LsitEHNe09qmpEf6eX1ajyI9Cn9syJ8p3ord40h9+08Qk72Yg8X7FNkrgvidJqr9bPwCkcRup2yyIq1mSa6w==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.2.tgz",
+            "integrity": "sha512-MrIvgseTdfMX7uZRL2Lrv8BjAe5lXtJFA5CSdSyhMAKPu3fIJdaJCLc4NhdbXj3hEiVugr5D699f1QkpaQ8wTg==",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions-extensions-base": "0.2.0",
-                "cookie": "^0.7.0"
+                "cookie": "^0.7.0",
+                "long": "^4.0.0",
+                "undici": "^5.29.0"
             },
             "engines": {
-                "node": ">=20.0"
+                "node": ">=18.0"
             }
         },
-        "node_modules/@azure/functions-extensions-base": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
-            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ==",
+        "node_modules/@fastify/busboy": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
             "license": "MIT",
             "engines": {
-                "node": ">=18.0"
+                "node": ">=14"
             }
         },
         "node_modules/agent-base": {
@@ -57,9 +58,9 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.16.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-            "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+            "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.16.0",
@@ -337,6 +338,12 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/long": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+            "license": "Apache-2.0"
+        },
         "node_modules/luxon": {
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
@@ -414,22 +421,35 @@
             "engines": {
                 "node": ">=8.10.0"
             }
+        },
+        "node_modules/undici": {
+            "version": "5.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+            "license": "MIT",
+            "dependencies": {
+                "@fastify/busboy": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.0"
+            }
         }
     },
     "dependencies": {
         "@azure/functions": {
-            "version": "4.14.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
-            "integrity": "sha512-13LsitEHNe09qmpEf6eX1ajyI9Cn9syJ8p3ord40h9+08Qk72Yg8X7FNkrgvidJqr9bPwCkcRup2yyIq1mSa6w==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.2.tgz",
+            "integrity": "sha512-MrIvgseTdfMX7uZRL2Lrv8BjAe5lXtJFA5CSdSyhMAKPu3fIJdaJCLc4NhdbXj3hEiVugr5D699f1QkpaQ8wTg==",
             "requires": {
-                "@azure/functions-extensions-base": "0.2.0",
-                "cookie": "^0.7.0"
+                "cookie": "^0.7.0",
+                "long": "^4.0.0",
+                "undici": "^5.29.0"
             }
         },
-        "@azure/functions-extensions-base": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
-            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ=="
+        "@fastify/busboy": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
         },
         "agent-base": {
             "version": "6.0.2",
@@ -445,9 +465,9 @@
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
         "axios": {
-            "version": "1.16.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-            "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+            "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
             "requires": {
                 "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",
@@ -615,6 +635,11 @@
                 "debug": "4"
             }
         },
+        "long": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+        },
         "luxon": {
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
@@ -659,6 +684,14 @@
             "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
             "requires": {
                 "picomatch": "^2.2.1"
+            }
+        },
+        "undici": {
+            "version": "5.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+            "requires": {
+                "@fastify/busboy": "^2.0.0"
             }
         }
     }

--- a/samples-js/package-lock.json
+++ b/samples-js/package-lock.json
@@ -10,12 +10,59 @@
             "dependencies": {
                 "@azure/functions": "^4.14.0",
                 "axios": "^1.18.0",
-                "durable-functions": "file:../durable-functions",
+                "durable-functions": "file:..",
                 "luxon": "^3.2.1",
                 "readdirp": "^3.6.0"
             }
         },
-        "../durable-functions": {},
+        "..": {
+            "name": "durable-functions",
+            "version": "3.3.1",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/functions": "^4.14.0",
+                "@opentelemetry/api": "^1.9.0",
+                "axios": "^1.18.0",
+                "debug": "~2.6.9",
+                "lodash": "^4.18.1",
+                "moment": "^2.29.2",
+                "uuid": "^11.1.1",
+                "validator": "~13.15.20"
+            },
+            "devDependencies": {
+                "@types/chai": "~4.1.6",
+                "@types/chai-as-promised": "~7.1.0",
+                "@types/chai-string": "~1.4.1",
+                "@types/debug": "0.0.29",
+                "@types/lodash": "^4.14.119",
+                "@types/mocha": "^7.0.2",
+                "@types/nock": "^9.3.0",
+                "@types/node": "^18.0.0",
+                "@types/rimraf": "0.0.28",
+                "@types/sinon": "~5.0.5",
+                "@types/uuid": "^9.0.7",
+                "@types/validator": "^9.4.3",
+                "@typescript-eslint/eslint-plugin": "^5.4.0",
+                "@typescript-eslint/parser": "^5.4.0",
+                "chai": "~4.2.0",
+                "chai-as-promised": "~7.1.1",
+                "chai-string": "~1.5.0",
+                "eslint": "^7.32.0",
+                "eslint-config-prettier": "^6.15.0",
+                "eslint-plugin-prettier": "^3.4.1",
+                "mocha": "^11.2.2",
+                "nock": "^10.0.6",
+                "prettier": "^2.0.5",
+                "rimraf": "~2.5.4",
+                "sinon": "~7.1.1",
+                "ts-node": "^10.0.0",
+                "typedoc": "^0.22.11",
+                "typescript": "~4.5.0"
+            },
+            "engines": {
+                "node": ">=18.0"
+            }
+        },
         "node_modules/@azure/functions": {
             "version": "4.14.0",
             "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
@@ -143,7 +190,7 @@
             }
         },
         "node_modules/durable-functions": {
-            "resolved": "../durable-functions",
+            "resolved": "..",
             "link": true
         },
         "node_modules/es-define-property": {
@@ -501,7 +548,45 @@
             }
         },
         "durable-functions": {
-            "version": "file:../durable-functions"
+            "version": "file:..",
+            "requires": {
+                "@azure/functions": "^4.14.0",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/chai": "~4.1.6",
+                "@types/chai-as-promised": "~7.1.0",
+                "@types/chai-string": "~1.4.1",
+                "@types/debug": "0.0.29",
+                "@types/lodash": "^4.14.119",
+                "@types/mocha": "^7.0.2",
+                "@types/nock": "^9.3.0",
+                "@types/node": "^18.0.0",
+                "@types/rimraf": "0.0.28",
+                "@types/sinon": "~5.0.5",
+                "@types/uuid": "^9.0.7",
+                "@types/validator": "^9.4.3",
+                "@typescript-eslint/eslint-plugin": "^5.4.0",
+                "@typescript-eslint/parser": "^5.4.0",
+                "axios": "^1.18.0",
+                "chai": "~4.2.0",
+                "chai-as-promised": "~7.1.1",
+                "chai-string": "~1.5.0",
+                "debug": "~2.6.9",
+                "eslint": "^7.32.0",
+                "eslint-config-prettier": "^6.15.0",
+                "eslint-plugin-prettier": "^3.4.1",
+                "lodash": "^4.18.1",
+                "mocha": "^11.2.2",
+                "moment": "^2.29.2",
+                "nock": "^10.0.6",
+                "prettier": "^2.0.5",
+                "rimraf": "~2.5.4",
+                "sinon": "~7.1.1",
+                "ts-node": "^10.0.0",
+                "typedoc": "^0.22.11",
+                "typescript": "~4.5.0",
+                "uuid": "^11.1.1",
+                "validator": "~13.15.20"
+            }
         },
         "es-define-property": {
             "version": "1.0.1",

--- a/samples-js/package.json
+++ b/samples-js/package.json
@@ -8,7 +8,7 @@
         "test": "echo \"No tests yet...\""
     },
     "dependencies": {
-        "@azure/functions": "^4.16.1",
+        "@azure/functions": "4.8.2",
         "axios": "^1.18.0",
         "durable-functions": "file:..",
         "luxon": "^3.2.1",

--- a/samples-js/package.json
+++ b/samples-js/package.json
@@ -10,7 +10,7 @@
     "dependencies": {
         "@azure/functions": "^4.14.0",
         "axios": "^1.18.0",
-        "durable-functions": "file:../durable-functions",
+        "durable-functions": "file:..",
         "luxon": "^3.2.1",
         "readdirp": "^3.6.0"
     }

--- a/samples-js/package.json
+++ b/samples-js/package.json
@@ -8,8 +8,8 @@
         "test": "echo \"No tests yet...\""
     },
     "dependencies": {
-        "@azure/functions": "^4.7.0",
-        "axios": "^1.12.0",
+        "@azure/functions": "^4.14.0",
+        "axios": "^1.16.1",
         "durable-functions": "file:../durable-functions",
         "luxon": "^3.2.1",
         "readdirp": "^3.6.0"

--- a/samples-js/package.json
+++ b/samples-js/package.json
@@ -9,7 +9,7 @@
     },
     "dependencies": {
         "@azure/functions": "^4.14.0",
-        "axios": "1.17.0",
+        "axios": "1.18.0",
         "durable-functions": "file:..",
         "luxon": "^3.2.1",
         "readdirp": "^3.6.0"

--- a/samples-js/package.json
+++ b/samples-js/package.json
@@ -9,7 +9,7 @@
     },
     "dependencies": {
         "@azure/functions": "4.8.2",
-        "axios": "^1.18.0",
+        "axios": "1.17.0",
         "durable-functions": "file:..",
         "luxon": "^3.2.1",
         "readdirp": "^3.6.0"

--- a/samples-js/package.json
+++ b/samples-js/package.json
@@ -9,7 +9,7 @@
     },
     "dependencies": {
         "@azure/functions": "^4.14.0",
-        "axios": "^1.17.0",
+        "axios": "^1.18.0",
         "durable-functions": "file:../durable-functions",
         "luxon": "^3.2.1",
         "readdirp": "^3.6.0"

--- a/samples-js/package.json
+++ b/samples-js/package.json
@@ -8,8 +8,8 @@
         "test": "echo \"No tests yet...\""
     },
     "dependencies": {
-        "@azure/functions": "^4.14.0",
-        "axios": "^1.16.1",
+        "@azure/functions": "^4.8.2",
+        "axios": "^1.17.0",
         "durable-functions": "file:../durable-functions",
         "luxon": "^3.2.1",
         "readdirp": "^3.6.0"

--- a/samples-js/package.json
+++ b/samples-js/package.json
@@ -8,7 +8,7 @@
         "test": "echo \"No tests yet...\""
     },
     "dependencies": {
-        "@azure/functions": "^4.14.0",
+        "@azure/functions": "^4.16.1",
         "axios": "^1.18.0",
         "durable-functions": "file:..",
         "luxon": "^3.2.1",

--- a/samples-js/package.json
+++ b/samples-js/package.json
@@ -8,7 +8,7 @@
         "test": "echo \"No tests yet...\""
     },
     "dependencies": {
-        "@azure/functions": "^4.8.2",
+        "@azure/functions": "^4.14.0",
         "axios": "^1.17.0",
         "durable-functions": "file:../durable-functions",
         "luxon": "^3.2.1",

--- a/samples-js/package.json
+++ b/samples-js/package.json
@@ -8,7 +8,7 @@
         "test": "echo \"No tests yet...\""
     },
     "dependencies": {
-        "@azure/functions": "4.8.2",
+        "@azure/functions": "^4.14.0",
         "axios": "1.17.0",
         "durable-functions": "file:..",
         "luxon": "^3.2.1",

--- a/samples-ts/package-lock.json
+++ b/samples-ts/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "@azure/functions": "^4.14.0",
                 "axios": "^1.18.0",
-                "durable-functions": "file:../durable-functions",
+                "durable-functions": "file:..",
                 "luxon": "^3.2.1",
                 "readdirp": "^3.6.0"
             },
@@ -20,7 +20,54 @@
                 "typescript": "^4.0.0"
             }
         },
-        "../durable-functions": {},
+        "..": {
+            "name": "durable-functions",
+            "version": "3.3.1",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/functions": "^4.14.0",
+                "@opentelemetry/api": "^1.9.0",
+                "axios": "^1.18.0",
+                "debug": "~2.6.9",
+                "lodash": "^4.18.1",
+                "moment": "^2.29.2",
+                "uuid": "^11.1.1",
+                "validator": "~13.15.20"
+            },
+            "devDependencies": {
+                "@types/chai": "~4.1.6",
+                "@types/chai-as-promised": "~7.1.0",
+                "@types/chai-string": "~1.4.1",
+                "@types/debug": "0.0.29",
+                "@types/lodash": "^4.14.119",
+                "@types/mocha": "^7.0.2",
+                "@types/nock": "^9.3.0",
+                "@types/node": "^18.0.0",
+                "@types/rimraf": "0.0.28",
+                "@types/sinon": "~5.0.5",
+                "@types/uuid": "^9.0.7",
+                "@types/validator": "^9.4.3",
+                "@typescript-eslint/eslint-plugin": "^5.4.0",
+                "@typescript-eslint/parser": "^5.4.0",
+                "chai": "~4.2.0",
+                "chai-as-promised": "~7.1.1",
+                "chai-string": "~1.5.0",
+                "eslint": "^7.32.0",
+                "eslint-config-prettier": "^6.15.0",
+                "eslint-plugin-prettier": "^3.4.1",
+                "mocha": "^11.2.2",
+                "nock": "^10.0.6",
+                "prettier": "^2.0.5",
+                "rimraf": "~2.5.4",
+                "sinon": "~7.1.1",
+                "ts-node": "^10.0.0",
+                "typedoc": "^0.22.11",
+                "typescript": "~4.5.0"
+            },
+            "engines": {
+                "node": ">=18.0"
+            }
+        },
         "node_modules/@azure/functions": {
             "version": "4.14.0",
             "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
@@ -162,7 +209,7 @@
             }
         },
         "node_modules/durable-functions": {
-            "resolved": "../durable-functions",
+            "resolved": "..",
             "link": true
         },
         "node_modules/es-define-property": {
@@ -546,7 +593,45 @@
             }
         },
         "durable-functions": {
-            "version": "file:../durable-functions"
+            "version": "file:..",
+            "requires": {
+                "@azure/functions": "^4.14.0",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/chai": "~4.1.6",
+                "@types/chai-as-promised": "~7.1.0",
+                "@types/chai-string": "~1.4.1",
+                "@types/debug": "0.0.29",
+                "@types/lodash": "^4.14.119",
+                "@types/mocha": "^7.0.2",
+                "@types/nock": "^9.3.0",
+                "@types/node": "^18.0.0",
+                "@types/rimraf": "0.0.28",
+                "@types/sinon": "~5.0.5",
+                "@types/uuid": "^9.0.7",
+                "@types/validator": "^9.4.3",
+                "@typescript-eslint/eslint-plugin": "^5.4.0",
+                "@typescript-eslint/parser": "^5.4.0",
+                "axios": "^1.18.0",
+                "chai": "~4.2.0",
+                "chai-as-promised": "~7.1.1",
+                "chai-string": "~1.5.0",
+                "debug": "~2.6.9",
+                "eslint": "^7.32.0",
+                "eslint-config-prettier": "^6.15.0",
+                "eslint-plugin-prettier": "^3.4.1",
+                "lodash": "^4.18.1",
+                "mocha": "^11.2.2",
+                "moment": "^2.29.2",
+                "nock": "^10.0.6",
+                "prettier": "^2.0.5",
+                "rimraf": "~2.5.4",
+                "sinon": "~7.1.1",
+                "ts-node": "^10.0.0",
+                "typedoc": "^0.22.11",
+                "typescript": "~4.5.0",
+                "uuid": "^11.1.1",
+                "validator": "~13.15.20"
+            }
         },
         "es-define-property": {
             "version": "1.0.1",

--- a/samples-ts/package-lock.json
+++ b/samples-ts/package-lock.json
@@ -91,16 +91,18 @@
             }
         },
         "node_modules/@types/luxon": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.2.0.tgz",
-            "integrity": "sha512-lGmaGFoaXHuOLXFvuju2bfvZRqxAqkHPx9Y9IQdQABrinJJshJwfNCKV+u7rR3kJbiqfTF/NhOkcxxAFrObyaA==",
-            "dev": true
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.2.tgz",
+            "integrity": "sha512-gW+Oib+vUtGJBtNC8V9Reww0oIpusw+4m81uncg9REGZAJfqOQHfo/nkabnc7w0QReXyPqjrbWMJk6NuAkiX3Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "16.18.11",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.11.tgz",
-            "integrity": "sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==",
-            "dev": true
+            "version": "16.18.126",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
+            "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/agent-base": {
             "version": "6.0.2",
@@ -402,9 +404,10 @@
             }
         },
         "node_modules/luxon": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
-            "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==",
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+            "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             }
@@ -470,6 +473,7 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
             "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "license": "MIT",
             "dependencies": {
                 "picomatch": "^2.2.1"
             },
@@ -478,10 +482,11 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.9.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-            "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -507,15 +512,15 @@
             "integrity": "sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA=="
         },
         "@types/luxon": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.2.0.tgz",
-            "integrity": "sha512-lGmaGFoaXHuOLXFvuju2bfvZRqxAqkHPx9Y9IQdQABrinJJshJwfNCKV+u7rR3kJbiqfTF/NhOkcxxAFrObyaA==",
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.2.tgz",
+            "integrity": "sha512-gW+Oib+vUtGJBtNC8V9Reww0oIpusw+4m81uncg9REGZAJfqOQHfo/nkabnc7w0QReXyPqjrbWMJk6NuAkiX3Q==",
             "dev": true
         },
         "@types/node": {
-            "version": "16.18.11",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.11.tgz",
-            "integrity": "sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==",
+            "version": "16.18.126",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
+            "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
             "dev": true
         },
         "agent-base": {
@@ -741,9 +746,9 @@
             }
         },
         "luxon": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
-            "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg=="
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+            "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="
         },
         "math-intrinsics": {
             "version": "1.1.0",
@@ -787,9 +792,9 @@
             }
         },
         "typescript": {
-            "version": "4.9.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-            "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true
         }
     }

--- a/samples-ts/package-lock.json
+++ b/samples-ts/package-lock.json
@@ -8,8 +8,8 @@
             "name": "samples-ts",
             "version": "1.0.0",
             "dependencies": {
-                "@azure/functions": "^4.0.0",
-                "axios": "^1.12.0",
+                "@azure/functions": "^4.14.0",
+                "axios": "^1.16.1",
                 "durable-functions": "file:../durable-functions",
                 "luxon": "^3.2.1",
                 "readdirp": "^3.6.0"
@@ -20,58 +20,71 @@
                 "typescript": "^4.0.0"
             }
         },
-        "../durable-functions": {
-            "version": "0.0.1"
-        },
+        "../durable-functions": {},
         "node_modules/@azure/functions": {
-            "version": "4.7.2",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.7.2.tgz",
-            "integrity": "sha512-5ps8yz4gn6oZSzeQbpUreWHFYl/YS03F1Sk/pz7YJphfctRcHuLF5tcrdm9AyRiYzja4Bkd63bju+g/E27opPQ==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
+            "integrity": "sha512-13LsitEHNe09qmpEf6eX1ajyI9Cn9syJ8p3ord40h9+08Qk72Yg8X7FNkrgvidJqr9bPwCkcRup2yyIq1mSa6w==",
             "license": "MIT",
             "dependencies": {
-                "cookie": "^0.7.0",
-                "long": "^4.0.0",
-                "undici": "^5.29.0"
+                "@azure/functions-extensions-base": "0.2.0",
+                "cookie": "^0.7.0"
             },
+            "engines": {
+                "node": ">=20.0"
+            }
+        },
+        "node_modules/@azure/functions-extensions-base": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
+            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=18.0"
             }
         },
-        "node_modules/@fastify/busboy": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14"
-            }
-        },
         "node_modules/@types/luxon": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.2.0.tgz",
-            "integrity": "sha512-lGmaGFoaXHuOLXFvuju2bfvZRqxAqkHPx9Y9IQdQABrinJJshJwfNCKV+u7rR3kJbiqfTF/NhOkcxxAFrObyaA==",
-            "dev": true
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.1.tgz",
+            "integrity": "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "16.18.11",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.11.tgz",
-            "integrity": "sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==",
-            "dev": true
+            "version": "16.18.126",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
+            "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
-            "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+            "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
             "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.4",
-                "proxy-from-env": "^1.1.0"
+                "follow-redirects": "^1.16.0",
+                "form-data": "^4.0.5",
+                "https-proxy-agent": "^5.0.1",
+                "proxy-from-env": "^2.1.0"
             }
         },
         "node_modules/call-bind-apply-helpers": {
@@ -91,6 +104,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "license": "MIT",
             "dependencies": {
                 "delayed-stream": "~1.0.0"
             },
@@ -107,10 +121,28 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -179,15 +211,16 @@
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.6",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "funding": [
                 {
                     "type": "individual",
                     "url": "https://github.com/sponsors/RubenVerborgh"
                 }
             ],
+            "license": "MIT",
             "engines": {
                 "node": ">=4.0"
             },
@@ -198,9 +231,9 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
@@ -299,9 +332,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+            "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -310,15 +343,24 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/long": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+        "node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
         },
         "node_modules/luxon": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
-            "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==",
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+            "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             }
@@ -336,6 +378,7 @@
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -344,6 +387,7 @@
             "version": "2.1.35",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "license": "MIT",
             "dependencies": {
                 "mime-db": "1.52.0"
             },
@@ -351,10 +395,17 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
+        },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8.6"
             },
@@ -363,14 +414,19 @@
             }
         },
         "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/readdirp": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
             "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "license": "MIT",
             "dependencies": {
                 "picomatch": "^2.2.1"
             },
@@ -379,10 +435,11 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.9.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-            "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -390,47 +447,42 @@
             "engines": {
                 "node": ">=4.2.0"
             }
-        },
-        "node_modules/undici": {
-            "version": "5.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-            "license": "MIT",
-            "dependencies": {
-                "@fastify/busboy": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.0"
-            }
         }
     },
     "dependencies": {
         "@azure/functions": {
-            "version": "4.7.2",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.7.2.tgz",
-            "integrity": "sha512-5ps8yz4gn6oZSzeQbpUreWHFYl/YS03F1Sk/pz7YJphfctRcHuLF5tcrdm9AyRiYzja4Bkd63bju+g/E27opPQ==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
+            "integrity": "sha512-13LsitEHNe09qmpEf6eX1ajyI9Cn9syJ8p3ord40h9+08Qk72Yg8X7FNkrgvidJqr9bPwCkcRup2yyIq1mSa6w==",
             "requires": {
-                "cookie": "^0.7.0",
-                "long": "^4.0.0",
-                "undici": "^5.29.0"
+                "@azure/functions-extensions-base": "0.2.0",
+                "cookie": "^0.7.0"
             }
         },
-        "@fastify/busboy": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
+        "@azure/functions-extensions-base": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
+            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ=="
         },
         "@types/luxon": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.2.0.tgz",
-            "integrity": "sha512-lGmaGFoaXHuOLXFvuju2bfvZRqxAqkHPx9Y9IQdQABrinJJshJwfNCKV+u7rR3kJbiqfTF/NhOkcxxAFrObyaA==",
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.1.tgz",
+            "integrity": "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==",
             "dev": true
         },
         "@types/node": {
-            "version": "16.18.11",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.11.tgz",
-            "integrity": "sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==",
+            "version": "16.18.126",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
+            "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
             "dev": true
+        },
+        "agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "requires": {
+                "debug": "4"
+            }
         },
         "asynckit": {
             "version": "0.4.0",
@@ -438,13 +490,14 @@
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
         "axios": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
-            "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+            "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
             "requires": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.4",
-                "proxy-from-env": "^1.1.0"
+                "follow-redirects": "^1.16.0",
+                "form-data": "^4.0.5",
+                "https-proxy-agent": "^5.0.1",
+                "proxy-from-env": "^2.1.0"
             }
         },
         "call-bind-apply-helpers": {
@@ -468,6 +521,14 @@
             "version": "0.7.2",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
             "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
+        },
+        "debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "requires": {
+                "ms": "^2.1.3"
+            }
         },
         "delayed-stream": {
             "version": "1.0.0",
@@ -517,14 +578,14 @@
             }
         },
         "follow-redirects": {
-            "version": "1.15.6",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="
         },
         "form-data": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
             "requires": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
@@ -583,22 +644,26 @@
             }
         },
         "hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+            "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
             "requires": {
                 "function-bind": "^1.1.2"
             }
         },
-        "long": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+        "https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "requires": {
+                "agent-base": "6",
+                "debug": "4"
+            }
         },
         "luxon": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
-            "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg=="
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+            "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="
         },
         "math-intrinsics": {
             "version": "1.1.0",
@@ -618,15 +683,20 @@
                 "mime-db": "1.52.0"
             }
         },
+        "ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        },
         "picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="
         },
         "proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="
         },
         "readdirp": {
             "version": "3.6.0",
@@ -637,18 +707,10 @@
             }
         },
         "typescript": {
-            "version": "4.9.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-            "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true
-        },
-        "undici": {
-            "version": "5.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-            "requires": {
-                "@fastify/busboy": "^2.0.0"
-            }
         }
     }
 }

--- a/samples-ts/package-lock.json
+++ b/samples-ts/package-lock.json
@@ -8,7 +8,7 @@
             "name": "samples-ts",
             "version": "1.0.0",
             "dependencies": {
-                "@azure/functions": "^4.14.0",
+                "@azure/functions": "^4.16.1",
                 "axios": "^1.18.0",
                 "durable-functions": "file:..",
                 "luxon": "^3.2.1",
@@ -25,14 +25,14 @@
             "version": "3.3.1",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions": "^4.14.0",
+                "@azure/functions": "^4.16.1",
                 "@opentelemetry/api": "^1.9.0",
                 "axios": "^1.18.0",
                 "debug": "~2.6.9",
                 "lodash": "^4.18.1",
                 "moment": "^2.29.2",
                 "uuid": "^11.1.1",
-                "validator": "~13.15.20"
+                "validator": "~13.15.35"
             },
             "devDependencies": {
                 "@types/chai": "~4.1.6",
@@ -69,12 +69,12 @@
             }
         },
         "node_modules/@azure/functions": {
-            "version": "4.14.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
-            "integrity": "sha512-13LsitEHNe09qmpEf6eX1ajyI9Cn9syJ8p3ord40h9+08Qk72Yg8X7FNkrgvidJqr9bPwCkcRup2yyIq1mSa6w==",
+            "version": "4.16.1",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.16.1.tgz",
+            "integrity": "sha512-A9obwC7IBg4NAmxUfTVfYEd8Xg6Px+o85JRprS3UJZt+GYYzIOmEecnFwTe3rl+aiHDewBk/8fnIVrSjR/fNGQ==",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions-extensions-base": "0.2.0",
+                "@azure/functions-extensions-base": "0.3.0",
                 "cookie": "^0.7.0"
             },
             "engines": {
@@ -82,9 +82,9 @@
             }
         },
         "node_modules/@azure/functions-extensions-base": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
-            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.3.0.tgz",
+            "integrity": "sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.0"
@@ -278,16 +278,16 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -379,9 +379,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-            "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -498,18 +498,18 @@
     },
     "dependencies": {
         "@azure/functions": {
-            "version": "4.14.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
-            "integrity": "sha512-13LsitEHNe09qmpEf6eX1ajyI9Cn9syJ8p3ord40h9+08Qk72Yg8X7FNkrgvidJqr9bPwCkcRup2yyIq1mSa6w==",
+            "version": "4.16.1",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.16.1.tgz",
+            "integrity": "sha512-A9obwC7IBg4NAmxUfTVfYEd8Xg6Px+o85JRprS3UJZt+GYYzIOmEecnFwTe3rl+aiHDewBk/8fnIVrSjR/fNGQ==",
             "requires": {
-                "@azure/functions-extensions-base": "0.2.0",
+                "@azure/functions-extensions-base": "0.3.0",
                 "cookie": "^0.7.0"
             }
         },
         "@azure/functions-extensions-base": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
-            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ=="
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.3.0.tgz",
+            "integrity": "sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA=="
         },
         "@types/luxon": {
             "version": "3.7.1",
@@ -595,7 +595,7 @@
         "durable-functions": {
             "version": "file:..",
             "requires": {
-                "@azure/functions": "^4.14.0",
+                "@azure/functions": "^4.16.1",
                 "@opentelemetry/api": "^1.9.0",
                 "@types/chai": "~4.1.6",
                 "@types/chai-as-promised": "~7.1.0",
@@ -630,7 +630,7 @@
                 "typedoc": "^0.22.11",
                 "typescript": "~4.5.0",
                 "uuid": "^11.1.1",
-                "validator": "~13.15.20"
+                "validator": "~13.15.35"
             }
         },
         "es-define-property": {
@@ -668,15 +668,15 @@
             "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="
         },
         "form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "requires": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             }
         },
         "function-bind": {
@@ -729,9 +729,9 @@
             }
         },
         "hasown": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-            "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "requires": {
                 "function-bind": "^1.1.2"
             }

--- a/samples-ts/package-lock.json
+++ b/samples-ts/package-lock.json
@@ -8,7 +8,7 @@
             "name": "samples-ts",
             "version": "1.0.0",
             "dependencies": {
-                "@azure/functions": "^4.16.1",
+                "@azure/functions": "4.8.2",
                 "axios": "^1.18.0",
                 "durable-functions": "file:..",
                 "luxon": "^3.2.1",
@@ -25,7 +25,7 @@
             "version": "3.3.1",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions": "^4.16.1",
+                "@azure/functions": "4.8.2",
                 "@opentelemetry/api": "^1.9.0",
                 "axios": "^1.18.0",
                 "debug": "~2.6.9",
@@ -69,40 +69,39 @@
             }
         },
         "node_modules/@azure/functions": {
-            "version": "4.16.1",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.16.1.tgz",
-            "integrity": "sha512-A9obwC7IBg4NAmxUfTVfYEd8Xg6Px+o85JRprS3UJZt+GYYzIOmEecnFwTe3rl+aiHDewBk/8fnIVrSjR/fNGQ==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.2.tgz",
+            "integrity": "sha512-MrIvgseTdfMX7uZRL2Lrv8BjAe5lXtJFA5CSdSyhMAKPu3fIJdaJCLc4NhdbXj3hEiVugr5D699f1QkpaQ8wTg==",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions-extensions-base": "0.3.0",
-                "cookie": "^0.7.0"
+                "cookie": "^0.7.0",
+                "long": "^4.0.0",
+                "undici": "^5.29.0"
             },
-            "engines": {
-                "node": ">=20.0"
-            }
-        },
-        "node_modules/@azure/functions-extensions-base": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.3.0.tgz",
-            "integrity": "sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA==",
-            "license": "MIT",
             "engines": {
                 "node": ">=18.0"
             }
         },
+        "node_modules/@fastify/busboy": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/@types/luxon": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.1.tgz",
-            "integrity": "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==",
-            "dev": true,
-            "license": "MIT"
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.2.0.tgz",
+            "integrity": "sha512-lGmaGFoaXHuOLXFvuju2bfvZRqxAqkHPx9Y9IQdQABrinJJshJwfNCKV+u7rR3kJbiqfTF/NhOkcxxAFrObyaA==",
+            "dev": true
         },
         "node_modules/@types/node": {
-            "version": "16.18.126",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
-            "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
-            "dev": true,
-            "license": "MIT"
+            "version": "16.18.11",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.11.tgz",
+            "integrity": "sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==",
+            "dev": true
         },
         "node_modules/agent-base": {
             "version": "6.0.2",
@@ -231,9 +230,9 @@
             }
         },
         "node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
@@ -403,11 +402,15 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/long": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+        },
         "node_modules/luxon": {
-            "version": "3.7.2",
-            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
-            "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
-            "license": "MIT",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
+            "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==",
             "engines": {
                 "node": ">=12"
             }
@@ -473,7 +476,6 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
             "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-            "license": "MIT",
             "dependencies": {
                 "picomatch": "^2.2.1"
             },
@@ -482,11 +484,10 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.9.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "version": "4.9.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+            "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
             "dev": true,
-            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -494,33 +495,46 @@
             "engines": {
                 "node": ">=4.2.0"
             }
+        },
+        "node_modules/undici": {
+            "version": "5.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+            "license": "MIT",
+            "dependencies": {
+                "@fastify/busboy": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.0"
+            }
         }
     },
     "dependencies": {
         "@azure/functions": {
-            "version": "4.16.1",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.16.1.tgz",
-            "integrity": "sha512-A9obwC7IBg4NAmxUfTVfYEd8Xg6Px+o85JRprS3UJZt+GYYzIOmEecnFwTe3rl+aiHDewBk/8fnIVrSjR/fNGQ==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.2.tgz",
+            "integrity": "sha512-MrIvgseTdfMX7uZRL2Lrv8BjAe5lXtJFA5CSdSyhMAKPu3fIJdaJCLc4NhdbXj3hEiVugr5D699f1QkpaQ8wTg==",
             "requires": {
-                "@azure/functions-extensions-base": "0.3.0",
-                "cookie": "^0.7.0"
+                "cookie": "^0.7.0",
+                "long": "^4.0.0",
+                "undici": "^5.29.0"
             }
         },
-        "@azure/functions-extensions-base": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.3.0.tgz",
-            "integrity": "sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA=="
+        "@fastify/busboy": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
         },
         "@types/luxon": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.1.tgz",
-            "integrity": "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.2.0.tgz",
+            "integrity": "sha512-lGmaGFoaXHuOLXFvuju2bfvZRqxAqkHPx9Y9IQdQABrinJJshJwfNCKV+u7rR3kJbiqfTF/NhOkcxxAFrObyaA==",
             "dev": true
         },
         "@types/node": {
-            "version": "16.18.126",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
-            "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+            "version": "16.18.11",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.11.tgz",
+            "integrity": "sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==",
             "dev": true
         },
         "agent-base": {
@@ -595,7 +609,7 @@
         "durable-functions": {
             "version": "file:..",
             "requires": {
-                "@azure/functions": "^4.16.1",
+                "@azure/functions": "4.8.2",
                 "@opentelemetry/api": "^1.9.0",
                 "@types/chai": "~4.1.6",
                 "@types/chai-as-promised": "~7.1.0",
@@ -644,9 +658,9 @@
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
         },
         "es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
             "requires": {
                 "es-errors": "^1.3.0"
             }
@@ -745,10 +759,15 @@
                 "debug": "4"
             }
         },
+        "long": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+        },
         "luxon": {
-            "version": "3.7.2",
-            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
-            "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
+            "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg=="
         },
         "math-intrinsics": {
             "version": "1.1.0",
@@ -792,10 +811,18 @@
             }
         },
         "typescript": {
-            "version": "4.9.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "version": "4.9.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+            "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
             "dev": true
+        },
+        "undici": {
+            "version": "5.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+            "requires": {
+                "@fastify/busboy": "^2.0.0"
+            }
         }
     }
 }

--- a/samples-ts/package-lock.json
+++ b/samples-ts/package-lock.json
@@ -8,7 +8,7 @@
             "name": "samples-ts",
             "version": "1.0.0",
             "dependencies": {
-                "@azure/functions": "^4.8.2",
+                "@azure/functions": "^4.14.0",
                 "axios": "^1.17.0",
                 "durable-functions": "file:../durable-functions",
                 "luxon": "^3.2.1",
@@ -22,26 +22,25 @@
         },
         "../durable-functions": {},
         "node_modules/@azure/functions": {
-            "version": "4.8.2",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.2.tgz",
-            "integrity": "sha512-MrIvgseTdfMX7uZRL2Lrv8BjAe5lXtJFA5CSdSyhMAKPu3fIJdaJCLc4NhdbXj3hEiVugr5D699f1QkpaQ8wTg==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
+            "integrity": "sha512-13LsitEHNe09qmpEf6eX1ajyI9Cn9syJ8p3ord40h9+08Qk72Yg8X7FNkrgvidJqr9bPwCkcRup2yyIq1mSa6w==",
             "license": "MIT",
             "dependencies": {
-                "cookie": "^0.7.0",
-                "long": "^4.0.0",
-                "undici": "^5.29.0"
+                "@azure/functions-extensions-base": "0.2.0",
+                "cookie": "^0.7.0"
             },
             "engines": {
-                "node": ">=18.0"
+                "node": ">=20.0"
             }
         },
-        "node_modules/@fastify/busboy": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+        "node_modules/@azure/functions-extensions-base": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
+            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ==",
             "license": "MIT",
             "engines": {
-                "node": ">=14"
+                "node": ">=18.0"
             }
         },
         "node_modules/@types/luxon": {
@@ -357,12 +356,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/long": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-            "license": "Apache-2.0"
-        },
         "node_modules/luxon": {
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
@@ -454,35 +447,22 @@
             "engines": {
                 "node": ">=4.2.0"
             }
-        },
-        "node_modules/undici": {
-            "version": "5.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-            "license": "MIT",
-            "dependencies": {
-                "@fastify/busboy": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.0"
-            }
         }
     },
     "dependencies": {
         "@azure/functions": {
-            "version": "4.8.2",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.2.tgz",
-            "integrity": "sha512-MrIvgseTdfMX7uZRL2Lrv8BjAe5lXtJFA5CSdSyhMAKPu3fIJdaJCLc4NhdbXj3hEiVugr5D699f1QkpaQ8wTg==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
+            "integrity": "sha512-13LsitEHNe09qmpEf6eX1ajyI9Cn9syJ8p3ord40h9+08Qk72Yg8X7FNkrgvidJqr9bPwCkcRup2yyIq1mSa6w==",
             "requires": {
-                "cookie": "^0.7.0",
-                "long": "^4.0.0",
-                "undici": "^5.29.0"
+                "@azure/functions-extensions-base": "0.2.0",
+                "cookie": "^0.7.0"
             }
         },
-        "@fastify/busboy": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
+        "@azure/functions-extensions-base": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
+            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ=="
         },
         "@types/luxon": {
             "version": "3.7.1",
@@ -680,11 +660,6 @@
                 "debug": "4"
             }
         },
-        "long": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-        },
         "luxon": {
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
@@ -736,14 +711,6 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
             "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true
-        },
-        "undici": {
-            "version": "5.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-            "requires": {
-                "@fastify/busboy": "^2.0.0"
-            }
         }
     }
 }

--- a/samples-ts/package-lock.json
+++ b/samples-ts/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "dependencies": {
                 "@azure/functions": "4.8.2",
-                "axios": "^1.18.0",
+                "axios": "1.17.0",
                 "durable-functions": "file:..",
                 "luxon": "^3.2.1",
                 "readdirp": "^3.6.0"
@@ -22,17 +22,17 @@
         },
         "..": {
             "name": "durable-functions",
-            "version": "3.3.1",
+            "version": "3.4.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/functions": "4.8.2",
                 "@opentelemetry/api": "^1.9.0",
-                "axios": "^1.18.0",
+                "axios": "1.17.0",
                 "debug": "~2.6.9",
                 "lodash": "^4.18.1",
                 "moment": "^2.29.2",
-                "uuid": "^10.0.0",
-                "validator": "~13.15.35"
+                "uuid": "^9.0.1",
+                "validator": "~13.15.20"
             },
             "devDependencies": {
                 "@types/chai": "~4.1.6",
@@ -52,7 +52,7 @@
                 "chai": "~4.2.0",
                 "chai-as-promised": "~7.1.1",
                 "chai-string": "~1.5.0",
-                "eslint": "^7.32.0",
+                "eslint": "^8.57.1",
                 "eslint-config-prettier": "^6.15.0",
                 "eslint-plugin-prettier": "^3.4.1",
                 "mocha": "^11.2.2",
@@ -122,9 +122,9 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
-            "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+            "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.16.0",
@@ -551,9 +551,9 @@
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
         "axios": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
-            "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+            "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
             "requires": {
                 "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",
@@ -625,12 +625,12 @@
                 "@types/validator": "^9.4.3",
                 "@typescript-eslint/eslint-plugin": "^5.4.0",
                 "@typescript-eslint/parser": "^5.4.0",
-                "axios": "^1.18.0",
+                "axios": "1.17.0",
                 "chai": "~4.2.0",
                 "chai-as-promised": "~7.1.1",
                 "chai-string": "~1.5.0",
                 "debug": "~2.6.9",
-                "eslint": "^7.32.0",
+                "eslint": "^8.57.1",
                 "eslint-config-prettier": "^6.15.0",
                 "eslint-plugin-prettier": "^3.4.1",
                 "lodash": "^4.18.1",
@@ -643,8 +643,8 @@
                 "ts-node": "^10.0.0",
                 "typedoc": "^0.22.11",
                 "typescript": "~4.5.0",
-                "uuid": "^10.0.0",
-                "validator": "~13.15.35"
+                "uuid": "^9.0.1",
+                "validator": "~13.15.20"
             }
         },
         "es-define-property": {

--- a/samples-ts/package-lock.json
+++ b/samples-ts/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "dependencies": {
                 "@azure/functions": "^4.14.0",
-                "axios": "^1.17.0",
+                "axios": "^1.18.0",
                 "durable-functions": "file:../durable-functions",
                 "luxon": "^3.2.1",
                 "readdirp": "^3.6.0"
@@ -76,9 +76,9 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-            "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+            "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.16.0",
@@ -490,9 +490,9 @@
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
         "axios": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-            "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+            "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
             "requires": {
                 "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",

--- a/samples-ts/package-lock.json
+++ b/samples-ts/package-lock.json
@@ -31,7 +31,7 @@
                 "debug": "~2.6.9",
                 "lodash": "^4.18.1",
                 "moment": "^2.29.2",
-                "uuid": "^11.1.1",
+                "uuid": "^10.0.0",
                 "validator": "~13.15.35"
             },
             "devDependencies": {
@@ -643,7 +643,7 @@
                 "ts-node": "^10.0.0",
                 "typedoc": "^0.22.11",
                 "typescript": "~4.5.0",
-                "uuid": "^11.1.1",
+                "uuid": "^10.0.0",
                 "validator": "~13.15.35"
             }
         },

--- a/samples-ts/package-lock.json
+++ b/samples-ts/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "dependencies": {
                 "@azure/functions": "^4.14.0",
-                "axios": "1.17.0",
+                "axios": "1.18.0",
                 "durable-functions": "file:..",
                 "luxon": "^3.2.1",
                 "readdirp": "^3.6.0"
@@ -27,7 +27,7 @@
             "dependencies": {
                 "@azure/functions": "^4.14.0",
                 "@opentelemetry/api": "^1.9.0",
-                "axios": "1.17.0",
+                "axios": "1.18.0",
                 "debug": "~2.6.9",
                 "lodash": "^4.18.1",
                 "moment": "^2.29.2",
@@ -121,9 +121,9 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-            "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+            "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.16.0",
@@ -532,9 +532,9 @@
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
         "axios": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-            "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+            "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
             "requires": {
                 "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",
@@ -606,7 +606,7 @@
                 "@types/validator": "^9.4.3",
                 "@typescript-eslint/eslint-plugin": "^5.4.0",
                 "@typescript-eslint/parser": "^5.4.0",
-                "axios": "1.17.0",
+                "axios": "1.18.0",
                 "chai": "~4.2.0",
                 "chai-as-promised": "~7.1.1",
                 "chai-string": "~1.5.0",

--- a/samples-ts/package-lock.json
+++ b/samples-ts/package-lock.json
@@ -8,7 +8,7 @@
             "name": "samples-ts",
             "version": "1.0.0",
             "dependencies": {
-                "@azure/functions": "4.8.2",
+                "@azure/functions": "^4.14.0",
                 "axios": "1.17.0",
                 "durable-functions": "file:..",
                 "luxon": "^3.2.1",
@@ -25,7 +25,7 @@
             "version": "3.4.0",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions": "4.8.2",
+                "@azure/functions": "^4.14.0",
                 "@opentelemetry/api": "^1.9.0",
                 "axios": "1.17.0",
                 "debug": "~2.6.9",
@@ -69,26 +69,25 @@
             }
         },
         "node_modules/@azure/functions": {
-            "version": "4.8.2",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.2.tgz",
-            "integrity": "sha512-MrIvgseTdfMX7uZRL2Lrv8BjAe5lXtJFA5CSdSyhMAKPu3fIJdaJCLc4NhdbXj3hEiVugr5D699f1QkpaQ8wTg==",
+            "version": "4.16.1",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.16.1.tgz",
+            "integrity": "sha512-A9obwC7IBg4NAmxUfTVfYEd8Xg6Px+o85JRprS3UJZt+GYYzIOmEecnFwTe3rl+aiHDewBk/8fnIVrSjR/fNGQ==",
             "license": "MIT",
             "dependencies": {
-                "cookie": "^0.7.0",
-                "long": "^4.0.0",
-                "undici": "^5.29.0"
+                "@azure/functions-extensions-base": "0.3.0",
+                "cookie": "^0.7.0"
             },
             "engines": {
-                "node": ">=18.0"
+                "node": ">=20.0"
             }
         },
-        "node_modules/@fastify/busboy": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+        "node_modules/@azure/functions-extensions-base": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.3.0.tgz",
+            "integrity": "sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA==",
             "license": "MIT",
             "engines": {
-                "node": ">=14"
+                "node": ">=18.0"
             }
         },
         "node_modules/@types/luxon": {
@@ -402,11 +401,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/long": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-        },
         "node_modules/luxon": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
@@ -495,35 +489,22 @@
             "engines": {
                 "node": ">=4.2.0"
             }
-        },
-        "node_modules/undici": {
-            "version": "5.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-            "license": "MIT",
-            "dependencies": {
-                "@fastify/busboy": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.0"
-            }
         }
     },
     "dependencies": {
         "@azure/functions": {
-            "version": "4.8.2",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.2.tgz",
-            "integrity": "sha512-MrIvgseTdfMX7uZRL2Lrv8BjAe5lXtJFA5CSdSyhMAKPu3fIJdaJCLc4NhdbXj3hEiVugr5D699f1QkpaQ8wTg==",
+            "version": "4.16.1",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.16.1.tgz",
+            "integrity": "sha512-A9obwC7IBg4NAmxUfTVfYEd8Xg6Px+o85JRprS3UJZt+GYYzIOmEecnFwTe3rl+aiHDewBk/8fnIVrSjR/fNGQ==",
             "requires": {
-                "cookie": "^0.7.0",
-                "long": "^4.0.0",
-                "undici": "^5.29.0"
+                "@azure/functions-extensions-base": "0.3.0",
+                "cookie": "^0.7.0"
             }
         },
-        "@fastify/busboy": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
+        "@azure/functions-extensions-base": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.3.0.tgz",
+            "integrity": "sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA=="
         },
         "@types/luxon": {
             "version": "3.2.0",
@@ -609,7 +590,7 @@
         "durable-functions": {
             "version": "file:..",
             "requires": {
-                "@azure/functions": "4.8.2",
+                "@azure/functions": "^4.14.0",
                 "@opentelemetry/api": "^1.9.0",
                 "@types/chai": "~4.1.6",
                 "@types/chai-as-promised": "~7.1.0",
@@ -759,11 +740,6 @@
                 "debug": "4"
             }
         },
-        "long": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-        },
         "luxon": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
@@ -815,14 +791,6 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
             "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
             "dev": true
-        },
-        "undici": {
-            "version": "5.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-            "requires": {
-                "@fastify/busboy": "^2.0.0"
-            }
         }
     }
 }

--- a/samples-ts/package-lock.json
+++ b/samples-ts/package-lock.json
@@ -8,8 +8,8 @@
             "name": "samples-ts",
             "version": "1.0.0",
             "dependencies": {
-                "@azure/functions": "^4.14.0",
-                "axios": "^1.16.1",
+                "@azure/functions": "^4.8.2",
+                "axios": "^1.17.0",
                 "durable-functions": "file:../durable-functions",
                 "luxon": "^3.2.1",
                 "readdirp": "^3.6.0"
@@ -22,25 +22,26 @@
         },
         "../durable-functions": {},
         "node_modules/@azure/functions": {
-            "version": "4.14.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
-            "integrity": "sha512-13LsitEHNe09qmpEf6eX1ajyI9Cn9syJ8p3ord40h9+08Qk72Yg8X7FNkrgvidJqr9bPwCkcRup2yyIq1mSa6w==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.2.tgz",
+            "integrity": "sha512-MrIvgseTdfMX7uZRL2Lrv8BjAe5lXtJFA5CSdSyhMAKPu3fIJdaJCLc4NhdbXj3hEiVugr5D699f1QkpaQ8wTg==",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions-extensions-base": "0.2.0",
-                "cookie": "^0.7.0"
+                "cookie": "^0.7.0",
+                "long": "^4.0.0",
+                "undici": "^5.29.0"
             },
             "engines": {
-                "node": ">=20.0"
+                "node": ">=18.0"
             }
         },
-        "node_modules/@azure/functions-extensions-base": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
-            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ==",
+        "node_modules/@fastify/busboy": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
             "license": "MIT",
             "engines": {
-                "node": ">=18.0"
+                "node": ">=14"
             }
         },
         "node_modules/@types/luxon": {
@@ -76,9 +77,9 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.16.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-            "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+            "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.16.0",
@@ -356,6 +357,12 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/long": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+            "license": "Apache-2.0"
+        },
         "node_modules/luxon": {
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
@@ -447,22 +454,35 @@
             "engines": {
                 "node": ">=4.2.0"
             }
+        },
+        "node_modules/undici": {
+            "version": "5.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+            "license": "MIT",
+            "dependencies": {
+                "@fastify/busboy": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.0"
+            }
         }
     },
     "dependencies": {
         "@azure/functions": {
-            "version": "4.14.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
-            "integrity": "sha512-13LsitEHNe09qmpEf6eX1ajyI9Cn9syJ8p3ord40h9+08Qk72Yg8X7FNkrgvidJqr9bPwCkcRup2yyIq1mSa6w==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.2.tgz",
+            "integrity": "sha512-MrIvgseTdfMX7uZRL2Lrv8BjAe5lXtJFA5CSdSyhMAKPu3fIJdaJCLc4NhdbXj3hEiVugr5D699f1QkpaQ8wTg==",
             "requires": {
-                "@azure/functions-extensions-base": "0.2.0",
-                "cookie": "^0.7.0"
+                "cookie": "^0.7.0",
+                "long": "^4.0.0",
+                "undici": "^5.29.0"
             }
         },
-        "@azure/functions-extensions-base": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
-            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ=="
+        "@fastify/busboy": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
         },
         "@types/luxon": {
             "version": "3.7.1",
@@ -490,9 +510,9 @@
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
         "axios": {
-            "version": "1.16.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-            "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+            "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
             "requires": {
                 "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",
@@ -660,6 +680,11 @@
                 "debug": "4"
             }
         },
+        "long": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+        },
         "luxon": {
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
@@ -711,6 +736,14 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
             "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true
+        },
+        "undici": {
+            "version": "5.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+            "requires": {
+                "@fastify/busboy": "^2.0.0"
+            }
         }
     }
 }

--- a/samples-ts/package.json
+++ b/samples-ts/package.json
@@ -16,8 +16,8 @@
         "typescript": "^4.0.0"
     },
     "dependencies": {
-        "@azure/functions": "^4.14.0",
-        "axios": "^1.16.1",
+        "@azure/functions": "^4.8.2",
+        "axios": "^1.17.0",
         "durable-functions": "file:../durable-functions",
         "luxon": "^3.2.1",
         "readdirp": "^3.6.0"

--- a/samples-ts/package.json
+++ b/samples-ts/package.json
@@ -16,8 +16,8 @@
         "typescript": "^4.0.0"
     },
     "dependencies": {
-        "@azure/functions": "^4.0.0",
-        "axios": "^1.12.0",
+        "@azure/functions": "^4.14.0",
+        "axios": "^1.16.1",
         "durable-functions": "file:../durable-functions",
         "luxon": "^3.2.1",
         "readdirp": "^3.6.0"

--- a/samples-ts/package.json
+++ b/samples-ts/package.json
@@ -16,7 +16,7 @@
         "typescript": "^4.0.0"
     },
     "dependencies": {
-        "@azure/functions": "^4.14.0",
+        "@azure/functions": "^4.16.1",
         "axios": "^1.18.0",
         "durable-functions": "file:..",
         "luxon": "^3.2.1",

--- a/samples-ts/package.json
+++ b/samples-ts/package.json
@@ -18,7 +18,7 @@
     "dependencies": {
         "@azure/functions": "^4.14.0",
         "axios": "^1.18.0",
-        "durable-functions": "file:../durable-functions",
+        "durable-functions": "file:..",
         "luxon": "^3.2.1",
         "readdirp": "^3.6.0"
     }

--- a/samples-ts/package.json
+++ b/samples-ts/package.json
@@ -17,7 +17,7 @@
     },
     "dependencies": {
         "@azure/functions": "^4.14.0",
-        "axios": "1.17.0",
+        "axios": "1.18.0",
         "durable-functions": "file:..",
         "luxon": "^3.2.1",
         "readdirp": "^3.6.0"

--- a/samples-ts/package.json
+++ b/samples-ts/package.json
@@ -16,7 +16,7 @@
         "typescript": "^4.0.0"
     },
     "dependencies": {
-        "@azure/functions": "4.8.2",
+        "@azure/functions": "^4.14.0",
         "axios": "1.17.0",
         "durable-functions": "file:..",
         "luxon": "^3.2.1",

--- a/samples-ts/package.json
+++ b/samples-ts/package.json
@@ -17,7 +17,7 @@
     },
     "dependencies": {
         "@azure/functions": "4.8.2",
-        "axios": "^1.18.0",
+        "axios": "1.17.0",
         "durable-functions": "file:..",
         "luxon": "^3.2.1",
         "readdirp": "^3.6.0"

--- a/samples-ts/package.json
+++ b/samples-ts/package.json
@@ -16,7 +16,7 @@
         "typescript": "^4.0.0"
     },
     "dependencies": {
-        "@azure/functions": "^4.8.2",
+        "@azure/functions": "^4.14.0",
         "axios": "^1.17.0",
         "durable-functions": "file:../durable-functions",
         "luxon": "^3.2.1",

--- a/samples-ts/package.json
+++ b/samples-ts/package.json
@@ -16,7 +16,7 @@
         "typescript": "^4.0.0"
     },
     "dependencies": {
-        "@azure/functions": "^4.16.1",
+        "@azure/functions": "4.8.2",
         "axios": "^1.18.0",
         "durable-functions": "file:..",
         "luxon": "^3.2.1",

--- a/samples-ts/package.json
+++ b/samples-ts/package.json
@@ -17,7 +17,7 @@
     },
     "dependencies": {
         "@azure/functions": "^4.14.0",
-        "axios": "^1.17.0",
+        "axios": "^1.18.0",
         "durable-functions": "file:../durable-functions",
         "luxon": "^3.2.1",
         "readdirp": "^3.6.0"

--- a/test/test-app/package-lock.json
+++ b/test/test-app/package-lock.json
@@ -8,7 +8,7 @@
             "name": "test-app",
             "version": "1.0.0",
             "dependencies": {
-                "@azure/functions": "4.8.2",
+                "@azure/functions": "^4.14.0",
                 "durable-functions": "file:../.."
             },
             "devDependencies": {
@@ -21,9 +21,9 @@
             "version": "3.4.0",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions": "4.8.2",
+                "@azure/functions": "^4.14.0",
                 "@opentelemetry/api": "^1.9.0",
-                "axios": "^1.18.0",
+                "axios": "1.17.0",
                 "debug": "~2.6.9",
                 "lodash": "^4.18.1",
                 "moment": "^2.29.2",
@@ -65,25 +65,25 @@
             }
         },
         "node_modules/@azure/functions": {
-            "version": "4.8.2",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.2.tgz",
-            "integrity": "sha512-MrIvgseTdfMX7uZRL2Lrv8BjAe5lXtJFA5CSdSyhMAKPu3fIJdaJCLc4NhdbXj3hEiVugr5D699f1QkpaQ8wTg==",
+            "version": "4.16.1",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.16.1.tgz",
+            "integrity": "sha512-A9obwC7IBg4NAmxUfTVfYEd8Xg6Px+o85JRprS3UJZt+GYYzIOmEecnFwTe3rl+aiHDewBk/8fnIVrSjR/fNGQ==",
             "license": "MIT",
             "dependencies": {
-                "cookie": "^0.7.0",
-                "long": "^4.0.0",
-                "undici": "^5.29.0"
+                "@azure/functions-extensions-base": "0.3.0",
+                "cookie": "^0.7.0"
             },
             "engines": {
-                "node": ">=18.0"
+                "node": ">=20.0"
             }
         },
-        "node_modules/@fastify/busboy": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
-            "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
+        "node_modules/@azure/functions-extensions-base": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.3.0.tgz",
+            "integrity": "sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA==",
+            "license": "MIT",
             "engines": {
-                "node": ">=14"
+                "node": ">=18.0"
             }
         },
         "node_modules/@types/node": {
@@ -105,11 +105,6 @@
             "resolved": "../..",
             "link": true
         },
-        "node_modules/long": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-        },
         "node_modules/typescript": {
             "version": "4.9.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -122,35 +117,22 @@
             "engines": {
                 "node": ">=4.2.0"
             }
-        },
-        "node_modules/undici": {
-            "version": "5.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-            "license": "MIT",
-            "dependencies": {
-                "@fastify/busboy": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.0"
-            }
         }
     },
     "dependencies": {
         "@azure/functions": {
-            "version": "4.8.2",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.2.tgz",
-            "integrity": "sha512-MrIvgseTdfMX7uZRL2Lrv8BjAe5lXtJFA5CSdSyhMAKPu3fIJdaJCLc4NhdbXj3hEiVugr5D699f1QkpaQ8wTg==",
+            "version": "4.16.1",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.16.1.tgz",
+            "integrity": "sha512-A9obwC7IBg4NAmxUfTVfYEd8Xg6Px+o85JRprS3UJZt+GYYzIOmEecnFwTe3rl+aiHDewBk/8fnIVrSjR/fNGQ==",
             "requires": {
-                "cookie": "^0.7.0",
-                "long": "^4.0.0",
-                "undici": "^5.29.0"
+                "@azure/functions-extensions-base": "0.3.0",
+                "cookie": "^0.7.0"
             }
         },
-        "@fastify/busboy": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
-            "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ=="
+        "@azure/functions-extensions-base": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.3.0.tgz",
+            "integrity": "sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA=="
         },
         "@types/node": {
             "version": "18.15.3",
@@ -166,7 +148,7 @@
         "durable-functions": {
             "version": "file:../..",
             "requires": {
-                "@azure/functions": "4.8.2",
+                "@azure/functions": "^4.14.0",
                 "@opentelemetry/api": "^1.9.0",
                 "@types/chai": "~4.1.6",
                 "@types/chai-as-promised": "~7.1.0",
@@ -182,7 +164,7 @@
                 "@types/validator": "^9.4.3",
                 "@typescript-eslint/eslint-plugin": "^5.4.0",
                 "@typescript-eslint/parser": "^5.4.0",
-                "axios": "^1.18.0",
+                "axios": "1.17.0",
                 "chai": "~4.2.0",
                 "chai-as-promised": "~7.1.1",
                 "chai-string": "~1.5.0",
@@ -204,24 +186,11 @@
                 "validator": "~13.15.20"
             }
         },
-        "long": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-        },
         "typescript": {
             "version": "4.9.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
             "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true
-        },
-        "undici": {
-            "version": "5.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-            "requires": {
-                "@fastify/busboy": "^2.0.0"
-            }
         }
     }
 }

--- a/test/test-app/package-lock.json
+++ b/test/test-app/package-lock.json
@@ -18,7 +18,7 @@
         },
         "../..": {
             "name": "durable-functions",
-            "version": "3.3.1",
+            "version": "3.4.0",
             "license": "MIT",
             "dependencies": {
                 "@azure/functions": "4.8.2",
@@ -27,8 +27,8 @@
                 "debug": "~2.6.9",
                 "lodash": "^4.18.1",
                 "moment": "^2.29.2",
-                "uuid": "^10.0.0",
-                "validator": "~13.15.35"
+                "uuid": "^9.0.1",
+                "validator": "~13.15.20"
             },
             "devDependencies": {
                 "@types/chai": "~4.1.6",
@@ -48,7 +48,7 @@
                 "chai": "~4.2.0",
                 "chai-as-promised": "~7.1.1",
                 "chai-string": "~1.5.0",
-                "eslint": "^7.32.0",
+                "eslint": "^8.57.1",
                 "eslint-config-prettier": "^6.15.0",
                 "eslint-plugin-prettier": "^3.4.1",
                 "mocha": "^11.2.2",
@@ -187,7 +187,7 @@
                 "chai-as-promised": "~7.1.1",
                 "chai-string": "~1.5.0",
                 "debug": "~2.6.9",
-                "eslint": "^7.32.0",
+                "eslint": "^8.57.1",
                 "eslint-config-prettier": "^6.15.0",
                 "eslint-plugin-prettier": "^3.4.1",
                 "lodash": "^4.18.1",
@@ -200,8 +200,8 @@
                 "ts-node": "^10.0.0",
                 "typedoc": "^0.22.11",
                 "typescript": "~4.5.0",
-                "uuid": "^10.0.0",
-                "validator": "~13.15.35"
+                "uuid": "^9.0.1",
+                "validator": "~13.15.20"
             }
         },
         "long": {

--- a/test/test-app/package-lock.json
+++ b/test/test-app/package-lock.json
@@ -9,14 +9,61 @@
             "version": "1.0.0",
             "dependencies": {
                 "@azure/functions": "^4.14.0",
-                "durable-functions": "file:../../durable-functions"
+                "durable-functions": "file:../.."
             },
             "devDependencies": {
                 "@types/node": "^18.x",
                 "typescript": "^4.7.2"
             }
         },
-        "../../durable-functions": {},
+        "../..": {
+            "name": "durable-functions",
+            "version": "3.3.1",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/functions": "^4.14.0",
+                "@opentelemetry/api": "^1.9.0",
+                "axios": "^1.18.0",
+                "debug": "~2.6.9",
+                "lodash": "^4.18.1",
+                "moment": "^2.29.2",
+                "uuid": "^11.1.1",
+                "validator": "~13.15.20"
+            },
+            "devDependencies": {
+                "@types/chai": "~4.1.6",
+                "@types/chai-as-promised": "~7.1.0",
+                "@types/chai-string": "~1.4.1",
+                "@types/debug": "0.0.29",
+                "@types/lodash": "^4.14.119",
+                "@types/mocha": "^7.0.2",
+                "@types/nock": "^9.3.0",
+                "@types/node": "^18.0.0",
+                "@types/rimraf": "0.0.28",
+                "@types/sinon": "~5.0.5",
+                "@types/uuid": "^9.0.7",
+                "@types/validator": "^9.4.3",
+                "@typescript-eslint/eslint-plugin": "^5.4.0",
+                "@typescript-eslint/parser": "^5.4.0",
+                "chai": "~4.2.0",
+                "chai-as-promised": "~7.1.1",
+                "chai-string": "~1.5.0",
+                "eslint": "^7.32.0",
+                "eslint-config-prettier": "^6.15.0",
+                "eslint-plugin-prettier": "^3.4.1",
+                "mocha": "^11.2.2",
+                "nock": "^10.0.6",
+                "prettier": "^2.0.5",
+                "rimraf": "~2.5.4",
+                "sinon": "~7.1.1",
+                "ts-node": "^10.0.0",
+                "typedoc": "^0.22.11",
+                "typescript": "~4.5.0"
+            },
+            "engines": {
+                "node": ">=18.0"
+            }
+        },
         "node_modules/@azure/functions": {
             "version": "4.14.0",
             "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
@@ -59,7 +106,7 @@
             }
         },
         "node_modules/durable-functions": {
-            "resolved": "../../durable-functions",
+            "resolved": "../..",
             "link": true
         },
         "node_modules/typescript": {
@@ -114,7 +161,45 @@
             "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
         },
         "durable-functions": {
-            "version": "file:../../durable-functions"
+            "version": "file:../..",
+            "requires": {
+                "@azure/functions": "^4.14.0",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/chai": "~4.1.6",
+                "@types/chai-as-promised": "~7.1.0",
+                "@types/chai-string": "~1.4.1",
+                "@types/debug": "0.0.29",
+                "@types/lodash": "^4.14.119",
+                "@types/mocha": "^7.0.2",
+                "@types/nock": "^9.3.0",
+                "@types/node": "^18.0.0",
+                "@types/rimraf": "0.0.28",
+                "@types/sinon": "~5.0.5",
+                "@types/uuid": "^9.0.7",
+                "@types/validator": "^9.4.3",
+                "@typescript-eslint/eslint-plugin": "^5.4.0",
+                "@typescript-eslint/parser": "^5.4.0",
+                "axios": "^1.18.0",
+                "chai": "~4.2.0",
+                "chai-as-promised": "~7.1.1",
+                "chai-string": "~1.5.0",
+                "debug": "~2.6.9",
+                "eslint": "^7.32.0",
+                "eslint-config-prettier": "^6.15.0",
+                "eslint-plugin-prettier": "^3.4.1",
+                "lodash": "^4.18.1",
+                "mocha": "^11.2.2",
+                "moment": "^2.29.2",
+                "nock": "^10.0.6",
+                "prettier": "^2.0.5",
+                "rimraf": "~2.5.4",
+                "sinon": "~7.1.1",
+                "ts-node": "^10.0.0",
+                "typedoc": "^0.22.11",
+                "typescript": "~4.5.0",
+                "uuid": "^11.1.1",
+                "validator": "~13.15.20"
+            }
         },
         "typescript": {
             "version": "4.9.5",

--- a/test/test-app/package-lock.json
+++ b/test/test-app/package-lock.json
@@ -8,7 +8,7 @@
             "name": "test-app",
             "version": "1.0.0",
             "dependencies": {
-                "@azure/functions": "^4.16.1",
+                "@azure/functions": "4.8.2",
                 "durable-functions": "file:../.."
             },
             "devDependencies": {
@@ -21,7 +21,7 @@
             "version": "3.3.1",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions": "^4.16.1",
+                "@azure/functions": "4.8.2",
                 "@opentelemetry/api": "^1.9.0",
                 "axios": "^1.18.0",
                 "debug": "~2.6.9",
@@ -65,36 +65,32 @@
             }
         },
         "node_modules/@azure/functions": {
-            "version": "4.16.1",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.16.1.tgz",
-            "integrity": "sha512-A9obwC7IBg4NAmxUfTVfYEd8Xg6Px+o85JRprS3UJZt+GYYzIOmEecnFwTe3rl+aiHDewBk/8fnIVrSjR/fNGQ==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.2.tgz",
+            "integrity": "sha512-MrIvgseTdfMX7uZRL2Lrv8BjAe5lXtJFA5CSdSyhMAKPu3fIJdaJCLc4NhdbXj3hEiVugr5D699f1QkpaQ8wTg==",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions-extensions-base": "0.3.0",
-                "cookie": "^0.7.0"
+                "cookie": "^0.7.0",
+                "long": "^4.0.0",
+                "undici": "^5.29.0"
             },
-            "engines": {
-                "node": ">=20.0"
-            }
-        },
-        "node_modules/@azure/functions-extensions-base": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.3.0.tgz",
-            "integrity": "sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA==",
-            "license": "MIT",
             "engines": {
                 "node": ">=18.0"
             }
         },
-        "node_modules/@types/node": {
-            "version": "18.19.130",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-            "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "undici-types": "~5.26.4"
+        "node_modules/@fastify/busboy": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
+            "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
+            "engines": {
+                "node": ">=14"
             }
+        },
+        "node_modules/@types/node": {
+            "version": "18.15.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.3.tgz",
+            "integrity": "sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw==",
+            "dev": true
         },
         "node_modules/cookie": {
             "version": "0.7.2",
@@ -109,12 +105,16 @@
             "resolved": "../..",
             "link": true
         },
+        "node_modules/long": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+        },
         "node_modules/typescript": {
             "version": "4.9.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
             "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true,
-            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -123,37 +123,40 @@
                 "node": ">=4.2.0"
             }
         },
-        "node_modules/undici-types": {
-            "version": "5.26.5",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-            "dev": true,
-            "license": "MIT"
+        "node_modules/undici": {
+            "version": "5.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+            "license": "MIT",
+            "dependencies": {
+                "@fastify/busboy": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.0"
+            }
         }
     },
     "dependencies": {
         "@azure/functions": {
-            "version": "4.16.1",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.16.1.tgz",
-            "integrity": "sha512-A9obwC7IBg4NAmxUfTVfYEd8Xg6Px+o85JRprS3UJZt+GYYzIOmEecnFwTe3rl+aiHDewBk/8fnIVrSjR/fNGQ==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.2.tgz",
+            "integrity": "sha512-MrIvgseTdfMX7uZRL2Lrv8BjAe5lXtJFA5CSdSyhMAKPu3fIJdaJCLc4NhdbXj3hEiVugr5D699f1QkpaQ8wTg==",
             "requires": {
-                "@azure/functions-extensions-base": "0.3.0",
-                "cookie": "^0.7.0"
+                "cookie": "^0.7.0",
+                "long": "^4.0.0",
+                "undici": "^5.29.0"
             }
         },
-        "@azure/functions-extensions-base": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.3.0.tgz",
-            "integrity": "sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA=="
+        "@fastify/busboy": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
+            "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ=="
         },
         "@types/node": {
-            "version": "18.19.130",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-            "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-            "dev": true,
-            "requires": {
-                "undici-types": "~5.26.4"
-            }
+            "version": "18.15.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.3.tgz",
+            "integrity": "sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw==",
+            "dev": true
         },
         "cookie": {
             "version": "0.7.2",
@@ -163,7 +166,7 @@
         "durable-functions": {
             "version": "file:../..",
             "requires": {
-                "@azure/functions": "^4.16.1",
+                "@azure/functions": "4.8.2",
                 "@opentelemetry/api": "^1.9.0",
                 "@types/chai": "~4.1.6",
                 "@types/chai-as-promised": "~7.1.0",
@@ -201,17 +204,24 @@
                 "validator": "~13.15.35"
             }
         },
+        "long": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+        },
         "typescript": {
             "version": "4.9.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
             "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true
         },
-        "undici-types": {
-            "version": "5.26.5",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-            "dev": true
+        "undici": {
+            "version": "5.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+            "requires": {
+                "@fastify/busboy": "^2.0.0"
+            }
         }
     }
 }

--- a/test/test-app/package-lock.json
+++ b/test/test-app/package-lock.json
@@ -8,7 +8,7 @@
             "name": "test-app",
             "version": "1.0.0",
             "dependencies": {
-                "@azure/functions": "^4.8.2",
+                "@azure/functions": "^4.14.0",
                 "durable-functions": "file:../../durable-functions"
             },
             "devDependencies": {
@@ -18,26 +18,25 @@
         },
         "../../durable-functions": {},
         "node_modules/@azure/functions": {
-            "version": "4.8.2",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.2.tgz",
-            "integrity": "sha512-MrIvgseTdfMX7uZRL2Lrv8BjAe5lXtJFA5CSdSyhMAKPu3fIJdaJCLc4NhdbXj3hEiVugr5D699f1QkpaQ8wTg==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
+            "integrity": "sha512-13LsitEHNe09qmpEf6eX1ajyI9Cn9syJ8p3ord40h9+08Qk72Yg8X7FNkrgvidJqr9bPwCkcRup2yyIq1mSa6w==",
             "license": "MIT",
             "dependencies": {
-                "cookie": "^0.7.0",
-                "long": "^4.0.0",
-                "undici": "^5.29.0"
+                "@azure/functions-extensions-base": "0.2.0",
+                "cookie": "^0.7.0"
             },
             "engines": {
-                "node": ">=18.0"
+                "node": ">=20.0"
             }
         },
-        "node_modules/@fastify/busboy": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+        "node_modules/@azure/functions-extensions-base": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
+            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ==",
             "license": "MIT",
             "engines": {
-                "node": ">=14"
+                "node": ">=18.0"
             }
         },
         "node_modules/@types/node": {
@@ -63,12 +62,6 @@
             "resolved": "../../durable-functions",
             "link": true
         },
-        "node_modules/long": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-            "license": "Apache-2.0"
-        },
         "node_modules/typescript": {
             "version": "4.9.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -83,18 +76,6 @@
                 "node": ">=4.2.0"
             }
         },
-        "node_modules/undici": {
-            "version": "5.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-            "license": "MIT",
-            "dependencies": {
-                "@fastify/busboy": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.0"
-            }
-        },
         "node_modules/undici-types": {
             "version": "5.26.5",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -105,19 +86,18 @@
     },
     "dependencies": {
         "@azure/functions": {
-            "version": "4.8.2",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.2.tgz",
-            "integrity": "sha512-MrIvgseTdfMX7uZRL2Lrv8BjAe5lXtJFA5CSdSyhMAKPu3fIJdaJCLc4NhdbXj3hEiVugr5D699f1QkpaQ8wTg==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
+            "integrity": "sha512-13LsitEHNe09qmpEf6eX1ajyI9Cn9syJ8p3ord40h9+08Qk72Yg8X7FNkrgvidJqr9bPwCkcRup2yyIq1mSa6w==",
             "requires": {
-                "cookie": "^0.7.0",
-                "long": "^4.0.0",
-                "undici": "^5.29.0"
+                "@azure/functions-extensions-base": "0.2.0",
+                "cookie": "^0.7.0"
             }
         },
-        "@fastify/busboy": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
+        "@azure/functions-extensions-base": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
+            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ=="
         },
         "@types/node": {
             "version": "18.19.130",
@@ -136,24 +116,11 @@
         "durable-functions": {
             "version": "file:../../durable-functions"
         },
-        "long": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-        },
         "typescript": {
             "version": "4.9.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
             "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true
-        },
-        "undici": {
-            "version": "5.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-            "requires": {
-                "@fastify/busboy": "^2.0.0"
-            }
         },
         "undici-types": {
             "version": "5.26.5",

--- a/test/test-app/package-lock.json
+++ b/test/test-app/package-lock.json
@@ -8,7 +8,7 @@
             "name": "test-app",
             "version": "1.0.0",
             "dependencies": {
-                "@azure/functions": "^4.14.0",
+                "@azure/functions": "^4.16.1",
                 "durable-functions": "file:../.."
             },
             "devDependencies": {
@@ -21,14 +21,14 @@
             "version": "3.3.1",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions": "^4.14.0",
+                "@azure/functions": "^4.16.1",
                 "@opentelemetry/api": "^1.9.0",
                 "axios": "^1.18.0",
                 "debug": "~2.6.9",
                 "lodash": "^4.18.1",
                 "moment": "^2.29.2",
                 "uuid": "^11.1.1",
-                "validator": "~13.15.20"
+                "validator": "~13.15.35"
             },
             "devDependencies": {
                 "@types/chai": "~4.1.6",
@@ -65,12 +65,12 @@
             }
         },
         "node_modules/@azure/functions": {
-            "version": "4.14.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
-            "integrity": "sha512-13LsitEHNe09qmpEf6eX1ajyI9Cn9syJ8p3ord40h9+08Qk72Yg8X7FNkrgvidJqr9bPwCkcRup2yyIq1mSa6w==",
+            "version": "4.16.1",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.16.1.tgz",
+            "integrity": "sha512-A9obwC7IBg4NAmxUfTVfYEd8Xg6Px+o85JRprS3UJZt+GYYzIOmEecnFwTe3rl+aiHDewBk/8fnIVrSjR/fNGQ==",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions-extensions-base": "0.2.0",
+                "@azure/functions-extensions-base": "0.3.0",
                 "cookie": "^0.7.0"
             },
             "engines": {
@@ -78,9 +78,9 @@
             }
         },
         "node_modules/@azure/functions-extensions-base": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
-            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.3.0.tgz",
+            "integrity": "sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.0"
@@ -133,18 +133,18 @@
     },
     "dependencies": {
         "@azure/functions": {
-            "version": "4.14.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
-            "integrity": "sha512-13LsitEHNe09qmpEf6eX1ajyI9Cn9syJ8p3ord40h9+08Qk72Yg8X7FNkrgvidJqr9bPwCkcRup2yyIq1mSa6w==",
+            "version": "4.16.1",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.16.1.tgz",
+            "integrity": "sha512-A9obwC7IBg4NAmxUfTVfYEd8Xg6Px+o85JRprS3UJZt+GYYzIOmEecnFwTe3rl+aiHDewBk/8fnIVrSjR/fNGQ==",
             "requires": {
-                "@azure/functions-extensions-base": "0.2.0",
+                "@azure/functions-extensions-base": "0.3.0",
                 "cookie": "^0.7.0"
             }
         },
         "@azure/functions-extensions-base": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
-            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ=="
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.3.0.tgz",
+            "integrity": "sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA=="
         },
         "@types/node": {
             "version": "18.19.130",
@@ -163,7 +163,7 @@
         "durable-functions": {
             "version": "file:../..",
             "requires": {
-                "@azure/functions": "^4.14.0",
+                "@azure/functions": "^4.16.1",
                 "@opentelemetry/api": "^1.9.0",
                 "@types/chai": "~4.1.6",
                 "@types/chai-as-promised": "~7.1.0",
@@ -198,7 +198,7 @@
                 "typedoc": "^0.22.11",
                 "typescript": "~4.5.0",
                 "uuid": "^11.1.1",
-                "validator": "~13.15.20"
+                "validator": "~13.15.35"
             }
         },
         "typescript": {

--- a/test/test-app/package-lock.json
+++ b/test/test-app/package-lock.json
@@ -87,10 +87,14 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "18.15.3",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.3.tgz",
-            "integrity": "sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw==",
-            "dev": true
+            "version": "18.19.130",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+            "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
         },
         "node_modules/cookie": {
             "version": "0.7.2",
@@ -110,6 +114,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
             "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -117,6 +122,13 @@
             "engines": {
                 "node": ">=4.2.0"
             }
+        },
+        "node_modules/undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "dev": true,
+            "license": "MIT"
         }
     },
     "dependencies": {
@@ -135,10 +147,13 @@
             "integrity": "sha512-Cux0hLu5ZXlC/Kb+yvJVhRLIdkfFwui2HeT5oGZL00r/GCUUkhGTzRfZUjRN4Bq729mPv3okPucz2z7SMQLStA=="
         },
         "@types/node": {
-            "version": "18.15.3",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.3.tgz",
-            "integrity": "sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw==",
-            "dev": true
+            "version": "18.19.130",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+            "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+            "dev": true,
+            "requires": {
+                "undici-types": "~5.26.4"
+            }
         },
         "cookie": {
             "version": "0.7.2",
@@ -190,6 +205,12 @@
             "version": "4.9.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
             "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "dev": true
+        },
+        "undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
             "dev": true
         }
     }

--- a/test/test-app/package-lock.json
+++ b/test/test-app/package-lock.json
@@ -27,7 +27,7 @@
                 "debug": "~2.6.9",
                 "lodash": "^4.18.1",
                 "moment": "^2.29.2",
-                "uuid": "^11.1.1",
+                "uuid": "^10.0.0",
                 "validator": "~13.15.35"
             },
             "devDependencies": {
@@ -200,7 +200,7 @@
                 "ts-node": "^10.0.0",
                 "typedoc": "^0.22.11",
                 "typescript": "~4.5.0",
-                "uuid": "^11.1.1",
+                "uuid": "^10.0.0",
                 "validator": "~13.15.35"
             }
         },

--- a/test/test-app/package-lock.json
+++ b/test/test-app/package-lock.json
@@ -8,7 +8,7 @@
             "name": "test-app",
             "version": "1.0.0",
             "dependencies": {
-                "@azure/functions": "^4.14.0",
+                "@azure/functions": "^4.8.2",
                 "durable-functions": "file:../../durable-functions"
             },
             "devDependencies": {
@@ -18,25 +18,26 @@
         },
         "../../durable-functions": {},
         "node_modules/@azure/functions": {
-            "version": "4.14.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
-            "integrity": "sha512-13LsitEHNe09qmpEf6eX1ajyI9Cn9syJ8p3ord40h9+08Qk72Yg8X7FNkrgvidJqr9bPwCkcRup2yyIq1mSa6w==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.2.tgz",
+            "integrity": "sha512-MrIvgseTdfMX7uZRL2Lrv8BjAe5lXtJFA5CSdSyhMAKPu3fIJdaJCLc4NhdbXj3hEiVugr5D699f1QkpaQ8wTg==",
             "license": "MIT",
             "dependencies": {
-                "@azure/functions-extensions-base": "0.2.0",
-                "cookie": "^0.7.0"
+                "cookie": "^0.7.0",
+                "long": "^4.0.0",
+                "undici": "^5.29.0"
             },
             "engines": {
-                "node": ">=20.0"
+                "node": ">=18.0"
             }
         },
-        "node_modules/@azure/functions-extensions-base": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
-            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ==",
+        "node_modules/@fastify/busboy": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
             "license": "MIT",
             "engines": {
-                "node": ">=18.0"
+                "node": ">=14"
             }
         },
         "node_modules/@types/node": {
@@ -62,6 +63,12 @@
             "resolved": "../../durable-functions",
             "link": true
         },
+        "node_modules/long": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+            "license": "Apache-2.0"
+        },
         "node_modules/typescript": {
             "version": "4.9.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -76,6 +83,18 @@
                 "node": ">=4.2.0"
             }
         },
+        "node_modules/undici": {
+            "version": "5.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+            "license": "MIT",
+            "dependencies": {
+                "@fastify/busboy": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.0"
+            }
+        },
         "node_modules/undici-types": {
             "version": "5.26.5",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -86,18 +105,19 @@
     },
     "dependencies": {
         "@azure/functions": {
-            "version": "4.14.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
-            "integrity": "sha512-13LsitEHNe09qmpEf6eX1ajyI9Cn9syJ8p3ord40h9+08Qk72Yg8X7FNkrgvidJqr9bPwCkcRup2yyIq1mSa6w==",
+            "version": "4.8.2",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.2.tgz",
+            "integrity": "sha512-MrIvgseTdfMX7uZRL2Lrv8BjAe5lXtJFA5CSdSyhMAKPu3fIJdaJCLc4NhdbXj3hEiVugr5D699f1QkpaQ8wTg==",
             "requires": {
-                "@azure/functions-extensions-base": "0.2.0",
-                "cookie": "^0.7.0"
+                "cookie": "^0.7.0",
+                "long": "^4.0.0",
+                "undici": "^5.29.0"
             }
         },
-        "@azure/functions-extensions-base": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
-            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ=="
+        "@fastify/busboy": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
         },
         "@types/node": {
             "version": "18.19.130",
@@ -116,11 +136,24 @@
         "durable-functions": {
             "version": "file:../../durable-functions"
         },
+        "long": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+        },
         "typescript": {
             "version": "4.9.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
             "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true
+        },
+        "undici": {
+            "version": "5.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+            "requires": {
+                "@fastify/busboy": "^2.0.0"
+            }
         },
         "undici-types": {
             "version": "5.26.5",

--- a/test/test-app/package-lock.json
+++ b/test/test-app/package-lock.json
@@ -23,7 +23,7 @@
             "dependencies": {
                 "@azure/functions": "^4.14.0",
                 "@opentelemetry/api": "^1.9.0",
-                "axios": "1.17.0",
+                "axios": "1.18.0",
                 "debug": "~2.6.9",
                 "lodash": "^4.18.1",
                 "moment": "^2.29.2",
@@ -164,7 +164,7 @@
                 "@types/validator": "^9.4.3",
                 "@typescript-eslint/eslint-plugin": "^5.4.0",
                 "@typescript-eslint/parser": "^5.4.0",
-                "axios": "1.17.0",
+                "axios": "1.18.0",
                 "chai": "~4.2.0",
                 "chai-as-promised": "~7.1.1",
                 "chai-string": "~1.5.0",

--- a/test/test-app/package-lock.json
+++ b/test/test-app/package-lock.json
@@ -8,7 +8,7 @@
             "name": "test-app",
             "version": "1.0.0",
             "dependencies": {
-                "@azure/functions": "^4.0.0-alpha.7",
+                "@azure/functions": "^4.14.0",
                 "durable-functions": "file:../../durable-functions"
             },
             "devDependencies": {
@@ -18,45 +18,56 @@
         },
         "../../durable-functions": {},
         "node_modules/@azure/functions": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.2.0.tgz",
-            "integrity": "sha512-RSECLoje4jGVpsVRjEzkna9KvmQOVeB96cg8J5J2g41QQpMWCzD1QTPI5+yI0uvOidGRLYElV1zHZjdvsGf9Nw==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
+            "integrity": "sha512-13LsitEHNe09qmpEf6eX1ajyI9Cn9syJ8p3ord40h9+08Qk72Yg8X7FNkrgvidJqr9bPwCkcRup2yyIq1mSa6w==",
+            "license": "MIT",
             "dependencies": {
-                "long": "^4.0.0",
-                "undici": "^5.13.0"
+                "@azure/functions-extensions-base": "0.2.0",
+                "cookie": "^0.7.0"
             },
+            "engines": {
+                "node": ">=20.0"
+            }
+        },
+        "node_modules/@azure/functions-extensions-base": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
+            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=18.0"
             }
         },
-        "node_modules/@fastify/busboy": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
-            "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
-            "engines": {
-                "node": ">=14"
+        "node_modules/@types/node": {
+            "version": "18.19.130",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+            "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~5.26.4"
             }
         },
-        "node_modules/@types/node": {
-            "version": "18.15.3",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.3.tgz",
-            "integrity": "sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw==",
-            "dev": true
+        "node_modules/cookie": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
         "node_modules/durable-functions": {
             "resolved": "../../durable-functions",
             "link": true
-        },
-        "node_modules/long": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
         },
         "node_modules/typescript": {
             "version": "4.9.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
             "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -65,47 +76,45 @@
                 "node": ">=4.2.0"
             }
         },
-        "node_modules/undici": {
-            "version": "5.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-            "license": "MIT",
-            "dependencies": {
-                "@fastify/busboy": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.0"
-            }
+        "node_modules/undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "dev": true,
+            "license": "MIT"
         }
     },
     "dependencies": {
         "@azure/functions": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.2.0.tgz",
-            "integrity": "sha512-RSECLoje4jGVpsVRjEzkna9KvmQOVeB96cg8J5J2g41QQpMWCzD1QTPI5+yI0uvOidGRLYElV1zHZjdvsGf9Nw==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.14.0.tgz",
+            "integrity": "sha512-13LsitEHNe09qmpEf6eX1ajyI9Cn9syJ8p3ord40h9+08Qk72Yg8X7FNkrgvidJqr9bPwCkcRup2yyIq1mSa6w==",
             "requires": {
-                "long": "^4.0.0",
-                "undici": "^5.13.0"
+                "@azure/functions-extensions-base": "0.2.0",
+                "cookie": "^0.7.0"
             }
         },
-        "@fastify/busboy": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
-            "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ=="
+        "@azure/functions-extensions-base": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@azure/functions-extensions-base/-/functions-extensions-base-0.2.0.tgz",
+            "integrity": "sha512-ncCkHBNQYJa93dBIh+toH0v1iSgCzSo9tr94s6SMBe7DPWREkaWh8cq33A5P4rPSFX1g5W+3SPvIzDr/6/VOWQ=="
         },
         "@types/node": {
-            "version": "18.15.3",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.3.tgz",
-            "integrity": "sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw==",
-            "dev": true
+            "version": "18.19.130",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+            "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+            "dev": true,
+            "requires": {
+                "undici-types": "~5.26.4"
+            }
+        },
+        "cookie": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
         },
         "durable-functions": {
             "version": "file:../../durable-functions"
-        },
-        "long": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
         },
         "typescript": {
             "version": "4.9.5",
@@ -113,13 +122,11 @@
             "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true
         },
-        "undici": {
-            "version": "5.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-            "requires": {
-                "@fastify/busboy": "^2.0.0"
-            }
+        "undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "dev": true
         }
     }
 }

--- a/test/test-app/package.json
+++ b/test/test-app/package.json
@@ -10,7 +10,7 @@
         "test": "echo \"No tests yet...\""
     },
     "dependencies": {
-        "@azure/functions": "^4.0.0-alpha.7",
+        "@azure/functions": "^4.14.0",
         "durable-functions": "file:../../durable-functions"
     },
     "devDependencies": {

--- a/test/test-app/package.json
+++ b/test/test-app/package.json
@@ -10,7 +10,7 @@
         "test": "echo \"No tests yet...\""
     },
     "dependencies": {
-        "@azure/functions": "^4.14.0",
+        "@azure/functions": "^4.8.2",
         "durable-functions": "file:../../durable-functions"
     },
     "devDependencies": {

--- a/test/test-app/package.json
+++ b/test/test-app/package.json
@@ -10,7 +10,7 @@
         "test": "echo \"No tests yet...\""
     },
     "dependencies": {
-        "@azure/functions": "^4.16.1",
+        "@azure/functions": "4.8.2",
         "durable-functions": "file:../.."
     },
     "devDependencies": {

--- a/test/test-app/package.json
+++ b/test/test-app/package.json
@@ -10,7 +10,7 @@
         "test": "echo \"No tests yet...\""
     },
     "dependencies": {
-        "@azure/functions": "^4.14.0",
+        "@azure/functions": "^4.16.1",
         "durable-functions": "file:../.."
     },
     "devDependencies": {

--- a/test/test-app/package.json
+++ b/test/test-app/package.json
@@ -10,7 +10,7 @@
         "test": "echo \"No tests yet...\""
     },
     "dependencies": {
-        "@azure/functions": "4.8.2",
+        "@azure/functions": "^4.14.0",
         "durable-functions": "file:../.."
     },
     "devDependencies": {

--- a/test/test-app/package.json
+++ b/test/test-app/package.json
@@ -10,7 +10,7 @@
         "test": "echo \"No tests yet...\""
     },
     "dependencies": {
-        "@azure/functions": "^4.8.2",
+        "@azure/functions": "^4.14.0",
         "durable-functions": "file:../../durable-functions"
     },
     "devDependencies": {

--- a/test/test-app/package.json
+++ b/test/test-app/package.json
@@ -11,7 +11,7 @@
     },
     "dependencies": {
         "@azure/functions": "^4.14.0",
-        "durable-functions": "file:../../durable-functions"
+        "durable-functions": "file:../.."
     },
     "devDependencies": {
         "@types/node": "^18.x",

--- a/types/activity.d.ts
+++ b/types/activity.d.ts
@@ -5,7 +5,7 @@ import {
     FunctionOutput,
     FunctionTrigger,
 } from "@azure/functions";
-import { RetryOptions, Task } from "durable-functions";
+import { RetryOptions, Task } from ".";
 
 export type ActivityHandler = FunctionHandler;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,6 @@
 import { InvocationContext } from "@azure/functions";
 import { DurableClient } from "./durableClient";
+import "./symbol-dispose";
 
 export * from "./activity";
 export * from "./durableClient";


### PR DESCRIPTION
## Summary

Consolidates the still-relevant open Dependabot PRs against `v3.x` into this draft PR.

Supersedes #710, #711, #692, #691, #689, #688, #687, #686, #685, #684, #683, #681, #680, #676, #674, and #673.

## Version choices

- `axios`: `1.18.0` in root, `samples-js`, and `samples-ts` (current npm latest), superseding the older `1.13.5` / `1.15.0` Dependabot targets.
- `@azure/functions`: lockfiles resolve `4.16.1`, the latest version selected by the existing `^4.14.0` range.
- `eslint`: `8.57.1`, the newest major compatible with the current `@typescript-eslint` v5 peer range; `eslint@10` is not compatible with that peer range.
- Transitive/package-lock updates include `lodash@4.18.1`, `js-yaml@4.2.0`, `form-data@4.0.6`, `picomatch@2.3.2`, `flatted@3.4.2`, `qs@6.15.2`, `validator@13.15.35`, `brace-expansion@1.1.15`, and `mocha@11.7.6`.
- Sample/test-app locks were refreshed to latest in-range resolutions where touched: `luxon@3.7.2`, `@types/luxon@3.7.2`, `@types/node@16.18.126` / `18.19.130`, and `typescript@4.9.5`.
- The `undici` Dependabot bumps are no longer relevant after the latest compatible `@azure/functions` resolution; production/runtime locks no longer resolve `undici`.
- Keeps the local `durable-functions` file links usable in samples/test-app and loads the existing `Symbol.dispose` ambient declaration for linked TypeScript consumers.

## Not included

- `uuid` remains at `9.0.1`; the audit fix is a major bump to `uuid@14` and was not part of the open Dependabot PR set.
- `serialize-javascript` remains under Mocha's `^6.0.2` range; patched `7.x` requires Node >=20, while this repo still declares Node >=18.

## Validation

- `npm test` (`273 passing`, `2 pending`)
- `npm --prefix samples-js test`
- `npm --prefix samples-ts run build && npm --prefix samples-ts test`
- `npm --prefix test/test-app run build && npm --prefix test/test-app test`
- `npm --prefix samples-js audit --audit-level=moderate`, `samples-ts`, and `test/test-app`: `found 0 vulnerabilities`
