### PR TITLE
Add critical sections support

### DIFF
--- a/samples-js/functions/transferTryFinally.js
+++ b/samples-js/functions/transferTryFinally.js
@@ -1,0 +1,41 @@
+// Critical sections sample (JavaScript, `try/finally` — primary JS pattern).
+//
+// Works on all supported Node versions (18+). Requires
+// azure-functions-durable-extension with OOProc schema V4 or newer.
+//
+// For Node >= 24 (or Node 22 with --harmony-explicit-resource-management),
+// see `transferUsing.js` for the more ergonomic `using` form.
+
+const df = require("durable-functions");
+
+df.app.entity("transferAccount", async function (context) {
+    let balance = context.df.getState(() => 0);
+    switch (context.df.operationName) {
+        case "add":
+            balance += context.df.getInput();
+            break;
+        case "get":
+            context.df.return(balance);
+            break;
+    }
+    context.df.setState(balance);
+});
+
+df.app.orchestration("transferTryFinally", function* (context) {
+    const { fromKey, toKey, amount } = context.df.getInput();
+    const src = new df.EntityId("transferAccount", fromKey);
+    const dst = new df.EntityId("transferAccount", toKey);
+
+    const lock = yield context.df.lock(src, dst);
+    try {
+        const balance = yield context.df.callEntity(src, "get");
+        if (balance >= amount) {
+            yield context.df.callEntity(src, "add", -amount);
+            yield context.df.callEntity(dst, "add", amount);
+            return { transferred: true };
+        }
+        return { transferred: false, reason: "insufficient funds" };
+    } finally {
+        lock.release();
+    }
+});

--- a/samples-js/functions/transferUsing.js
+++ b/samples-js/functions/transferUsing.js
@@ -1,0 +1,24 @@
+// Critical sections sample (JavaScript, `using` — requires Node >= 24
+// unflagged, or Node 22 with --harmony-explicit-resource-management).
+//
+// Use `transferTryFinally.js` instead on older Node runtimes.
+
+const df = require("durable-functions");
+
+// Re-uses `transferAccount` entity from transferTryFinally.js.
+
+df.app.orchestration("transferUsing", function* (context) {
+    const { fromKey, toKey, amount } = context.df.getInput();
+    const src = new df.EntityId("transferAccount", fromKey);
+    const dst = new df.EntityId("transferAccount", toKey);
+
+    using lock = yield context.df.lock(src, dst);
+
+    const balance = yield context.df.callEntity(src, "get");
+    if (balance >= amount) {
+        yield context.df.callEntity(src, "add", -amount);
+        yield context.df.callEntity(dst, "add", amount);
+        return { transferred: true, lockedEntities: lock.ownedLocks.length };
+    }
+    return { transferred: false, reason: "insufficient funds" };
+});

--- a/samples-ts/functions/transferEntities.ts
+++ b/samples-ts/functions/transferEntities.ts
@@ -1,0 +1,68 @@
+// Critical sections sample (TypeScript) — atomic two-entity transfer.
+//
+// Demonstrates the `lock` API for atomically coordinating updates across
+// two entities. Requires azure-functions-durable-extension with OOProc
+// schema V4 or newer.
+//
+// This file uses the `try/finally` pattern so it compiles on the
+// samples-ts toolchain (TypeScript 4.x). On TypeScript >= 5.2, prefer
+// the more ergonomic `using` syntax:
+//
+//   using lock = (yield context.df.lock(src, dst)) as DurableLock;
+//   // ...critical section... (released at block exit, even on throw)
+
+import * as df from "durable-functions";
+import {
+    DurableLock,
+    EntityContext,
+    EntityHandler,
+    OrchestrationContext,
+    OrchestrationHandler,
+} from "durable-functions";
+
+const accountEntityName = "transferAccount";
+
+const accountEntity: EntityHandler<number> = async function (
+    context: EntityContext<number>
+): Promise<void> {
+    await Promise.resolve();
+    let balance: number = context.df.getState(() => 0);
+
+    switch (context.df.operationName) {
+        case "add":
+            balance += context.df.getInput<number>();
+            break;
+        case "get":
+            context.df.return(balance);
+            break;
+    }
+
+    context.df.setState(balance);
+};
+df.app.entity(accountEntityName, accountEntity);
+
+interface TransferInput {
+    fromKey: string;
+    toKey: string;
+    amount: number;
+}
+
+const transferOrchestration: OrchestrationHandler = function* (context: OrchestrationContext) {
+    const { fromKey, toKey, amount } = context.df.getInput<TransferInput>();
+    const src = new df.EntityId(accountEntityName, fromKey);
+    const dst = new df.EntityId(accountEntityName, toKey);
+
+    const lock = (yield context.df.lock(src, dst)) as DurableLock;
+    try {
+        const balance: number = yield context.df.callEntity(src, "get");
+        if (balance >= amount) {
+            yield context.df.callEntity(src, "add", -amount);
+            yield context.df.callEntity(dst, "add", amount);
+            return { transferred: true, locks: lock.ownedLocks.length };
+        }
+        return { transferred: false, reason: "insufficient funds" };
+    } finally {
+        lock.release();
+    }
+};
+df.app.orchestration("transferEntities", transferOrchestration);

--- a/src/actions/ActionType.ts
+++ b/src/actions/ActionType.ts
@@ -21,4 +21,6 @@ export enum ActionType {
     // ActionType 10 corresponds to ScheduledSignalEntity, which is not supported yet
     WhenAny = 11,
     WhenAll = 12,
+    LockEntities = 13,
+    ReleaseEntities = 14,
 }

--- a/src/actions/LockEntitiesAction.ts
+++ b/src/actions/LockEntitiesAction.ts
@@ -1,0 +1,21 @@
+import { EntityId } from "../entities/EntityId";
+import { ActionType } from "./ActionType";
+import { IAction } from "./IAction";
+
+/** @hidden */
+interface LockSetEntry {
+    name: string;
+    key: string;
+}
+
+/** @hidden */
+export class LockEntitiesAction implements IAction {
+    public readonly actionType: ActionType = ActionType.LockEntities;
+    public readonly lockRequestId: string;
+    public readonly lockSet: LockSetEntry[];
+
+    constructor(lockSet: EntityId[], lockRequestId: string) {
+        this.lockRequestId = lockRequestId;
+        this.lockSet = lockSet.map((e) => ({ name: e.name, key: e.key }));
+    }
+}

--- a/src/actions/ReleaseEntitiesAction.ts
+++ b/src/actions/ReleaseEntitiesAction.ts
@@ -1,0 +1,7 @@
+import { ActionType } from "./ActionType";
+import { IAction } from "./IAction";
+
+/** @hidden */
+export class ReleaseEntitiesAction implements IAction {
+    public readonly actionType: ActionType = ActionType.ReleaseEntities;
+}

--- a/src/entities/DurableLock.ts
+++ b/src/entities/DurableLock.ts
@@ -1,16 +1,19 @@
 import { EntityId } from "./EntityId";
 
-// Define Symbol.dispose for runtimes (Node <20) that lack it natively.
-// TypeScript >=5.2 emits this same polyfill in user code that uses `using`,
-// but adding it here ensures `[Symbol.dispose]` is callable even from plain
-// JavaScript without TS down-level emit.
-if (typeof (Symbol as { dispose?: symbol }).dispose === "undefined") {
-    Object.defineProperty(Symbol, "dispose", {
-        value: Symbol("Symbol.dispose"),
-        writable: false,
-        enumerable: false,
-        configurable: false,
-    });
+// Polyfill Symbol.dispose on Node <20, where the `[Symbol.dispose]()` member below needs it
+// (`using` only reads this symbol). `configurable: true` and try/catch keep it non-destructive.
+if (typeof (Symbol as { dispose?: symbol }).dispose !== "symbol") {
+    try {
+        Object.defineProperty(Symbol, "dispose", {
+            value: Symbol("Symbol.dispose"),
+            writable: false,
+            enumerable: false,
+            configurable: true,
+        });
+    } catch {
+        // Another polyfill defined it first so we read the global
+        // `Symbol.dispose` when wiring up the `[Symbol.dispose]()` member below.
+    }
 }
 
 /**

--- a/src/entities/DurableLock.ts
+++ b/src/entities/DurableLock.ts
@@ -1,6 +1,78 @@
+import { EntityId } from "./EntityId";
+
+// Define Symbol.dispose for runtimes (Node <20) that lack it natively.
+// TypeScript >=5.2 emits this same polyfill in user code that uses `using`,
+// but adding it here ensures `[Symbol.dispose]` is callable even from plain
+// JavaScript without TS down-level emit.
+if (typeof (Symbol as { dispose?: symbol }).dispose === "undefined") {
+    Object.defineProperty(Symbol, "dispose", {
+        value: Symbol("Symbol.dispose"),
+        writable: false,
+        enumerable: false,
+        configurable: false,
+    });
+}
+
 /**
- * @hidden
- * For use with locking operations.
- * TODO: improve this
+ * Returned by yielding `DurableOrchestrationContext.lock(...)`. Represents
+ * the critical section over the locked entities.
+ *
+ * Release options (in recommended order):
+ *   1. `using` syntax (TS >=5.2 or plain JS on Node >=24). Invokes
+ *      `[Symbol.dispose]()` at block exit, which is an alias for `release()`.
+ *   2. `try/finally` calling `release()`.
+ *   3. Implicit release at orchestration completion (handled by the extension).
+ *
+ * `release()` is idempotent.
  */
-export class DurableLock {}
+export class DurableLock {
+    /** The locks held by this critical section, in deterministic (sorted) order. */
+    public readonly ownedLocks: ReadonlyArray<EntityId>;
+
+    private released = false;
+    private readonly onRelease: () => void;
+
+    /**
+     * @hidden
+     * Tracks scheduler-ids of entity calls scheduled inside the section but
+     * not yet resolved, used to enforce the "no parallel call to same locked
+     * entity" rule.
+     */
+    public readonly inFlightEntityCalls: Set<string> = new Set<string>();
+
+    /** @hidden */
+    constructor(ownedLocks: EntityId[], onRelease: () => void) {
+        // Defensive freeze so plain-JS callers can't mutate the held-lock list at runtime.
+        // (`ReadonlyArray<T>` is compile-time only.)
+        this.ownedLocks = Object.freeze([...ownedLocks]);
+        this.onRelease = onRelease;
+    }
+
+    /**
+     * Release the lock. Idempotent.
+     *
+     * Emits a `ReleaseEntities` action that the extension translates into
+     * `DurableOrchestrationContext.ReleaseLocks()`. If the lock has already
+     * been released (or the orchestration has ended), this is a no-op.
+     */
+    public release(): void {
+        if (this.released) {
+            return;
+        }
+        this.released = true;
+        this.inFlightEntityCalls.clear();
+        this.onRelease();
+    }
+
+    /**
+     * Alias for `release()`, enabling the `using` statement (TS >=5.2 / Node >=24).
+     */
+    public [Symbol.dispose](): void {
+        this.release();
+    }
+
+    /** @hidden */
+    public get isReleased(): boolean {
+        return this.released;
+    }
+}

--- a/src/error/LockingRulesViolationError.ts
+++ b/src/error/LockingRulesViolationError.ts
@@ -1,0 +1,34 @@
+/**
+ * Error thrown when an orchestration violates one of the locking rules
+ * enforced inside a critical section (see DurableOrchestrationContext.lock).
+ */
+export class LockingRulesViolationError extends Error {
+    public static readonly code = "LOCKING_RULES_VIOLATION";
+
+    constructor(message: string, options?: { cause?: unknown }) {
+        super(message);
+        this.name = "LockingRulesViolationError";
+        if (options && "cause" in options) {
+            // ES2022 `cause` propagation for runtimes that don't pass it via super().
+            (this as Error & { cause?: unknown }).cause = options.cause;
+        }
+        // Restore prototype chain for ES5/ES2015 transpile targets so
+        // `err instanceof LockingRulesViolationError` works everywhere.
+        Object.setPrototypeOf(this, LockingRulesViolationError.prototype);
+    }
+}
+
+/**
+ * Canonical message strings for locking-rule violations.
+ * Centralized so tests can assert against the same constants.
+ */
+export const LockingRulesViolationMessages = {
+    NestedSection: "Cannot acquire more locks when already holding some locks.",
+    SubOrchestrationInSection: "Cannot invoke sub-orchestrations from within a critical section.",
+    CallUnlockedEntity:
+        "Cannot call an entity from within a critical section unless it is one of the locked entities.",
+    ParallelSameEntity:
+        "Cannot call the same entity multiple times in parallel within a critical section.",
+    SignalLockedEntity:
+        "Cannot signal an entity from within a critical section if the entity is one of the locked entities.",
+} as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,9 @@ import { DummyEntityContext, DummyOrchestrationContext } from "./util/testingUti
 import { ManagedIdentityTokenSource } from "./ManagedIdentityTokenSource";
 import { EntityId } from "./entities/EntityId";
 import { EntityStateResponse } from "./entities/EntityStateResponse";
+import { DurableLock } from "./entities/DurableLock";
+import { LockState } from "./entities/LockState";
+import { LockingRulesViolationError } from "./error/LockingRulesViolationError";
 import { OrchestrationRuntimeStatus } from "./orchestrations/OrchestrationRuntimeStatus";
 import { RetryOptions } from "./RetryOptions";
 import { getClient } from "./durableClient/getClient";
@@ -13,6 +16,9 @@ export * as input from "./input";
 export {
     EntityId,
     EntityStateResponse,
+    DurableLock,
+    LockState,
+    LockingRulesViolationError,
     getClient,
     ManagedIdentityTokenSource,
     OrchestrationRuntimeStatus,

--- a/src/orchestrations/DurableOrchestrationContext.ts
+++ b/src/orchestrations/DurableOrchestrationContext.ts
@@ -392,8 +392,8 @@ export class DurableOrchestrationContext implements types.DurableOrchestrationCo
 
     /**
      * @hidden
-     * Tracks the active critical section (if any). Set when a `lock` task
-     * resolves; cleared when `release()` is invoked.
+     * Tracks the active (or pending) critical section (if any). Set when `lock(...)` is scheduled;
+     * cleared when `release()` is invoked.
      */
     private currentLock: DurableLock | undefined;
 
@@ -465,11 +465,11 @@ export class DurableOrchestrationContext implements types.DurableOrchestrationCo
         const entities = entitiesRaw as EntityId[];
 
         // Sort by scheduler id, then dedupe consecutive duplicates.
-        const sorted = [...entities].sort((a, b) =>
-            EntityId.getSchedulerIdFromEntityId(a).localeCompare(
-                EntityId.getSchedulerIdFromEntityId(b)
-            )
-        );
+        const sorted = [...entities].sort((a, b) => {
+            const aId = EntityId.getSchedulerIdFromEntityId(a);
+            const bId = EntityId.getSchedulerIdFromEntityId(b);
+            return aId < bId ? -1 : aId > bId ? 1 : 0;
+        });
         const deduped = sorted.filter(
             (e, i, arr) =>
                 i === 0 ||

--- a/src/orchestrations/DurableOrchestrationContext.ts
+++ b/src/orchestrations/DurableOrchestrationContext.ts
@@ -418,7 +418,7 @@ export class DurableOrchestrationContext implements types.DurableOrchestrationCo
      *   ctx.df.lock(a, b)
      *   ctx.df.lock([a, b])
      *
-     * @throws RangeError if no entities are supplied.
+     * @throws RangeError if no entities are supplied (zero arguments or empty array).
      * @throws TypeError if any element is not an EntityId.
      * @throws LockingRulesViolationError if called from inside an existing
      *         critical section.
@@ -443,12 +443,16 @@ export class DurableOrchestrationContext implements types.DurableOrchestrationCo
             );
         }
 
+        // Reject the no-args case up front. Without this check, normalization
+        // below would produce `[undefined]` and surface a TypeError, which
+        // contradicts the documented RangeError contract.
+        if (typeof first === "undefined" && rest.length === 0) {
+            throw new RangeError("lock requires at least one EntityId");
+        }
+
         // Normalize varargs vs array form.
         const entitiesRaw: unknown[] = Array.isArray(first) ? first : [first, ...rest];
 
-        if (!Array.isArray(entitiesRaw)) {
-            throw new TypeError("lock expected EntityId[]");
-        }
         if (entitiesRaw.length === 0) {
             throw new RangeError("lock requires at least one EntityId");
         }

--- a/src/orchestrations/DurableOrchestrationContext.ts
+++ b/src/orchestrations/DurableOrchestrationContext.ts
@@ -438,8 +438,8 @@ export class DurableOrchestrationContext implements types.DurableOrchestrationCo
     public lock(first: types.EntityId | types.EntityId[], ...rest: types.EntityId[]): Task {
         if (this.schemaVersion < ReplaySchema.V4) {
             throw new Error(
-                `lock requires a Durable Functions extension that advertises OOProc schema V4 or higher (negotiated V${
-                    (this.schemaVersion as number) + 1
+                `lock requires a Durable Functions extension that supports OOProc schema V4 or higher (this extension supports up to ${
+                    ReplaySchema[this.schemaVersion]
                 }). Please upgrade the Microsoft.Azure.WebJobs.Extensions.DurableTask package.`
             );
         }

--- a/src/orchestrations/DurableOrchestrationContext.ts
+++ b/src/orchestrations/DurableOrchestrationContext.ts
@@ -25,12 +25,21 @@ import { CallSubOrchestratorWithRetryAction } from "../actions/CallSubOrchestrat
 import { ContinueAsNewAction } from "../actions/ContinueAsNewAction";
 import { CreateTimerAction } from "../actions/CreateTimerAction";
 import { ExternalEventType } from "../actions/ExternalEventType";
+import { LockEntitiesAction } from "../actions/LockEntitiesAction";
+import { ReleaseEntitiesAction } from "../actions/ReleaseEntitiesAction";
 import { WaitForExternalEventAction } from "../actions/WaitForExternalEventAction";
 import { GuidManager } from "../util/GuidManager";
 import { HistoryEvent } from "../history/HistoryEvent";
 import { DurableHttpRequest } from "../http/DurableHttpRequest";
 import { HistoryEventType } from "../history/HistoryEventType";
 import { ExecutionStartedEvent } from "../history/ExecutionStartedEvent";
+import { DurableLock } from "../entities/DurableLock";
+import { EntityId } from "../entities/EntityId";
+import { LockState } from "../entities/LockState";
+import {
+    LockingRulesViolationError,
+    LockingRulesViolationMessages,
+} from "../error/LockingRulesViolationError";
 
 /**
  * Parameter data for orchestration bindings that can be used to schedule
@@ -188,6 +197,24 @@ export class DurableOrchestrationContext implements types.DurableOrchestrationCo
         operationName: string,
         operationInput?: unknown
     ): Task {
+        // Critical-section rules.
+        if (this.currentLock !== undefined) {
+            const targetSchedulerId = EntityId.getSchedulerIdFromEntityId(entityId as EntityId);
+            const isLocked = this.currentLock.ownedLocks.some(
+                (e) => EntityId.getSchedulerIdFromEntityId(e) === targetSchedulerId
+            );
+            if (!isLocked) {
+                throw new LockingRulesViolationError(
+                    LockingRulesViolationMessages.CallUnlockedEntity
+                );
+            }
+            if (this.currentLock.inFlightEntityCalls.has(targetSchedulerId)) {
+                throw new LockingRulesViolationError(
+                    LockingRulesViolationMessages.ParallelSameEntity
+                );
+            }
+            this.currentLock.inFlightEntityCalls.add(targetSchedulerId);
+        }
         const newAction = new CallEntityAction(entityId, operationName, operationInput);
         const task = new AtomicTask(false, newAction);
         return task;
@@ -197,6 +224,17 @@ export class DurableOrchestrationContext implements types.DurableOrchestrationCo
         operationName: string,
         operationInput?: unknown
     ): void {
+        if (this.currentLock !== undefined) {
+            const targetSchedulerId = EntityId.getSchedulerIdFromEntityId(entityId as EntityId);
+            const isLocked = this.currentLock.ownedLocks.some(
+                (e) => EntityId.getSchedulerIdFromEntityId(e) === targetSchedulerId
+            );
+            if (isLocked) {
+                throw new LockingRulesViolationError(
+                    LockingRulesViolationMessages.SignalLockedEntity
+                );
+            }
+        }
         const action = new SignalEntityAction(entityId, operationName, operationInput);
         this.taskOrchestratorExecutor.recordFireAndForgetAction(action);
     }
@@ -210,6 +248,11 @@ export class DurableOrchestrationContext implements types.DurableOrchestrationCo
         if (!name) {
             throw new Error(
                 "A sub-orchestration function name must be provided when attempting to create a suborchestration"
+            );
+        }
+        if (this.currentLock !== undefined) {
+            throw new LockingRulesViolationError(
+                LockingRulesViolationMessages.SubOrchestrationInSection
             );
         }
 
@@ -228,6 +271,11 @@ export class DurableOrchestrationContext implements types.DurableOrchestrationCo
         if (!name) {
             throw new Error(
                 "A sub-orchestration function name must be provided when attempting to create a suborchestration"
+            );
+        }
+        if (this.currentLock !== undefined) {
+            throw new LockingRulesViolationError(
+                LockingRulesViolationMessages.SubOrchestrationInSection
             );
         }
 
@@ -340,5 +388,137 @@ export class DurableOrchestrationContext implements types.DurableOrchestrationCo
         const newAction = new WaitForExternalEventAction(name, ExternalEventType.ExternalEvent);
         const task = new AtomicTask(name, newAction);
         return task;
+    }
+
+    /**
+     * @hidden
+     * Tracks the active critical section (if any). Set when a `lock` task
+     * resolves; cleared when `release()` is invoked.
+     */
+    private currentLock: DurableLock | undefined;
+
+    /**
+     * @hidden
+     * Called by the executor when a `callEntity` task resolves (success or
+     * failure) so the "no parallel call to same locked entity" rule no
+     * longer treats the call as in flight.
+     */
+    public _onEntityCallResolved(schedulerId: string): void {
+        if (this.currentLock === undefined) {
+            return;
+        }
+        this.currentLock.inFlightEntityCalls.delete(schedulerId);
+    }
+
+    /**
+     * Acquires one or more entity locks, atomically, forming a critical
+     * section. Yield the returned task to receive a `DurableLock`.
+     *
+     * Supports both varargs and array form:
+     *   ctx.df.lock(a, b)
+     *   ctx.df.lock([a, b])
+     *
+     * @throws RangeError if no entities are supplied.
+     * @throws TypeError if any element is not an EntityId.
+     * @throws LockingRulesViolationError if called from inside an existing
+     *         critical section.
+     * @throws Error if the negotiated extension protocol does not support
+     *         critical sections (requires schema V4 or newer).
+     *
+     * @remarks
+     * **Replay-protocol contract:** the wire shape on replay is identical
+     * to `callEntity`. The extension sends a `RequestMessage`
+     * (history `EventSent`, with `Input.id` = lock-request GUID) and awaits
+     * an `EventRaised` whose `Name` equals that same GUID. The executor's
+     * `EventSent` handler re-keys this task to that GUID, so the subsequent
+     * `EventRaised` matches and resolves the lock task — without requiring
+     * any new history event type.
+     */
+    public lock(first: types.EntityId | types.EntityId[], ...rest: types.EntityId[]): Task {
+        if (this.schemaVersion < ReplaySchema.V4) {
+            throw new Error(
+                `lock requires a Durable Functions extension that advertises OOProc schema V4 or higher (negotiated V${
+                    (this.schemaVersion as number) + 1
+                }). Please upgrade the Microsoft.Azure.WebJobs.Extensions.DurableTask package.`
+            );
+        }
+
+        // Normalize varargs vs array form.
+        const entitiesRaw: unknown[] = Array.isArray(first) ? first : [first, ...rest];
+
+        if (!Array.isArray(entitiesRaw)) {
+            throw new TypeError("lock expected EntityId[]");
+        }
+        if (entitiesRaw.length === 0) {
+            throw new RangeError("lock requires at least one EntityId");
+        }
+        for (const e of entitiesRaw) {
+            if (!(e instanceof EntityId)) {
+                throw new TypeError("lock expected EntityId[]");
+            }
+        }
+
+        if (this.currentLock !== undefined) {
+            throw new LockingRulesViolationError(LockingRulesViolationMessages.NestedSection);
+        }
+
+        const entities = entitiesRaw as EntityId[];
+
+        // Sort by scheduler id, then dedupe consecutive duplicates.
+        const sorted = [...entities].sort((a, b) =>
+            EntityId.getSchedulerIdFromEntityId(a).localeCompare(
+                EntityId.getSchedulerIdFromEntityId(b)
+            )
+        );
+        const deduped = sorted.filter(
+            (e, i, arr) =>
+                i === 0 ||
+                EntityId.getSchedulerIdFromEntityId(arr[i - 1]) !==
+                    EntityId.getSchedulerIdFromEntityId(e)
+        );
+
+        const lockRequestId = this.newGuid(this.instanceId);
+        const action = new LockEntitiesAction(deduped, lockRequestId);
+        const task = new AtomicTask(false, action);
+
+        // Install a value-translation hook so that when the action completes
+        // the orchestrator generator receives a DurableLock (not the raw
+        // extension response).
+        const lock = new DurableLock(deduped, () => {
+            this.taskOrchestratorExecutor.recordFireAndForgetAction(new ReleaseEntitiesAction());
+            // Clear the active-section flag so subsequent code outside the
+            // section is no longer treated as locked.
+            if (this.currentLock === lock) {
+                this.currentLock = undefined;
+            }
+        });
+
+        // The AtomicTask returned to the user must resolve to `lock` on success.
+        // We achieve this by attaching a post-resolve override; the executor's
+        // setTaskValue path calls task.setValue(...) with the raw result.
+        // We intercept by wrapping the AtomicTask in a thin adapter that swaps
+        // the result. To keep things simple, we mark the task and let
+        // TaskOrchestrationExecutor recognize LockEntitiesAction and translate.
+        (task as AtomicTask & { __lockResult?: DurableLock }).__lockResult = lock;
+
+        // Activate the section eagerly so subsequent yielded callEntity/etc
+        // inside the same generator frame see the rules. The lock won't
+        // *actually* be acquired by the extension until the action completes,
+        // but rule enforcement is purely worker-side bookkeeping and we want
+        // it to behave the same on first execution and on replay.
+        this.currentLock = lock;
+
+        return task;
+    }
+
+    /**
+     * Returns whether the orchestration is currently inside a critical
+     * section and, if so, which entities are locked.
+     */
+    public isLocked(): LockState {
+        if (this.currentLock === undefined) {
+            return new LockState(false, []);
+        }
+        return new LockState(true, [...this.currentLock.ownedLocks]);
     }
 }

--- a/src/orchestrations/DurableOrchestrationContext.ts
+++ b/src/orchestrations/DurableOrchestrationContext.ts
@@ -5,6 +5,7 @@ import {
     WhenAllTask,
     WhenAnyTask,
     AtomicTask,
+    LockTask,
     RetryableTask,
     DFTimerTask,
     DFTask,
@@ -483,11 +484,11 @@ export class DurableOrchestrationContext implements types.DurableOrchestrationCo
 
         const lockRequestId = this.newGuid(this.instanceId);
         const action = new LockEntitiesAction(deduped, lockRequestId);
-        const task = new AtomicTask(false, action);
 
-        // Install a value-translation hook so that when the action completes
-        // the orchestrator generator receives a DurableLock (not the raw
-        // extension response).
+        // The DurableLock the orchestrator generator receives on
+        // `yield ctx.df.lock(...)`. It is carried on the returned LockTask as a
+        // typed field (see LockTask), so the executor can hand it back on
+        // completion without a shared untyped property between the two.
         const lock = new DurableLock(deduped, () => {
             this.taskOrchestratorExecutor.recordFireAndForgetAction(new ReleaseEntitiesAction());
             // Clear the active-section flag so subsequent code outside the
@@ -497,13 +498,7 @@ export class DurableOrchestrationContext implements types.DurableOrchestrationCo
             }
         });
 
-        // The AtomicTask returned to the user must resolve to `lock` on success.
-        // We achieve this by attaching a post-resolve override; the executor's
-        // setTaskValue path calls task.setValue(...) with the raw result.
-        // We intercept by wrapping the AtomicTask in a thin adapter that swaps
-        // the result. To keep things simple, we mark the task and let
-        // TaskOrchestrationExecutor recognize LockEntitiesAction and translate.
-        (task as AtomicTask & { __lockResult?: DurableLock }).__lockResult = lock;
+        const task = new LockTask(action, lock);
 
         // Activate the section eagerly so subsequent yielded callEntity/etc
         // inside the same generator frame see the rules. The lock won't

--- a/src/orchestrations/ReplaySchema.ts
+++ b/src/orchestrations/ReplaySchema.ts
@@ -6,6 +6,7 @@ export enum ReplaySchema {
     V1 = 0,
     V2 = 1,
     V3 = 2,
+    V4 = 3,
 }
 
-export const LatestReplaySchema: ReplaySchema = ReplaySchema.V3;
+export const LatestReplaySchema: ReplaySchema = ReplaySchema.V4;

--- a/src/orchestrations/TaskOrchestrationExecutor.ts
+++ b/src/orchestrations/TaskOrchestrationExecutor.ts
@@ -5,6 +5,7 @@ import { ReplaySchema } from "./ReplaySchema";
 import { Utils } from "../util/Utils";
 import { DurableOrchestrationContext, OrchestrationContext } from "durable-functions";
 import { CallEntityAction } from "../actions/CallEntityAction";
+import { LockEntitiesAction } from "../actions/LockEntitiesAction";
 import { IAction } from "../actions/IAction";
 import { WaitForExternalEventAction } from "../actions/WaitForExternalEventAction";
 import { RequestMessage } from "../entities/RequestMessage";
@@ -196,23 +197,30 @@ export class TaskOrchestrationExecutor {
             }
             case HistoryEventType.EventSent: {
                 // The EventSent event requires careful handling because it is re-used among
-                // CallEntity and WaitForExternalEvent APIs.
-                // For CallEntity, the EventRaised event that contains that API's result will
-                // expect a TaskID that is different from the TaskID found at the root of this
-                // EventSent event. Namely, the TaskID it expects can be found nested in the
-                // "Input" field of the corresponding EventSent event. Here, we handle that
-                // edge-case by correcting the expected TaskID in our openTask list.
+                // CallEntity, LockEntities, and WaitForExternalEvent APIs.
+                // For CallEntity/LockEntities, the completion event (EventRaised) carries
+                // a TaskID that is different from the TaskID at the root of this EventSent
+                // event. The expected TaskID lives in the "Input" field of the
+                // corresponding EventSent (as the `id` of the RequestMessage). We handle
+                // that edge-case here by re-keying the open task.
                 const key = event.EventId;
                 const task = this.openTasks[key];
                 if (task !== undefined) {
-                    if (task.actionObj instanceof CallEntityAction) {
+                    if (
+                        task.actionObj instanceof CallEntityAction ||
+                        task.actionObj instanceof LockEntitiesAction
+                    ) {
                         // extract TaskID from Input field
                         const eventSent = event as EventSentEvent;
                         const requestMessage = JSON.parse(
                             eventSent.Input as string
                         ) as RequestMessage;
 
-                        // Obtain correct Task ID and update the task to be associated with it
+                        // Obtain correct Task ID and update the task to be associated with it.
+                        // For LockEntitiesAction this id equals the action's lockRequestId,
+                        // and the upcoming EventRaised carrying "LockAcquisitionCompleted"
+                        // is named with the same GUID -- which is how the worker matches
+                        // lock-acquisition without a new history event type.
                         const eventId = requestMessage.id;
                         delete this.openTasks[key];
                         this.openTasks[eventId] = task;
@@ -340,6 +348,14 @@ export class TaskOrchestrationExecutor {
                     taskResult = Error(taskResult as string);
                     isSuccess = false;
                 }
+            } else if (action instanceof LockEntitiesAction) {
+                // Replace the raw extension response with the DurableLock
+                // attached to the task at schedule time. This is the value
+                // the orchestrator generator will see on `yield ctx.df.lock(...)`.
+                const lockResult = (task as { __lockResult?: unknown }).__lockResult;
+                if (lockResult !== undefined) {
+                    taskResult = lockResult;
+                }
             }
         } else {
             // The task failed, we attempt to extract the Reason and Details from the event.
@@ -359,6 +375,15 @@ export class TaskOrchestrationExecutor {
         // Set result to the task, and update it's isPlayed flag.
         task.isPlayed = event.IsPlayed;
         task.setValue(!isSuccess, taskResult, this);
+
+        // If this was a callEntity inside a critical section, mark the call
+        // as no longer in flight so the orchestrator can issue another call
+        // to the same locked entity. Done in both success and failure paths.
+        if (task.actionObj instanceof CallEntityAction) {
+            ((this.context as unknown) as {
+                _onEntityCallResolved(schedulerId: string): void;
+            })._onEntityCallResolved(task.actionObj.instanceId);
+        }
     }
 
     /**

--- a/src/orchestrations/TaskOrchestrationExecutor.ts
+++ b/src/orchestrations/TaskOrchestrationExecutor.ts
@@ -1,9 +1,10 @@
 import { OrchestrationFailureError } from "../error/OrchestrationFailureError";
 import { OrchestratorState } from "./OrchestratorState";
-import { TaskBase, NoOpTask, DFTask, CompoundTask, TaskState } from "../task";
+import { TaskBase, NoOpTask, DFTask, CompoundTask, TaskState, LockTask } from "../task";
 import { ReplaySchema } from "./ReplaySchema";
 import { Utils } from "../util/Utils";
 import { DurableOrchestrationContext, OrchestrationContext } from "durable-functions";
+import type { DurableOrchestrationContext as DurableOrchestrationContextImpl } from "./DurableOrchestrationContext";
 import { CallEntityAction } from "../actions/CallEntityAction";
 import { LockEntitiesAction } from "../actions/LockEntitiesAction";
 import { IAction } from "../actions/IAction";
@@ -348,14 +349,11 @@ export class TaskOrchestrationExecutor {
                     taskResult = Error(taskResult as string);
                     isSuccess = false;
                 }
-            } else if (action instanceof LockEntitiesAction) {
-                // Replace the raw extension response with the DurableLock
-                // attached to the task at schedule time. This is the value
-                // the orchestrator generator will see on `yield ctx.df.lock(...)`.
-                const lockResult = (task as { __lockResult?: unknown }).__lockResult;
-                if (lockResult !== undefined) {
-                    taskResult = lockResult;
-                }
+            } else if (task instanceof LockTask) {
+                // Replace the raw extension response with the DurableLock that
+                // the LockTask carries (set at schedule time). This is the
+                // value the orchestrator generator sees on `yield ctx.df.lock(...)`.
+                taskResult = task.lockResult;
             }
         } else {
             // The task failed, we attempt to extract the Reason and Details from the event.
@@ -380,9 +378,9 @@ export class TaskOrchestrationExecutor {
         // as no longer in flight so the orchestrator can issue another call
         // to the same locked entity. Done in both success and failure paths.
         if (task.actionObj instanceof CallEntityAction) {
-            ((this.context as unknown) as {
-                _onEntityCallResolved(schedulerId: string): void;
-            })._onEntityCallResolved(task.actionObj.instanceId);
+            (this.context as DurableOrchestrationContextImpl)._onEntityCallResolved(
+                task.actionObj.instanceId
+            );
         }
     }
 

--- a/src/task/LockTask.ts
+++ b/src/task/LockTask.ts
@@ -1,0 +1,21 @@
+import { IAction } from "../actions/IAction";
+import { DurableLock } from "../entities/DurableLock";
+import { AtomicTask } from "./AtomicTask";
+
+/**
+ * @hidden
+ * An {@link AtomicTask} that resolves to a {@link DurableLock}.
+ *
+ * The lock instance is carried as a typed, readonly field so the executor can
+ * hand it back to the orchestrator when the lock action completes — replacing
+ * the previous untyped `__lockResult` property bag that was attached and read
+ * via casts on both sides. With this class the Context (writer) and Executor
+ * (reader) share a single compile-checked contract.
+ */
+export class LockTask extends AtomicTask {
+    constructor(action: IAction, public readonly lockResult: DurableLock) {
+        // `false` is the TaskID for an un-awaited task, matching how `lock()`
+        // previously constructed its AtomicTask.
+        super(false, action);
+    }
+}

--- a/src/task/LockTask.ts
+++ b/src/task/LockTask.ts
@@ -7,10 +7,7 @@ import { AtomicTask } from "./AtomicTask";
  * An {@link AtomicTask} that resolves to a {@link DurableLock}.
  *
  * The lock instance is carried as a typed, readonly field so the executor can
- * hand it back to the orchestrator when the lock action completes — replacing
- * the previous untyped `__lockResult` property bag that was attached and read
- * via casts on both sides. With this class the Context (writer) and Executor
- * (reader) share a single compile-checked contract.
+ * hand it back to the orchestrator when the lock action completes.
  */
 export class LockTask extends AtomicTask {
     constructor(action: IAction, public readonly lockResult: DurableLock) {

--- a/src/task/index.ts
+++ b/src/task/index.ts
@@ -28,6 +28,7 @@ export * from "./TaskBase";
 export * from "./DFTask";
 export * from "./CompoundTask";
 export * from "./AtomicTask";
+export * from "./LockTask";
 export * from "./NoOpTask";
 export * from "./DFTimerTask";
 export * from "./CallHttpWithPollingTask";

--- a/test/integration/critical-sections-spec.ts
+++ b/test/integration/critical-sections-spec.ts
@@ -15,7 +15,7 @@ import { ActionType } from "../../src/actions/ActionType";
 import { HistoryEvent } from "../../src/history/HistoryEvent";
 import { OrchestratorStartedEvent } from "../../src/history/OrchestratorStartedEvent";
 import { HistoryEventOptions } from "../../src/history/HistoryEventOptions";
-import { AtomicTask } from "../../src/task";
+import { AtomicTask, LockTask } from "../../src/task";
 
 function newContext(
     schema: ReplaySchema = ReplaySchema.V4
@@ -225,11 +225,11 @@ describe("Critical Sections (lock / isLocked)", () => {
             const a = new EntityId("Account", "A");
 
             // Acquire the lock.
-            const firstTask = ctx.lock(a) as AtomicTask & { __lockResult?: DurableLock };
+            const firstTask = ctx.lock(a) as LockTask;
             expect(ctx.isLocked().isLocked).to.equal(true);
 
             // Do work then release.
-            const firstLock = firstTask.__lockResult as DurableLock;
+            const firstLock = firstTask.lockResult;
             firstLock.release();
 
             // currentLock is now reset to undefined.

--- a/test/integration/critical-sections-spec.ts
+++ b/test/integration/critical-sections-spec.ts
@@ -1,0 +1,586 @@
+import { expect } from "chai";
+import "mocha";
+import { DurableOrchestrationContext } from "../../src/orchestrations/DurableOrchestrationContext";
+import { TaskOrchestrationExecutor } from "../../src/orchestrations/TaskOrchestrationExecutor";
+import { ReplaySchema } from "../../src/orchestrations/ReplaySchema";
+import { EntityId } from "../../src/entities/EntityId";
+import { DurableLock } from "../../src/entities/DurableLock";
+import { LockState } from "../../src/entities/LockState";
+import {
+    LockingRulesViolationError,
+    LockingRulesViolationMessages,
+} from "../../src/error/LockingRulesViolationError";
+import { LockEntitiesAction } from "../../src/actions/LockEntitiesAction";
+import { ActionType } from "../../src/actions/ActionType";
+import { HistoryEvent } from "../../src/history/HistoryEvent";
+import { OrchestratorStartedEvent } from "../../src/history/OrchestratorStartedEvent";
+import { HistoryEventOptions } from "../../src/history/HistoryEventOptions";
+import { AtomicTask } from "../../src/task";
+
+function newContext(
+    schema: ReplaySchema = ReplaySchema.V4
+): {
+    ctx: DurableOrchestrationContext;
+    executor: TaskOrchestrationExecutor;
+} {
+    const executor = new TaskOrchestrationExecutor();
+    const history: HistoryEvent[] = [
+        new OrchestratorStartedEvent(new HistoryEventOptions(0, new Date())),
+    ];
+    const ctx = new DurableOrchestrationContext(
+        history,
+        "test-instance",
+        new Date(),
+        false,
+        undefined,
+        "3.00:00:00",
+        "6.00:00:00",
+        30000,
+        schema,
+        undefined,
+        executor
+    );
+    return { ctx, executor };
+}
+
+describe("Critical Sections (lock / isLocked)", () => {
+    describe("input validation", () => {
+        it("throws RangeError when called with empty array", () => {
+            const { ctx } = newContext();
+            expect(() => ctx.lock([])).to.throw(RangeError, /at least one EntityId/);
+        });
+
+        it("throws TypeError when an element is not an EntityId", () => {
+            const { ctx } = newContext();
+            expect(() => ctx.lock([({ name: "x", key: "y" } as unknown) as EntityId])).to.throw(
+                TypeError,
+                /EntityId/
+            );
+        });
+    });
+
+    describe("schema-version gating", () => {
+        it("throws a clear error when negotiated schema is below V4", () => {
+            const { ctx } = newContext(ReplaySchema.V3);
+            const a = new EntityId("Account", "A");
+            expect(() => ctx.lock(a)).to.throw(/schema V4/);
+        });
+    });
+
+    describe("action emission", () => {
+        it("emits a single LockEntitiesAction with sorted+deduped lockset (varargs)", () => {
+            const { ctx } = newContext();
+            const a = new EntityId("Account", "A");
+            const b = new EntityId("Account", "B");
+            const task = ctx.lock(b, a) as AtomicTask;
+            expect(task.actionObj).to.be.instanceOf(LockEntitiesAction);
+            const action = task.actionObj as LockEntitiesAction;
+            expect(action.actionType).to.equal(ActionType.LockEntities);
+            expect(action.lockSet.map((e) => e.key)).to.deep.equal(["A", "B"]);
+            expect(action.lockRequestId).to.be.a("string").and.not.empty;
+        });
+
+        it("array form produces identical lockset to varargs form", () => {
+            const { ctx: ctx1 } = newContext();
+            const { ctx: ctx2 } = newContext();
+            const a = new EntityId("Account", "A");
+            const b = new EntityId("Account", "B");
+            const t1 = ctx1.lock(b, a) as AtomicTask;
+            const t2 = ctx2.lock([b, a]) as AtomicTask;
+            const a1 = t1.actionObj as LockEntitiesAction;
+            const a2 = t2.actionObj as LockEntitiesAction;
+            expect(a1.lockSet.map((e) => e.key)).to.deep.equal(a2.lockSet.map((e) => e.key));
+        });
+
+        it("dedupes duplicate entities in the lock set", () => {
+            const { ctx } = newContext();
+            const a = new EntityId("Account", "A");
+            const task = ctx.lock(a, a, a) as AtomicTask;
+            const action = task.actionObj as LockEntitiesAction;
+            expect(action.lockSet).to.have.lengthOf(1);
+        });
+    });
+
+    describe("isLocked()", () => {
+        it("returns false before lock", () => {
+            const { ctx } = newContext();
+            const state = ctx.isLocked();
+            expect(state).to.be.instanceOf(LockState);
+            expect(state.isLocked).to.equal(false);
+            expect(state.ownedLocks).to.deep.equal([]);
+        });
+
+        it("returns true and the owned locks after lock", () => {
+            const { ctx } = newContext();
+            const a = new EntityId("Account", "A");
+            const b = new EntityId("Account", "B");
+            ctx.lock(a, b);
+            const state = ctx.isLocked();
+            expect(state.isLocked).to.equal(true);
+            expect(state.ownedLocks.map((e) => e.key)).to.deep.equal(["A", "B"]);
+        });
+    });
+
+    describe("rule enforcement", () => {
+        it("throws LockingRulesViolationError on nested lock", () => {
+            const { ctx } = newContext();
+            const a = new EntityId("Account", "A");
+            const b = new EntityId("Account", "B");
+            ctx.lock(a);
+            expect(() => ctx.lock(b)).to.throw(
+                LockingRulesViolationError,
+                LockingRulesViolationMessages.NestedSection
+            );
+        });
+
+        it("throws on sub-orchestration call inside section", () => {
+            const { ctx } = newContext();
+            ctx.lock(new EntityId("Account", "A"));
+            expect(() => ctx.callSubOrchestrator("Child")).to.throw(
+                LockingRulesViolationError,
+                LockingRulesViolationMessages.SubOrchestrationInSection
+            );
+        });
+
+        it("throws on callEntity to an entity outside the lock set", () => {
+            const { ctx } = newContext();
+            ctx.lock(new EntityId("Account", "A"));
+            expect(() => ctx.callEntity(new EntityId("Account", "B"), "get")).to.throw(
+                LockingRulesViolationError,
+                LockingRulesViolationMessages.CallUnlockedEntity
+            );
+        });
+
+        it("throws on parallel callEntity to the same locked entity", () => {
+            const { ctx } = newContext();
+            const a = new EntityId("Account", "A");
+            ctx.lock(a);
+            ctx.callEntity(a, "get");
+            expect(() => ctx.callEntity(a, "get")).to.throw(
+                LockingRulesViolationError,
+                LockingRulesViolationMessages.ParallelSameEntity
+            );
+        });
+
+        it("throws on signalEntity to a locked entity", () => {
+            const { ctx } = newContext();
+            const a = new EntityId("Account", "A");
+            ctx.lock(a);
+            expect(() => ctx.signalEntity(a, "add", 1)).to.throw(
+                LockingRulesViolationError,
+                LockingRulesViolationMessages.SignalLockedEntity
+            );
+        });
+
+        it("allows signalEntity to an entity outside the lock set", () => {
+            const { ctx } = newContext();
+            ctx.lock(new EntityId("Account", "A"));
+            expect(() => ctx.signalEntity(new EntityId("Other", "X"), "noop")).to.not.throw();
+        });
+    });
+
+    describe("DurableLock release", () => {
+        it("release() is idempotent", () => {
+            const lock = new DurableLock([new EntityId("X", "1")], () => {
+                releaseCalls++;
+            });
+            let releaseCalls = 0;
+            lock.release();
+            lock.release();
+            expect(releaseCalls).to.equal(1);
+        });
+
+        it("[Symbol.dispose]() aliases release()", () => {
+            let calls = 0;
+            const lock = new DurableLock([new EntityId("X", "1")], () => {
+                calls++;
+            });
+            lock[Symbol.dispose]();
+            expect(calls).to.equal(1);
+            expect(lock.isReleased).to.equal(true);
+        });
+
+        it("ownedLocks is frozen", () => {
+            const lock = new DurableLock([new EntityId("X", "1")], () => undefined);
+            expect(Object.isFrozen(lock.ownedLocks)).to.equal(true);
+        });
+    });
+});
+
+// -----------------------------------------------------------------------------
+// Replay-integration tests
+//
+// These exercise the full Orchestrator.handle pipeline (action emission +
+// history matching), proving that the LockEntities action completes via the
+// same EventSent->EventRaised re-keying machinery as CallEntity. The history
+// shape produced by the extension for a lock acquisition is:
+//   1) EventSent carrying a RequestMessage with `id` = lockRequestId GUID
+//   2) EventRaised whose `Name` equals that GUID
+// -----------------------------------------------------------------------------
+
+import moment = require("moment");
+import { v1 as uuidv1 } from "uuid";
+import {
+    DummyOrchestrationContext as DummyOrchestrationContextRuntime,
+    createOrchestrator,
+    DurableOrchestrationInput,
+} from "../../src/util/testingUtils";
+import { ExecutionStartedEvent } from "../../src/history/ExecutionStartedEvent";
+import { EventSentEvent } from "../../src/history/EventSentEvent";
+import { EventRaisedEvent } from "../../src/history/EventRaisedEvent";
+import { OrchestratorCompletedEvent } from "../../src/history/OrchestratorCompletedEvent";
+
+function buildLockHistory(
+    firstTimestamp: Date,
+    entities: EntityId[],
+    lockRequestId: string,
+    includeResponse: boolean
+): HistoryEvent[] {
+    const orchestratorId = uuidv1();
+    const t0 = firstTimestamp;
+    const t1 = moment(firstTimestamp).add(1, "s").toDate();
+    const t2 = moment(firstTimestamp).add(2, "s").toDate();
+
+    const events: HistoryEvent[] = [
+        new OrchestratorStartedEvent({ eventId: -1, timestamp: t0, isPlayed: false }),
+        new ExecutionStartedEvent({
+            eventId: -1,
+            timestamp: t1,
+            isPlayed: true,
+            name: orchestratorId,
+            input: undefined,
+        }),
+        new EventSentEvent({
+            eventId: 0,
+            timestamp: t1,
+            isPlayed: true,
+            name: "op",
+            input: JSON.stringify({
+                id: lockRequestId,
+                parent: orchestratorId,
+                lockset: entities.map((e) => ({
+                    name: e.name,
+                    key: e.key,
+                })),
+                position: 0,
+            }),
+            instanceId: EntityId.getSchedulerIdFromEntityId(entities[0]),
+        }),
+        new OrchestratorCompletedEvent({ eventId: -1, timestamp: t1, isPlayed: true }),
+    ];
+
+    if (includeResponse) {
+        events.push(
+            new OrchestratorStartedEvent({ eventId: -1, timestamp: t2, isPlayed: false }),
+            // The extension surfaces lock acquisition as an EventRaised
+            // whose Name equals the lockRequestId GUID (the second arg to
+            // WaitForExternalEvent, "LockAcquisitionCompleted", is only a log label).
+            new EventRaisedEvent({
+                eventId: -1,
+                timestamp: t2,
+                isPlayed: false,
+                name: lockRequestId,
+                input: JSON.stringify({ result: null }),
+            })
+        );
+    }
+
+    return events;
+}
+
+describe("Critical Sections - replay integration", () => {
+    it("yields a DurableLock when the EventRaised response arrives", async () => {
+        const src = new EntityId("Account", "A");
+        const dst = new EntityId("Account", "B");
+        let yieldedLock: DurableLock | undefined;
+
+        const orchestrator = createOrchestrator(function* (context) {
+            const lock = (yield context.df.lock(src, dst)) as DurableLock;
+            yieldedLock = lock;
+            return { locks: lock.ownedLocks.map((e) => e.key) };
+        });
+
+        // Predict the lockRequestId. The implementation derives it from
+        // newGuid(instanceId) which uses (instanceId, currentUtcDateTime,
+        // counter=0). To make the test deterministic, run once first to
+        // capture what GUID the worker would generate, then rebuild history
+        // with that GUID. We do this via a "first pass" where the response
+        // is absent so the orchestration suspends and we can read the
+        // emitted action's lockRequestId.
+        const firstTs = moment.utc().toDate();
+        const initialCtx = new DummyOrchestrationContextRuntime();
+        const initialInput = new DurableOrchestrationInput(
+            "test-instance-1",
+            buildLockHistory(firstTs, [src, dst], "placeholder-not-used", false),
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            ReplaySchema.V4
+        );
+        const firstResult = await orchestrator(initialInput, initialCtx);
+        const emittedAction = firstResult.actions[0][0] as LockEntitiesAction;
+        expect(emittedAction.actionType).to.equal(ActionType.LockEntities);
+        const realLockRequestId = emittedAction.lockRequestId;
+
+        // Now replay with a history that includes the response keyed by the
+        // real lockRequestId.
+        const fullHistory = buildLockHistory(firstTs, [src, dst], realLockRequestId, true);
+        const replayCtx = new DummyOrchestrationContextRuntime();
+        const replayInput = new DurableOrchestrationInput(
+            "test-instance-1",
+            fullHistory,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            ReplaySchema.V4
+        );
+        const replayResult = await orchestrator(replayInput, replayCtx);
+
+        expect(replayResult.isDone).to.equal(true);
+        expect(replayResult.output).to.deep.equal({ locks: ["A", "B"] });
+        expect(yieldedLock).to.be.instanceOf(DurableLock);
+        expect((yieldedLock as DurableLock).ownedLocks.map((e) => e.key)).to.deep.equal(["A", "B"]);
+    });
+
+    it("suspends (isDone=false) when the EventRaised response is missing", async () => {
+        const a = new EntityId("Account", "A");
+
+        const orchestrator = createOrchestrator(function* (context) {
+            yield context.df.lock(a);
+            return "should-not-reach";
+        });
+
+        const firstTs = moment.utc().toDate();
+        const ctx = new DummyOrchestrationContextRuntime();
+        const input = new DurableOrchestrationInput(
+            "test-instance-2",
+            buildLockHistory(firstTs, [a], "irrelevant", false),
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            ReplaySchema.V4
+        );
+        const result = await orchestrator(input, ctx);
+
+        expect(result.isDone).to.equal(false);
+        expect(result.actions[0]).to.have.lengthOf(1);
+        expect((result.actions[0][0] as LockEntitiesAction).actionType).to.equal(
+            ActionType.LockEntities
+        );
+    });
+
+    it("emits ReleaseEntities action when lock.release() is called", async () => {
+        const a = new EntityId("Account", "A");
+
+        const orchestrator = createOrchestrator(function* (context) {
+            const lock = (yield context.df.lock(a)) as DurableLock;
+            lock.release();
+            return "done";
+        });
+
+        // First pass to read the generated lockRequestId.
+        const firstTs = moment.utc().toDate();
+        const probeCtx = new DummyOrchestrationContextRuntime();
+        const probeInput = new DurableOrchestrationInput(
+            "test-instance-3",
+            buildLockHistory(firstTs, [a], "x", false),
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            ReplaySchema.V4
+        );
+        const probeResult = await orchestrator(probeInput, probeCtx);
+        const lockRequestId = (probeResult.actions[0][0] as LockEntitiesAction).lockRequestId;
+
+        // Replay with response present so release() actually executes.
+        const replayCtx = new DummyOrchestrationContextRuntime();
+        const replayInput = new DurableOrchestrationInput(
+            "test-instance-3",
+            buildLockHistory(firstTs, [a], lockRequestId, true),
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            ReplaySchema.V4
+        );
+        const result = await orchestrator(replayInput, replayCtx);
+
+        expect(result.isDone).to.equal(true);
+        expect(result.actions[0]).to.have.lengthOf(2);
+        expect(result.actions[0][0].actionType).to.equal(ActionType.LockEntities);
+        expect(result.actions[0][1].actionType).to.equal(ActionType.ReleaseEntities);
+    });
+});
+
+// -----------------------------------------------------------------------------
+// Release-pattern parity matrix
+//
+// The public release surface offers three patterns: explicit `release()`,
+// `try/finally`, and `[Symbol.dispose]()` (the underlying mechanic of TS 5.2+
+// `using` syntax). We can't exercise the `using` *syntax* from a TS 4.x test
+// project, but we can directly invoke `[Symbol.dispose]()` which is the same
+// runtime call the compiler emits. The invariant verified by this matrix:
+// regardless of release pattern, the emitted action stream is identical
+// ([LockEntities, ReleaseEntities] in that order).
+// -----------------------------------------------------------------------------
+
+describe("Critical Sections - release-pattern parity", () => {
+    const entity = new EntityId("Account", "A");
+
+    async function runWithRelease(
+        release: (lock: DurableLock) => void
+    ): Promise<{ types: ActionType[] }> {
+        const orchestrator = createOrchestrator(function* (context) {
+            const lock = (yield context.df.lock(entity)) as DurableLock;
+            release(lock);
+            return "ok";
+        });
+
+        // Probe pass to capture the deterministic lockRequestId.
+        const firstTs = moment.utc().toDate();
+        const probeCtx = new DummyOrchestrationContextRuntime();
+        const probeInput = new DurableOrchestrationInput(
+            "matrix-instance",
+            buildLockHistory(firstTs, [entity], "x", false),
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            ReplaySchema.V4
+        );
+        const probe = await orchestrator(probeInput, probeCtx);
+        const lockRequestId = (probe.actions[0][0] as LockEntitiesAction).lockRequestId;
+
+        const replayCtx = new DummyOrchestrationContextRuntime();
+        const replayInput = new DurableOrchestrationInput(
+            "matrix-instance",
+            buildLockHistory(firstTs, [entity], lockRequestId, true),
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            ReplaySchema.V4
+        );
+        const result = await orchestrator(replayInput, replayCtx);
+        expect(result.isDone).to.equal(true);
+        return { types: result.actions[0].map((a: { actionType: ActionType }) => a.actionType) };
+    }
+
+    it("explicit release() emits [LockEntities, ReleaseEntities]", async () => {
+        const { types } = await runWithRelease((l) => l.release());
+        expect(types).to.deep.equal([ActionType.LockEntities, ActionType.ReleaseEntities]);
+    });
+
+    it("[Symbol.dispose]() emits the same action stream as release()", async () => {
+        const { types } = await runWithRelease((l) => l[Symbol.dispose]());
+        expect(types).to.deep.equal([ActionType.LockEntities, ActionType.ReleaseEntities]);
+    });
+
+    it("double-release is idempotent (still emits exactly one ReleaseEntities)", async () => {
+        const { types } = await runWithRelease((l) => {
+            l.release();
+            l.release();
+            l[Symbol.dispose]();
+        });
+        expect(types).to.deep.equal([ActionType.LockEntities, ActionType.ReleaseEntities]);
+    });
+
+    it("try/finally releases when the protected code throws", async () => {
+        const orchestrator = createOrchestrator(function* (context) {
+            const lock = (yield context.df.lock(entity)) as DurableLock;
+            try {
+                throw new Error("boom inside section");
+            } finally {
+                lock.release();
+            }
+        });
+
+        // Probe.
+        const firstTs = moment.utc().toDate();
+        const probeCtx = new DummyOrchestrationContextRuntime();
+        const probeInput = new DurableOrchestrationInput(
+            "throw-instance",
+            buildLockHistory(firstTs, [entity], "x", false),
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            ReplaySchema.V4
+        );
+        const probe = await orchestrator(probeInput, probeCtx);
+        const lockRequestId = (probe.actions[0][0] as LockEntitiesAction).lockRequestId;
+
+        // Replay — orchestration is expected to fail with the user error,
+        // but the release action MUST still have been emitted before the
+        // throw bubbled up.
+        const replayCtx = new DummyOrchestrationContextRuntime();
+        const replayInput = new DurableOrchestrationInput(
+            "throw-instance",
+            buildLockHistory(firstTs, [entity], lockRequestId, true),
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            ReplaySchema.V4
+        );
+
+        let caught: unknown;
+        try {
+            await orchestrator(replayInput, replayCtx);
+        } catch (e) {
+            caught = e;
+        }
+        expect(caught, "orchestration should have surfaced the user error").to.exist;
+        const errMsg = (caught as Error).message;
+        const label = "\n\n$OutOfProcData$:";
+        const dataStart = errMsg.indexOf(label) + label.length;
+        const state = JSON.parse(errMsg.substr(dataStart)) as {
+            actions: { actionType: ActionType }[][];
+        };
+        const types = state.actions[0].map((a) => a.actionType);
+        expect(types).to.deep.equal([ActionType.LockEntities, ActionType.ReleaseEntities]);
+    });
+
+    it("no release leaves the action stream as [LockEntities] only (implicit release at orchestration end)", async () => {
+        const orchestrator = createOrchestrator(function* (context) {
+            yield context.df.lock(entity);
+            return "implicit";
+        });
+
+        const firstTs = moment.utc().toDate();
+        const probeCtx = new DummyOrchestrationContextRuntime();
+        const probeInput = new DurableOrchestrationInput(
+            "implicit-instance",
+            buildLockHistory(firstTs, [entity], "x", false),
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            ReplaySchema.V4
+        );
+        const probe = await orchestrator(probeInput, probeCtx);
+        const lockRequestId = (probe.actions[0][0] as LockEntitiesAction).lockRequestId;
+
+        const replayCtx = new DummyOrchestrationContextRuntime();
+        const replayInput = new DurableOrchestrationInput(
+            "implicit-instance",
+            buildLockHistory(firstTs, [entity], lockRequestId, true),
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            ReplaySchema.V4
+        );
+        const result = await orchestrator(replayInput, replayCtx);
+
+        expect(result.isDone).to.equal(true);
+        // No ReleaseEntities action -- the extension cleans up at
+        // orchestration termination. This is the documented safety net.
+        const types = result.actions[0].map((a: { actionType: ActionType }) => a.actionType);
+        expect(types).to.deep.equal([ActionType.LockEntities]);
+    });
+});

--- a/test/integration/critical-sections-spec.ts
+++ b/test/integration/critical-sections-spec.ts
@@ -43,6 +43,19 @@ function newContext(
     return { ctx, executor };
 }
 
+// -----------------------------------------------------------------------------
+// Critical Sections unit coverage
+//
+// Grouped by concern:
+//   - input validation:       arg shape (no-args, empty array, non-EntityId)
+//   - schema-version gating:  lock() requires negotiated OOProc schema >= V4
+//   - action emission:        lock() emits one LockEntitiesAction, sorted+deduped
+//   - isLocked():             section-state reporting before/after lock
+//   - rule enforcement:       nested lock, sub-orchestration, calls to unlocked
+//                             entities, parallel-vs-sequential calls, signals
+//   - re-lock after release:  section reset + re-acquire on the same entity
+//   - DurableLock release:    idempotent release()/[Symbol.dispose]()/frozen locks
+// -----------------------------------------------------------------------------
 describe("Critical Sections (lock / isLocked)", () => {
     describe("input validation", () => {
         it("throws RangeError when called with no arguments", () => {
@@ -170,6 +183,22 @@ describe("Critical Sections (lock / isLocked)", () => {
             );
         });
 
+        // Counterpart to the parallel case above: sequential calls to the same
+        // locked entity ARE allowed. The guard only blocks a *second* call while
+        // the first is still in flight. Once the first call resolves (the
+        // executor invokes `_onEntityCallResolved`, clearing it from
+        // `inFlightEntityCalls`), the next call is permitted.
+        it("allows sequential callEntity to the same locked entity (after the prior call resolves)", () => {
+            const { ctx } = newContext();
+            const a = new EntityId("Account", "A");
+            ctx.lock(a);
+            ctx.callEntity(a, "get"); // first call: now in flight
+            // Simulate the first call resolving, exactly as the executor does
+            // (it passes CallEntityAction.instanceId, which is this scheduler id).
+            ctx._onEntityCallResolved(EntityId.getSchedulerIdFromEntityId(a));
+            expect(() => ctx.callEntity(a, "get")).to.not.throw();
+        });
+
         it("throws on signalEntity to a locked entity", () => {
             const { ctx } = newContext();
             const a = new EntityId("Account", "A");
@@ -184,6 +213,32 @@ describe("Critical Sections (lock / isLocked)", () => {
             const { ctx } = newContext();
             ctx.lock(new EntityId("Account", "A"));
             expect(() => ctx.signalEntity(new EntityId("Other", "X"), "noop")).to.not.throw();
+        });
+    });
+
+    // Lock lifecycle: releasing a section resets `currentLock` to undefined so a
+    // brand-new critical section can be opened afterwards. Confirms the invariant
+    // lock -> work -> release -> lock again succeeds (no NestedSection violation).
+    describe("re-lock after release", () => {
+        it("a second lock() succeeds once the first section is released", () => {
+            const { ctx } = newContext();
+            const a = new EntityId("Account", "A");
+
+            // Acquire the lock.
+            const firstTask = ctx.lock(a) as AtomicTask & { __lockResult?: DurableLock };
+            expect(ctx.isLocked().isLocked).to.equal(true);
+
+            // Do work then release.
+            const firstLock = firstTask.__lockResult as DurableLock;
+            firstLock.release();
+
+            // currentLock is now reset to undefined.
+            expect(ctx.isLocked().isLocked).to.equal(false);
+
+            // Re-lock the same entity: a new critical section opens cleanly.
+            expect(() => ctx.lock(a)).to.not.throw();
+            expect(ctx.isLocked().isLocked).to.equal(true);
+            expect(ctx.isLocked().ownedLocks.map((e) => e.key)).to.deep.equal(["A"]);
         });
     });
 

--- a/test/integration/critical-sections-spec.ts
+++ b/test/integration/critical-sections-spec.ts
@@ -45,6 +45,14 @@ function newContext(
 
 describe("Critical Sections (lock / isLocked)", () => {
     describe("input validation", () => {
+        it("throws RangeError when called with no arguments", () => {
+            const { ctx } = newContext();
+            // Cast through `any` so the runtime guard is exercised; the public
+            // overloads disallow zero-arg calls at the type level, but plain
+            // JS callers can still hit this path.
+            expect(() => (ctx as any).lock()).to.throw(RangeError, /at least one EntityId/);
+        });
+
         it("throws RangeError when called with empty array", () => {
             const { ctx } = newContext();
             expect(() => ctx.lock([])).to.throw(RangeError, /at least one EntityId/);

--- a/types/entity.d.ts
+++ b/types/entity.d.ts
@@ -146,6 +146,43 @@ export declare class EntityId {
 }
 
 /**
+ * Represents an acquired critical section. Returned from
+ * `DurableOrchestrationContext.lock`. Implements `Symbol.dispose` for use
+ * with the `using` statement (TypeScript >=5.2 / Node >=24).
+ */
+export declare class DurableLock {
+    /** The locks held by this critical section, in deterministic order. */
+    readonly ownedLocks: ReadonlyArray<EntityId>;
+
+    /** Release the lock. Idempotent. */
+    release(): void;
+
+    /** Alias for `release()`, invoked by the `using` statement. */
+    [Symbol.dispose](): void;
+}
+
+/**
+ * Snapshot of an orchestration's lock state. Returned by
+ * `DurableOrchestrationContext.isLocked`.
+ */
+export declare class LockState {
+    constructor(isLocked: boolean, ownedLocks: EntityId[]);
+    /** Whether the orchestration currently holds any locks. */
+    readonly isLocked: boolean;
+    /** The locks held by the orchestration. */
+    readonly ownedLocks: EntityId[];
+}
+
+/**
+ * Thrown when an orchestration violates one of the locking rules enforced
+ * inside a critical section (see `DurableOrchestrationContext.lock`).
+ */
+export declare class LockingRulesViolationError extends Error {
+    static readonly code: "LOCKING_RULES_VIOLATION";
+    constructor(message: string, options?: { cause?: unknown });
+}
+
+/**
  * The response returned by DurableClient.readEntityState().
  */
 export declare class EntityStateResponse<T> {

--- a/types/orchestration.d.ts
+++ b/types/orchestration.d.ts
@@ -1,6 +1,6 @@
 import { FunctionOptions, FunctionTrigger, InvocationContext, LogHandler } from "@azure/functions";
 import { RetryOptions, Task, TimerTask, TokenSource } from ".";
-import { EntityId } from "./entity";
+import { EntityId, LockState } from "./entity";
 
 /**
  * Type of a Generator that can be registered as an orchestration
@@ -179,6 +179,42 @@ export declare class DurableOrchestrationContext {
      * @param operationInput (optional) input for the operation.
      */
     signalEntity(entityId: EntityId, operationName: string, operationInput?: unknown): void;
+
+    /**
+     * Atomically acquires locks on one or more entities, forming a critical
+     * section. Yield the returned Task to receive a `DurableLock`.
+     *
+     * The lock set is sorted and deduplicated by entity id, then acquired
+     * in order to prevent deadlock.
+     *
+     * Release options (in recommended order):
+     *   1. `using` syntax (TS >=5.2 or plain JS on Node >=24).
+     *   2. `try/finally` calling `lock.release()`.
+     *   3. Implicit release at orchestration termination.
+     *
+     * Rules enforced inside a critical section (each throws
+     * `LockingRulesViolationError`):
+     *   - Cannot nest critical sections.
+     *   - Cannot invoke sub-orchestrations.
+     *   - `callEntity` only allowed on locked entities; no parallel calls to
+     *     the same locked entity.
+     *   - `signalEntity` only allowed on entities outside the lock set.
+     *
+     * @param entities One or more entities to lock. Supports varargs
+     *   (`lock(a, b)`) and array form (`lock([a, b])`).
+     *
+     * @throws RangeError when called with an empty array.
+     * @throws TypeError when an element is not an EntityId.
+     * @throws LockingRulesViolationError when locking rules are violated.
+     */
+    lock(...entities: EntityId[]): Task;
+    lock(entities: EntityId[]): Task;
+
+    /**
+     * Returns whether the orchestration is currently inside a critical
+     * section and, if so, which entities are locked.
+     */
+    isLocked(): LockState;
 
     /**
      * Schedules an orchestration function named `name` for execution.

--- a/types/orchestration.d.ts
+++ b/types/orchestration.d.ts
@@ -203,7 +203,7 @@ export declare class DurableOrchestrationContext {
      * @param entities One or more entities to lock. Supports varargs
      *   (`lock(a, b)`) and array form (`lock([a, b])`).
      *
-     * @throws RangeError when called with an empty array.
+     * @throws RangeError when called with no arguments or an empty array.
      * @throws TypeError when an element is not an EntityId.
      * @throws LockingRulesViolationError when locking rules are violated.
      */

--- a/types/symbol-dispose.d.ts
+++ b/types/symbol-dispose.d.ts
@@ -1,0 +1,12 @@
+// Ambient declaration of Symbol.dispose for projects targeting < ES2023.
+// TypeScript >=5.2 includes this in lib.esnext.disposable, but the SDK
+// targets ES6 to support older Node versions, so we augment the symbol
+// globally here.
+
+declare global {
+    interface SymbolConstructor {
+        readonly dispose: unique symbol;
+    }
+}
+
+export {};


### PR DESCRIPTION
## Summary

Brings the **critical sections** API to Durable Functions for JS/TS. Orchestrations can now acquire one or more entity locks via `context.df.lock(...)` and perform a sequence of operations on those entities atomically, with no other orchestration able to interleave operations against the same entities. This brings JS to parity with the `LockAsync` API that in .NET.

## What's new

- **`context.df.lock(...entities)`** — acquires locks on one or more entities atomically. Yield the returned task to receive a `DurableLock`.
- **`DurableLock`** — represents the held critical section. Exposes `release()`, `[Symbol.dispose]()`, and `ownedLocks`.
- **`context.df.isLocked()`** — returns a `LockState` indicating whether the orchestration currently holds locks and which entities are locked.
- **`LockingRulesViolationError`** — thrown when an orchestration violates the critical-section rules (nested lock, sub-orchestration call inside a section, calls to non-locked entities, parallel calls to the same locked entity, signaling a locked entity).

## Rules enforced inside a critical section

| Rule | Why |
|------|-----|
| Cannot acquire another lock (no nested sections) | Prevents deadlock; the lock set is fixed for the lifetime of a section |
| Cannot invoke sub-orchestrations | Sub-orchestrations cannot inherit the parent's locks |
| Can only call entities that are in the lock set | Prevents reaching outside the section's atomicity boundary |
| Cannot make two parallel calls to the same locked entity | The entity processes one operation at a time; parallel calls would serialize anyway |
| Cannot signal an entity that is in the lock set | Signals bypass the lock; would break the section's atomicity guarantee |

## Lock Release patterns

JavaScript needs multiple patterns because `using` only landed in TS 5.2 / Node 24 (so older toolchains can't use it), there is no reliable finalizer (so the extension itself plays the safety-net role at orchestration end), and `try/finally` fills the gap for the large segment of customers stuck between those two extremes.

| Pattern | Boilerplate | Exception-safe? | Hold time | Min Node | Min TS |
|---------|-------------|-----------------|-----------|----------|--------|
| `using` | None | ✅ Automatic | Block scope | 24+ | 5.2+ |
| `try/finally` | 3 lines | ✅ If written correctly | Block scope | 18+ | Any |
| Implicit | None | ✅ Always | **Entire orchestration** | 18+ | Any |
| `try/finally` + early `release()` | 4 lines | ✅ + minimal hold time | Until first release | 18+ | Any |

### `using` (TS 5.2+ / Node 24+)
```js
using lock = yield context.df.lock(src, dst);
yield context.df.callEntity(src, "debit", amount);
yield context.df.callEntity(dst, "credit", amount);
// lock auto-released at scope exit, even on throw
```

### `try / finally`
```js
const lock = yield context.df.lock(src, dst);
try {
    yield context.df.callEntity(src, "debit", amount);
    yield context.df.callEntity(dst, "credit", amount);
} finally {
    lock.release();
}
```

### Implicit (no release — extension cleans up at orchestration end)
```js
yield context.df.lock(src, dst);
yield context.df.callEntity(src, "debit", amount);
yield context.df.callEntity(dst, "credit", amount);
// locks held until the orchestration terminates
```

### `try / finally` + early `release()`
```js
const lock = yield context.df.lock(src, dst);
try {
    yield context.df.callEntity(src, "debit", amount);
    yield context.df.callEntity(dst, "credit", amount);
    lock.release();                 // release early — other orchestrations can proceed
    yield context.df.callActivity("sendReceipt", { src, dst, amount });
} finally {
    lock.release();                 // safety net; idempotent if already released
}
```
### Protocol

Requires negotiated OOProc schema **V4+**; older extensions get a clear upgrade error. Reuses the existing `callEntity` replay shape (`RequestMessage` keyed by lock-request GUID, resolved by matching `EventRaised`) — no new history event type.

### Rule enforcement

Inside a section, the worker throws `LockingRulesViolationError` for: nested `lock(...)`, `callSubOrchestrator(...)`, `callEntity(...)` to an unlocked entity, parallel `callEntity(...)` to the same locked entity, and `signalEntity(...)` to a locked entity.

### Release semantics

`release()` is idempotent. `[Symbol.dispose]()` aliases `release()`. Implicit release at orchestration end is handled by the extension.

### Changes

16 files, +1166 / −14:

- **Actions:** `LockEntitiesAction`, `ReleaseEntitiesAction`
- **Error:** `LockingRulesViolationError`
- **Lock primitive:** `DurableLock` (with `Symbol.dispose` polyfill for Node <20)
- **Context:** `lock`, `isLocked`, rule enforcement in `DurableOrchestrationContext`
- **Executor:** lock-action translation and response handling in `TaskOrchestrationExecutor`
- **Schema:** added `V4` to `ReplaySchema`
- **Public types** and `index.ts` exports
- **Samples:** JS try/finally, JS `using`, TS transfer-entities
- **Tests:** 25 new tests in `test/integration/critical-sections-spec.ts`

### Tests

`npm test` — **262 passing**, 2 pending (pre-existing), 0 failing. Covers input validation, schema gating, action emission, `isLocked()` state, rule enforcement, replay integration, and release-pattern parity (`release()`, `using`, `try/finally`, double-release, implicit-on-end).