### PR TITLE
Add getActivityInvocationInfo and getInstanceRetryHistory helpers for activity retry visibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { EntityStateResponse } from "./entities/EntityStateResponse";
 import { OrchestrationRuntimeStatus } from "./orchestrations/OrchestrationRuntimeStatus";
 import { RetryOptions } from "./RetryOptions";
 import { getClient } from "./durableClient/getClient";
+import { getActivityInvocationInfo, getInstanceRetryHistory } from "./retryVisibility";
 
 export * as app from "./app";
 export * as trigger from "./trigger";
@@ -14,6 +15,8 @@ export {
     EntityId,
     EntityStateResponse,
     getClient,
+    getActivityInvocationInfo,
+    getInstanceRetryHistory,
     ManagedIdentityTokenSource,
     OrchestrationRuntimeStatus,
     RetryOptions,

--- a/src/orchestrations/DurableOrchestrationStatus.ts
+++ b/src/orchestrations/DurableOrchestrationStatus.ts
@@ -30,7 +30,10 @@ export class DurableOrchestrationStatus implements types.DurableOrchestrationSta
         this.output = init.output;
         this.runtimeStatus = init.runtimeStatus as OrchestrationRuntimeStatus;
         this.customStatus = init.customStatus;
-        this.history = init.history;
+        // The Functions extension HTTP RPC layer emits the history array under
+        // the key `historyEvents` (per its response-formatting code), while
+        // raw DTFx-style management APIs use `history`. Accept either.
+        this.history = init.history ?? init.historyEvents;
     }
 
     private isDurableOrchestrationStatusInit(obj: unknown): obj is DurableOrchestrationStatusInit {
@@ -59,4 +62,6 @@ interface DurableOrchestrationStatusInit {
     runtimeStatus: string;
     customStatus?: unknown;
     history?: Array<unknown>;
+    /** Alternate key used by the Functions extension HTTP RPC response. */
+    historyEvents?: Array<unknown>;
 }

--- a/src/orchestrations/DurableOrchestrationStatus.ts
+++ b/src/orchestrations/DurableOrchestrationStatus.ts
@@ -30,9 +30,8 @@ export class DurableOrchestrationStatus implements types.DurableOrchestrationSta
         this.output = init.output;
         this.runtimeStatus = init.runtimeStatus as OrchestrationRuntimeStatus;
         this.customStatus = init.customStatus;
-        // The HTTP RPC status response emits the history array under the key
-        // `historyEvents`, while raw DTFx-style management APIs use `history`.
-        // Accept either.
+        // Some status responses emit the history array under the key
+        // `historyEvents` instead of `history`. Accept either.
         this.history = init.history ?? init.historyEvents;
     }
 
@@ -62,6 +61,6 @@ interface DurableOrchestrationStatusInit {
     runtimeStatus: string;
     customStatus?: unknown;
     history?: Array<unknown>;
-    /** Alternate key used by the HTTP RPC status response. */
+    /** Alternate key some status responses use for the history array. */
     historyEvents?: Array<unknown>;
 }

--- a/src/orchestrations/DurableOrchestrationStatus.ts
+++ b/src/orchestrations/DurableOrchestrationStatus.ts
@@ -30,9 +30,9 @@ export class DurableOrchestrationStatus implements types.DurableOrchestrationSta
         this.output = init.output;
         this.runtimeStatus = init.runtimeStatus as OrchestrationRuntimeStatus;
         this.customStatus = init.customStatus;
-        // The Functions extension HTTP RPC layer emits the history array under
-        // the key `historyEvents` (per its response-formatting code), while
-        // raw DTFx-style management APIs use `history`. Accept either.
+        // The HTTP RPC status response emits the history array under the key
+        // `historyEvents`, while raw DTFx-style management APIs use `history`.
+        // Accept either.
         this.history = init.history ?? init.historyEvents;
     }
 
@@ -62,6 +62,6 @@ interface DurableOrchestrationStatusInit {
     runtimeStatus: string;
     customStatus?: unknown;
     history?: Array<unknown>;
-    /** Alternate key used by the Functions extension HTTP RPC response. */
+    /** Alternate key used by the HTTP RPC status response. */
     historyEvents?: Array<unknown>;
 }

--- a/src/retryVisibility.ts
+++ b/src/retryVisibility.ts
@@ -178,22 +178,33 @@ function makeUnavailable(): ActivityInvocationInfo {
 // getInstanceRetryHistory — client-side helper.
 // ---------------------------------------------------------------------------
 
-/** Minimal shape of getStatus payload we depend on. */
+/** Minimal shape of getStatus payload we depend on.
+ *  The extension's HTTP RPC layer returns history under the key `historyEvents`
+ *  (per host-side post-processing), while older or alternate transports may use
+ *  `history`. We accept either. */
 interface DurableClientLike {
     getStatus(
         instanceId: string,
         options?: { showHistory?: boolean; showInput?: boolean; showHistoryOutput?: boolean }
-    ): Promise<{ history?: Array<unknown> } | undefined>;
+    ): Promise<{ history?: Array<unknown>; historyEvents?: Array<unknown> } | undefined>;
 }
 
 /**
  * Project retry history for an orchestration instance.
  *
- * Calls `client.getStatus(instanceId, {showHistory: true})`, filters history
- * events to `TaskScheduled` entries carrying `dt.retry.*` tags, and joins each
- * to its matching `TaskCompleted` / `TaskFailed` (or marks `"running"` if
- * neither has appeared yet). Returns `undefined` when the instance does not
- * exist (matching the missing-instance contract of `getStatus`).
+ * Calls `client.getStatus(instanceId, {showHistory: true})` and walks the
+ * returned history to identify activity invocations carrying `dt.retry.*` tags.
+ *
+ * **Tag-location compatibility.** Tags are read from two places, in priority order:
+ *   1. `TaskScheduledEvent.Tags` — the canonical source of truth (raw DTFx history).
+ *   2. `TaskCompletedEvent.Tags` / `TaskFailedEvent.Tags` — set by the Functions
+ *      extension's `AddScheduledEventDataAndAggregate` post-processor, which
+ *      folds TaskScheduled events away and propagates their Tags onto the
+ *      aggregated Completed/Failed event. This is what `DurableClient.getStatus`
+ *      actually returns over the HTTP RPC endpoint.
+ *
+ * Returns `undefined` when the instance does not exist (matching the
+ * missing-instance contract of `getStatus`).
  *
  * **Complexity:** `O(history length)`. Downloads the full history. For
  * long-running instances with very large histories (>10k events), expect
@@ -216,11 +227,21 @@ export async function getInstanceRetryHistory(
         return undefined;
     }
 
-    const events = Array.isArray(status.history) ? status.history : [];
+    // Accept either casing: `history` (raw DTFx-style) or `historyEvents`
+    // (Functions extension HTTP RPC response).
+    const events: Array<unknown> = Array.isArray(status.history)
+        ? status.history
+        : Array.isArray(status.historyEvents)
+        ? status.historyEvents
+        : [];
 
     interface NormalizedEvent {
         readonly eventType: string;
-        readonly taskScheduledId?: number;
+        /** For TaskScheduled events: the event's own EventId (which is what
+         *  TaskCompleted/TaskFailed point back at via TaskScheduledId).
+         *  For TaskCompleted/TaskFailed events: the original TaskScheduledId.
+         *  Unified into one field so the join below is a single set lookup. */
+        readonly scheduledId?: number;
         readonly name?: string;
         readonly tags?: Record<string, string>;
     }
@@ -237,8 +258,21 @@ export async function getInstanceRetryHistory(
         if (typeof eventType !== "string") {
             return undefined;
         }
-        const taskScheduledIdRaw = o["TaskScheduledId"] ?? o["taskScheduledId"];
-        const name = (o["Name"] ?? o["name"]) as string | undefined;
+        // Read the per-event "join key" depending on event type. The join
+        // direction is: TaskCompleted/TaskFailed.TaskScheduledId === TaskScheduled.EventId.
+        // We collapse both into one normalized `scheduledId` field so the
+        // joiner below does not have to know about event-type specifics.
+        const idCandidate =
+            eventType === "TaskScheduled"
+                ? o["EventId"] ?? o["eventId"]
+                : o["TaskScheduledId"] ?? o["taskScheduledId"];
+        // The activity name lives under different keys depending on whether
+        // the response is raw DTFx history (`Name`/`name`) or post-processed
+        // by the extension's HTTP RPC layer (`FunctionName`/`functionName` —
+        // moved over by AddScheduledEventDataAndAggregate).
+        const name = (o["Name"] ?? o["name"] ?? o["FunctionName"] ?? o["functionName"]) as
+            | string
+            | undefined;
         const tagsRaw = o["Tags"] ?? o["tags"];
         const tags =
             tagsRaw && typeof tagsRaw === "object"
@@ -247,8 +281,7 @@ export async function getInstanceRetryHistory(
 
         return {
             eventType,
-            taskScheduledId:
-                typeof taskScheduledIdRaw === "number" ? taskScheduledIdRaw : undefined,
+            scheduledId: typeof idCandidate === "number" ? idCandidate : undefined,
             name,
             tags,
         };
@@ -262,20 +295,24 @@ export async function getInstanceRetryHistory(
         }
     }
 
-    // Index TaskCompleted / TaskFailed by their TaskScheduledId for the join.
+    // Index TaskCompleted / TaskFailed by their TaskScheduledId (now stored in
+    // scheduledId after normalization) for the join below.
     const completed = new Set<number>();
     const failed = new Set<number>();
     for (const e of normalized) {
-        if (e.taskScheduledId === undefined) continue;
-        if (e.eventType === "TaskCompleted") completed.add(e.taskScheduledId);
-        else if (e.eventType === "TaskFailed") failed.add(e.taskScheduledId);
+        if (e.scheduledId === undefined) continue;
+        if (e.eventType === "TaskCompleted") completed.add(e.scheduledId);
+        else if (e.eventType === "TaskFailed") failed.add(e.scheduledId);
     }
 
     const attempts: ActivityRetryRecord[] = [];
     let retryAttemptCount = 0;
     let retryMaxAttemptsReached = false;
     let sawAnyTaskScheduled = false;
+    let sawAnyAggregated = false;
 
+    // Path A: raw DTFx-style history with TaskScheduled events that still carry
+    // Tags. This is what direct backend history APIs would return.
     for (const e of normalized) {
         if (e.eventType !== "TaskScheduled") continue;
         sawAnyTaskScheduled = true;
@@ -294,15 +331,9 @@ export async function getInstanceRetryHistory(
             continue;
         }
 
-        const id = e.taskScheduledId ?? -1;
-        // For TaskScheduled events the id is the event's own EventId, not TaskScheduledId.
-        // Pull EventId as a fallback.
-        const scheduledId =
-            id >= 0
-                ? id
-                : typeof ((e as unknown) as { EventId?: number }).EventId === "number"
-                ? ((e as unknown) as { EventId: number }).EventId
-                : -1;
+        // For TaskScheduled events, scheduledId is the event's own EventId,
+        // which is the join key TaskCompleted/TaskFailed events reference.
+        const scheduledId = e.scheduledId ?? -1;
 
         const isMax = attempt === maxAttempts;
         let recordStatus: "running" | "completed" | "failed" = "running";
@@ -322,14 +353,57 @@ export async function getInstanceRetryHistory(
         if (isMax && recordStatus === "failed") retryMaxAttemptsReached = true;
     }
 
+    // Path B: Functions extension HTTP RPC response shape — TaskScheduled events
+    // are folded away by AddScheduledEventDataAndAggregate and their Tags are
+    // propagated onto the aggregated TaskCompleted / TaskFailed event. Only run
+    // when Path A produced nothing (i.e. no raw TaskScheduled events were
+    // present in the response) to avoid double-counting on hybrid shapes.
+    if (attempts.length === 0) {
+        for (const e of normalized) {
+            if (e.eventType !== "TaskCompleted" && e.eventType !== "TaskFailed") continue;
+
+            const tags = e.tags;
+            if (!tags) continue;
+
+            const attempt = parsePositiveInt(tags[HISTORY_TAG_ATTEMPT]);
+            const maxAttempts = parsePositiveInt(tags[HISTORY_TAG_MAX_ATTEMPTS]);
+            if (
+                attempt === undefined ||
+                maxAttempts === undefined ||
+                attempt < 1 ||
+                maxAttempts < attempt
+            ) {
+                continue;
+            }
+
+            sawAnyAggregated = true;
+            const isMax = attempt === maxAttempts;
+            const recordStatus = e.eventType === "TaskCompleted" ? "completed" : "failed";
+
+            attempts.push({
+                // For aggregated events, the FunctionName (set by the
+                // extension's post-processor) is the activity name source.
+                activityName: e.name ?? "",
+                taskScheduledId: e.scheduledId ?? -1,
+                attempt,
+                maxAttempts,
+                isMaxAttempt: isMax,
+                status: recordStatus,
+            });
+
+            if (attempt > 1) retryAttemptCount++;
+            if (isMax && recordStatus === "failed") retryMaxAttemptsReached = true;
+        }
+    }
+
     // If we saw TaskScheduled events but none carried retry tags, the backend
     // likely stripped them at persistence (or no activities used retry policy).
     // We can't distinguish those two cases with the data available here — the
     // safer choice is to report metadataAvailable=true (we successfully fetched
     // history) and let the caller infer "no retries" from the empty array.
     // metadataAvailable=false is reserved for the case where getStatus itself
-    // gave us nothing usable.
-    const retryMetadataAvailable = sawAnyTaskScheduled;
+    // gave us nothing usable. Path B also counts toward metadata-available.
+    const retryMetadataAvailable = sawAnyTaskScheduled || sawAnyAggregated;
 
     return {
         instanceId,

--- a/src/retryVisibility.ts
+++ b/src/retryVisibility.ts
@@ -45,7 +45,7 @@ export interface ActivityInvocationInfo {
      * True when the retry counter has reached the policy's `maxAttempts`
      * (i.e. `attempt === maxAttempts`). False when metadata is unavailable.
      *
-     * ⚠️ This does NOT mean "no further attempts will run." `RetryOptions.handle`
+     * NOTE: This does NOT mean "no further attempts will run." `RetryOptions.handle`
      * may abort the retry loop sooner by rejecting an exception, in which case
      * the actual last execution can have `isMaxAttempt === false`.
      */
@@ -179,15 +179,36 @@ function makeUnavailable(): ActivityInvocationInfo {
 // getInstanceRetryHistory — client-side helper.
 // ---------------------------------------------------------------------------
 
-/** Minimal shape of getStatus payload we depend on.
- *  The extension's HTTP RPC layer returns history under the key `historyEvents`
- *  (per host-side post-processing), while older or alternate transports may use
- *  `history`. We accept either. */
+/** Minimal shape of the getStatus payload we depend on.
+ *  `DurableClient.getStatus` returns a `DurableOrchestrationStatus`, whose
+ *  constructor already normalizes the two possible history keys
+ *  (`history` from raw DTFx-style management APIs and `historyEvents` from the
+ *  HTTP RPC status response) into a single `history` field. We therefore only
+ *  depend on `history` here. */
 interface DurableClientLike {
     getStatus(
         instanceId: string,
         options?: { showHistory?: boolean; showInput?: boolean; showHistoryOutput?: boolean }
-    ): Promise<{ history?: Array<unknown>; historyEvents?: Array<unknown> } | undefined>;
+    ): Promise<{ history?: Array<unknown> } | undefined>;
+}
+
+/**
+ * Detects the "instance does not exist" signal from a thrown `getStatus` error.
+ *
+ * `DurableClient.getStatus` does not return `undefined` for a missing instance —
+ * it throws when the extension replies with HTTP 404. We recover that single case
+ * and map it back to the documented "missing instance" contract (return
+ * `undefined`), while letting every other error (e.g. HTTP 500) propagate.
+ */
+function isInstanceNotFoundError(error: unknown): boolean {
+    if (typeof error !== "object" || error === null) {
+        return false;
+    }
+    const e = error as { status?: unknown; statusCode?: unknown; message?: unknown };
+    if (e.status === 404 || e.statusCode === 404) {
+        return true;
+    }
+    return typeof e.message === "string" && /HTTP 404 response/.test(e.message);
 }
 
 /**
@@ -204,8 +225,9 @@ interface DurableClientLike {
  *      aggregated Completed/Failed event. This is what `DurableClient.getStatus`
  *      actually returns over the HTTP RPC endpoint.
  *
- * Returns `undefined` when the instance does not exist (matching the
- * missing-instance contract of `getStatus`).
+ * Returns `undefined` when the instance does not exist. `getStatus` signals a
+ * missing instance by throwing (HTTP 404); that throw is caught here and mapped
+ * to `undefined`. All other errors propagate.
  *
  * **Complexity:** `O(history length)`. Downloads the full history. For
  * long-running instances with very large histories (>10k events), expect
@@ -224,18 +246,26 @@ export async function getInstanceRetryHistory(
     client: DurableClientLike,
     instanceId: string
 ): Promise<InstanceRetryHistory | undefined> {
-    const status = await client.getStatus(instanceId, { showHistory: true });
+    let status: Awaited<ReturnType<DurableClientLike["getStatus"]>>;
+    try {
+        status = await client.getStatus(instanceId, { showHistory: true });
+    } catch (error) {
+        // getStatus throws (HTTP 404) when the instance does not exist. Map that
+        // to the documented missing-instance contract by returning undefined,
+        // and re-throw anything else so genuine failures are not swallowed.
+        if (isInstanceNotFoundError(error)) {
+            return undefined;
+        }
+        throw error;
+    }
+    // A conforming test double may still return undefined for a missing instance.
     if (!status) {
         return undefined;
     }
 
-    // Accept either casing: `history` (raw DTFx-style) or `historyEvents`
-    // (HTTP RPC status-response shape).
-    const events: Array<unknown> = Array.isArray(status.history)
-        ? status.history
-        : Array.isArray(status.historyEvents)
-        ? status.historyEvents
-        : [];
+    // `DurableOrchestrationStatus` already normalizes the `history`/`historyEvents`
+    // keys into `history`, so we only read from there.
+    const events: Array<unknown> = Array.isArray(status.history) ? status.history : [];
 
     interface NormalizedEvent {
         readonly eventType: string;

--- a/src/retryVisibility.ts
+++ b/src/retryVisibility.ts
@@ -1,0 +1,341 @@
+/**
+ * Native activity retry visibility — JS SDK helpers.
+ *
+ * Two surfaces are exported from this module:
+ *
+ *  - `getActivityInvocationInfo(context)` — read from inside an activity to learn
+ *    the current retry attempt and policy ceiling (Goal #1).
+ *  - `getInstanceRetryHistory(client, instanceId)` — read from outside an orchestration
+ *    to project the retry trail per activity (Goal #4).
+ *
+ * Both helpers share a single strict-decimal parser (see `parsePositiveInt`) to
+ * guarantee identical interpretation of `dt.retry.*` history tags across
+ * activity-side and client-side consumers. The shared parser is exported privately
+ * via `internalParsePositiveInt` for the cross-stack test-vector fixture.
+ *
+ * Design: see `investigations/df-retry-information/design.MD`.
+ */
+
+import type { InvocationContext } from "@azure/functions";
+
+// ---------------------------------------------------------------------------
+// Trigger metadata key constants — must match the extension's
+// RetryMetadataConstants (camelCase, `durabletask.` prefix). Frozen at v1.
+// ---------------------------------------------------------------------------
+const TRIGGER_KEY_ATTEMPT = "durabletask.attempt";
+const TRIGGER_KEY_MAX_ATTEMPTS = "durabletask.maxAttempts";
+const TRIGGER_KEY_IS_MAX_ATTEMPT = "durabletask.isMaxAttempt";
+
+// History tag keys — must match DTFx core's RetryTags.cs. Frozen at v1.
+const HISTORY_TAG_ATTEMPT = "dt.retry.attempt";
+const HISTORY_TAG_MAX_ATTEMPTS = "dt.retry.maxAttempts";
+
+// ---------------------------------------------------------------------------
+// Public types — shipped via types/activity.d.ts and types/durableClient.d.ts.
+// ---------------------------------------------------------------------------
+
+export interface ActivityInvocationInfo {
+    /** 1-based attempt counter; defaults to 1 when metadata is unavailable. */
+    readonly attempt: number;
+    /** Policy ceiling (the `maxAttempts` value the customer passed to `RetryOptions`);
+     *  defaults to 1 when metadata is unavailable. */
+    readonly maxAttempts: number;
+    /**
+     * True when the retry counter has reached the policy's `maxAttempts`
+     * (i.e. `attempt === maxAttempts`). False when metadata is unavailable.
+     *
+     * ⚠️ This does NOT mean "no further attempts will run." `RetryOptions.handle`
+     * may abort the retry loop sooner by rejecting an exception, in which case
+     * the actual last execution can have `isMaxAttempt === false`.
+     */
+    readonly isMaxAttempt: boolean;
+    /**
+     * False when retry metadata could not be recovered (no retry policy in use,
+     * or backend does not roundtrip Tags). The only safe way to distinguish a
+     * genuine first attempt from missing metadata.
+     */
+    readonly metadataAvailable: boolean;
+}
+
+export interface ActivityRetryRecord {
+    readonly activityName: string;
+    readonly taskScheduledId: number;
+    readonly attempt: number;
+    readonly maxAttempts: number;
+    readonly isMaxAttempt: boolean;
+    readonly status: "running" | "completed" | "failed";
+}
+
+export interface InstanceRetryHistory {
+    readonly instanceId: string;
+    /** All activity scheduling events that carried retry tags, in history order. */
+    readonly attempts: ActivityRetryRecord[];
+    /** Same aggregate semantics as the orchestration-span attribute:
+     *  count of TaskScheduledEvents with attempt > 1. */
+    readonly retryAttemptCount: number;
+    /** True iff at least one retried activity has a TaskFailed for an
+     *  attempt where attempt === maxAttempts. */
+    readonly retryMaxAttemptsReached: boolean;
+    /**
+     * True when retry metadata for this instance is available and the counts
+     * above are trustworthy. False when retry metadata could not be recovered
+     * (currently for backends that don't roundtrip TaskScheduledEvent.Tags —
+     * Azure Storage, MSSQL, Netherite in v1).
+     */
+    readonly retryMetadataAvailable: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Parser — strict-decimal positive integer. Used by both helpers.
+// ---------------------------------------------------------------------------
+
+/**
+ * Strict decimal parser. Returns the integer when input is a non-empty string
+ * matching `^[1-9][0-9]*$` (or `"0"`); returns `undefined` otherwise.
+ * Matches `int.TryParse(s, NumberStyles.None, CultureInfo.InvariantCulture)`
+ * semantics on the extension side. No whitespace, signs, hex, or scientific
+ * notation. ASCII decimal only.
+ */
+function parsePositiveInt(raw: unknown): number | undefined {
+    if (typeof raw === "number" && Number.isInteger(raw) && raw >= 0) {
+        return raw;
+    }
+    if (typeof raw !== "string" || raw.length === 0) {
+        return undefined;
+    }
+    // Strict regex: leading zeros only allowed for "0"; otherwise must start with 1-9.
+    if (!/^(0|[1-9][0-9]*)$/.test(raw)) {
+        return undefined;
+    }
+    const n = Number(raw);
+    // Guard against any number that didn't round-trip cleanly.
+    if (!Number.isInteger(n) || n < 0) {
+        return undefined;
+    }
+    return n;
+}
+
+/** Internal test hook — exported under a deliberately-ugly name for use by
+ *  the cross-stack test-vector fixture. NOT part of the public API. */
+export const __internalParsePositiveInt = parsePositiveInt;
+
+// ---------------------------------------------------------------------------
+// getActivityInvocationInfo — activity-side helper.
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the current retry attempt information for an activity invocation.
+ *
+ * Reads three keys from `context.triggerMetadata`:
+ *  - `durabletask.attempt`
+ *  - `durabletask.maxAttempts`
+ *  - `durabletask.isMaxAttempt`
+ *
+ * When any required key is missing or fails strict-decimal parsing, returns a
+ * fallback shape with `metadataAvailable: false`. The `metadataAvailable` flag
+ * is the ONLY safe way to distinguish a genuine first attempt from missing
+ * metadata — `info.attempt === 1` is true in both cases.
+ *
+ * @example
+ *   const info = getActivityInvocationInfo(context);
+ *   if (info.metadataAvailable && info.attempt > 1) {
+ *       context.log(`retry attempt ${info.attempt} of ${info.maxAttempts}`);
+ *   }
+ */
+export function getActivityInvocationInfo(context: InvocationContext): ActivityInvocationInfo {
+    const meta = ((context as unknown) as { triggerMetadata?: Record<string, unknown> })
+        .triggerMetadata;
+    if (!meta) {
+        return makeUnavailable();
+    }
+
+    const attempt = parsePositiveInt(meta[TRIGGER_KEY_ATTEMPT]);
+    const maxAttempts = parsePositiveInt(meta[TRIGGER_KEY_MAX_ATTEMPTS]);
+
+    if (
+        attempt === undefined ||
+        maxAttempts === undefined ||
+        attempt < 1 ||
+        maxAttempts < attempt
+    ) {
+        return makeUnavailable();
+    }
+
+    // Prefer the precomputed boolean from the extension when present (saves the
+    // round-trip and lets future telemetry distinguish Handle()-aborted cases).
+    const isMaxAttemptRaw = meta[TRIGGER_KEY_IS_MAX_ATTEMPT];
+    const isMaxAttempt =
+        typeof isMaxAttemptRaw === "boolean" ? isMaxAttemptRaw : attempt === maxAttempts;
+
+    return { attempt, maxAttempts, isMaxAttempt, metadataAvailable: true };
+}
+
+function makeUnavailable(): ActivityInvocationInfo {
+    return { attempt: 1, maxAttempts: 1, isMaxAttempt: false, metadataAvailable: false };
+}
+
+// ---------------------------------------------------------------------------
+// getInstanceRetryHistory — client-side helper.
+// ---------------------------------------------------------------------------
+
+/** Minimal shape of getStatus payload we depend on. */
+interface DurableClientLike {
+    getStatus(
+        instanceId: string,
+        options?: { showHistory?: boolean; showInput?: boolean; showHistoryOutput?: boolean }
+    ): Promise<{ history?: Array<unknown> } | undefined>;
+}
+
+/**
+ * Project retry history for an orchestration instance.
+ *
+ * Calls `client.getStatus(instanceId, {showHistory: true})`, filters history
+ * events to `TaskScheduled` entries carrying `dt.retry.*` tags, and joins each
+ * to its matching `TaskCompleted` / `TaskFailed` (or marks `"running"` if
+ * neither has appeared yet). Returns `undefined` when the instance does not
+ * exist (matching the missing-instance contract of `getStatus`).
+ *
+ * **Complexity:** `O(history length)`. Downloads the full history. For
+ * long-running instances with very large histories (>10k events), expect
+ * proportional payload size on the underlying `getStatus` call. No pagination in v1.
+ *
+ * **Latency:** polling latency = customer's polling interval. There is no push
+ * notification — for subscribe-style alerts use OTel span attributes instead.
+ *
+ * **Backend dependency:** Backends that don't roundtrip `TaskScheduledEvent.Tags`
+ * (Azure Storage, MSSQL, Netherite in v1) drop retry metadata at persistence.
+ * Use `retryMetadataAvailable` to distinguish "no retries happened" from "we
+ * don't know if retries happened."
+ */
+export async function getInstanceRetryHistory(
+    client: DurableClientLike,
+    instanceId: string
+): Promise<InstanceRetryHistory | undefined> {
+    const status = await client.getStatus(instanceId, { showHistory: true });
+    if (!status) {
+        return undefined;
+    }
+
+    const events = Array.isArray(status.history) ? status.history : [];
+
+    interface NormalizedEvent {
+        readonly eventType: string;
+        readonly taskScheduledId?: number;
+        readonly name?: string;
+        readonly tags?: Record<string, string>;
+    }
+
+    // Property casing on getStatus payload — Spike #2 in the design called for
+    // empirical verification. We defensively accept both Tags/tags and
+    // EventType/eventType etc. Adjust this normalizer once Spike #2 resolves.
+    function normalize(raw: unknown): NormalizedEvent | undefined {
+        if (typeof raw !== "object" || raw === null) {
+            return undefined;
+        }
+        const o = raw as Record<string, unknown>;
+        const eventType = (o["EventType"] ?? o["eventType"]) as string | undefined;
+        if (typeof eventType !== "string") {
+            return undefined;
+        }
+        const taskScheduledIdRaw = o["TaskScheduledId"] ?? o["taskScheduledId"];
+        const name = (o["Name"] ?? o["name"]) as string | undefined;
+        const tagsRaw = o["Tags"] ?? o["tags"];
+        const tags =
+            tagsRaw && typeof tagsRaw === "object"
+                ? (tagsRaw as Record<string, string>)
+                : undefined;
+
+        return {
+            eventType,
+            taskScheduledId:
+                typeof taskScheduledIdRaw === "number" ? taskScheduledIdRaw : undefined,
+            name,
+            tags,
+        };
+    }
+
+    const normalized: NormalizedEvent[] = [];
+    for (const raw of events) {
+        const e = normalize(raw);
+        if (e !== undefined) {
+            normalized.push(e);
+        }
+    }
+
+    // Index TaskCompleted / TaskFailed by their TaskScheduledId for the join.
+    const completed = new Set<number>();
+    const failed = new Set<number>();
+    for (const e of normalized) {
+        if (e.taskScheduledId === undefined) continue;
+        if (e.eventType === "TaskCompleted") completed.add(e.taskScheduledId);
+        else if (e.eventType === "TaskFailed") failed.add(e.taskScheduledId);
+    }
+
+    const attempts: ActivityRetryRecord[] = [];
+    let retryAttemptCount = 0;
+    let retryMaxAttemptsReached = false;
+    let sawAnyTaskScheduled = false;
+
+    for (const e of normalized) {
+        if (e.eventType !== "TaskScheduled") continue;
+        sawAnyTaskScheduled = true;
+
+        const tags = e.tags;
+        if (!tags) continue;
+
+        const attempt = parsePositiveInt(tags[HISTORY_TAG_ATTEMPT]);
+        const maxAttempts = parsePositiveInt(tags[HISTORY_TAG_MAX_ATTEMPTS]);
+        if (
+            attempt === undefined ||
+            maxAttempts === undefined ||
+            attempt < 1 ||
+            maxAttempts < attempt
+        ) {
+            continue;
+        }
+
+        const id = e.taskScheduledId ?? -1;
+        // For TaskScheduled events the id is the event's own EventId, not TaskScheduledId.
+        // Pull EventId as a fallback.
+        const scheduledId =
+            id >= 0
+                ? id
+                : typeof ((e as unknown) as { EventId?: number }).EventId === "number"
+                ? ((e as unknown) as { EventId: number }).EventId
+                : -1;
+
+        const isMax = attempt === maxAttempts;
+        let recordStatus: "running" | "completed" | "failed" = "running";
+        if (completed.has(scheduledId)) recordStatus = "completed";
+        else if (failed.has(scheduledId)) recordStatus = "failed";
+
+        attempts.push({
+            activityName: e.name ?? "",
+            taskScheduledId: scheduledId,
+            attempt,
+            maxAttempts,
+            isMaxAttempt: isMax,
+            status: recordStatus,
+        });
+
+        if (attempt > 1) retryAttemptCount++;
+        if (isMax && recordStatus === "failed") retryMaxAttemptsReached = true;
+    }
+
+    // If we saw TaskScheduled events but none carried retry tags, the backend
+    // likely stripped them at persistence (or no activities used retry policy).
+    // We can't distinguish those two cases with the data available here — the
+    // safer choice is to report metadataAvailable=true (we successfully fetched
+    // history) and let the caller infer "no retries" from the empty array.
+    // metadataAvailable=false is reserved for the case where getStatus itself
+    // gave us nothing usable.
+    const retryMetadataAvailable = sawAnyTaskScheduled;
+
+    return {
+        instanceId,
+        attempts,
+        retryAttemptCount,
+        retryMaxAttemptsReached,
+        retryMetadataAvailable,
+    };
+}

--- a/src/retryVisibility.ts
+++ b/src/retryVisibility.ts
@@ -1,5 +1,6 @@
 /**
- * Native activity retry visibility — JS SDK helpers.
+ * Native activity retry visibility — helpers for inspecting per-attempt
+ * retry metadata recorded on activity history events.
  *
  * Two surfaces are exported from this module:
  *
@@ -12,21 +13,21 @@
  * guarantee identical interpretation of `dt.retry.*` history tags across
  * activity-side and client-side consumers. The shared parser is exported privately
  * via `internalParsePositiveInt` for the cross-stack test-vector fixture.
- *
- * Design: see `investigations/df-retry-information/design.MD`.
  */
 
 import type { InvocationContext } from "@azure/functions";
 
 // ---------------------------------------------------------------------------
-// Trigger metadata key constants — must match the extension's
-// RetryMetadataConstants (camelCase, `durabletask.` prefix). Frozen at v1.
+// Trigger metadata key constants — camelCase, `durabletask.` prefix.
+// These names are part of the cross-stack wire contract and must not change
+// without a coordinated update to every consumer of activity-trigger metadata.
 // ---------------------------------------------------------------------------
 const TRIGGER_KEY_ATTEMPT = "durabletask.attempt";
 const TRIGGER_KEY_MAX_ATTEMPTS = "durabletask.maxAttempts";
 const TRIGGER_KEY_IS_MAX_ATTEMPT = "durabletask.isMaxAttempt";
 
-// History tag keys — must match DTFx core's RetryTags.cs. Frozen at v1.
+// History tag keys — names are part of the cross-stack wire contract and must
+// match every producer / consumer of `TaskScheduledEvent.Tags`.
 const HISTORY_TAG_ATTEMPT = "dt.retry.attempt";
 const HISTORY_TAG_MAX_ATTEMPTS = "dt.retry.maxAttempts";
 
@@ -79,8 +80,8 @@ export interface InstanceRetryHistory {
     /**
      * True when retry metadata for this instance is available and the counts
      * above are trustworthy. False when retry metadata could not be recovered
-     * (currently for backends that don't roundtrip TaskScheduledEvent.Tags —
-     * Azure Storage, MSSQL, Netherite in v1).
+     * — typically when the backend in use does not preserve
+     * `TaskScheduledEvent.Tags` through persistence.
      */
     readonly retryMetadataAvailable: boolean;
 }
@@ -208,13 +209,14 @@ interface DurableClientLike {
  *
  * **Complexity:** `O(history length)`. Downloads the full history. For
  * long-running instances with very large histories (>10k events), expect
- * proportional payload size on the underlying `getStatus` call. No pagination in v1.
+ * proportional payload size on the underlying `getStatus` call — there is
+ * no pagination.
  *
  * **Latency:** polling latency = customer's polling interval. There is no push
  * notification — for subscribe-style alerts use OTel span attributes instead.
  *
- * **Backend dependency:** Backends that don't roundtrip `TaskScheduledEvent.Tags`
- * (Azure Storage, MSSQL, Netherite in v1) drop retry metadata at persistence.
+ * **Backend dependency:** Backends that do not preserve
+ * `TaskScheduledEvent.Tags` through persistence drop retry metadata.
  * Use `retryMetadataAvailable` to distinguish "no retries happened" from "we
  * don't know if retries happened."
  */
@@ -228,7 +230,7 @@ export async function getInstanceRetryHistory(
     }
 
     // Accept either casing: `history` (raw DTFx-style) or `historyEvents`
-    // (Functions extension HTTP RPC response).
+    // (HTTP RPC status-response shape).
     const events: Array<unknown> = Array.isArray(status.history)
         ? status.history
         : Array.isArray(status.historyEvents)
@@ -353,8 +355,8 @@ export async function getInstanceRetryHistory(
         if (isMax && recordStatus === "failed") retryMaxAttemptsReached = true;
     }
 
-    // Path B: Functions extension HTTP RPC response shape — TaskScheduled events
-    // are folded away by AddScheduledEventDataAndAggregate and their Tags are
+    // Path B: HTTP RPC status-response shape — TaskScheduled events
+    // are folded away by the host's response post-processor and their Tags are
     // propagated onto the aggregated TaskCompleted / TaskFailed event. Only run
     // when Path A produced nothing (i.e. no raw TaskScheduled events were
     // present in the response) to avoid double-counting on hybrid shapes.

--- a/src/retryVisibility.ts
+++ b/src/retryVisibility.ts
@@ -2,32 +2,31 @@
  * Native activity retry visibility — helpers for inspecting per-attempt
  * retry metadata recorded on activity history events.
  *
- * Two surfaces are exported from this module:
+ * Two helpers are exported from this module:
  *
  *  - `getActivityInvocationInfo(context)` — read from inside an activity to learn
- *    the current retry attempt and policy ceiling (Goal #1).
+ *    the current retry attempt and policy ceiling.
  *  - `getInstanceRetryHistory(client, instanceId)` — read from outside an orchestration
- *    to project the retry trail per activity (Goal #4).
+ *    to project the retry trail per activity.
  *
- * Both helpers share a single strict-decimal parser (see `parsePositiveInt`) to
- * guarantee identical interpretation of `dt.retry.*` history tags across
- * activity-side and client-side consumers. The shared parser is exported privately
- * via `internalParsePositiveInt` for the cross-stack test-vector fixture.
+ * Both helpers share a single strict-decimal parser (see `parsePositiveInt`) so
+ * that `dt.retry.*` history tags are interpreted identically on the activity side
+ * and the client side.
  */
 
 import type { InvocationContext } from "@azure/functions";
 
 // ---------------------------------------------------------------------------
 // Trigger metadata key constants — camelCase, `durabletask.` prefix.
-// These names are part of the cross-stack wire contract and must not change
-// without a coordinated update to every consumer of activity-trigger metadata.
+// These key names must match the names written to the activity trigger
+// metadata; renaming them here breaks reading that metadata.
 // ---------------------------------------------------------------------------
 const TRIGGER_KEY_ATTEMPT = "durabletask.attempt";
 const TRIGGER_KEY_MAX_ATTEMPTS = "durabletask.maxAttempts";
 const TRIGGER_KEY_IS_MAX_ATTEMPT = "durabletask.isMaxAttempt";
 
-// History tag keys — names are part of the cross-stack wire contract and must
-// match every producer / consumer of `TaskScheduledEvent.Tags`.
+// History tag keys — these key names must match the tag names written to
+// `TaskScheduledEvent.Tags`.
 const HISTORY_TAG_ATTEMPT = "dt.retry.attempt";
 const HISTORY_TAG_MAX_ATTEMPTS = "dt.retry.maxAttempts";
 
@@ -42,12 +41,11 @@ export interface ActivityInvocationInfo {
      *  defaults to 1 when metadata is unavailable. */
     readonly maxAttempts: number;
     /**
-     * True when the retry counter has reached the policy's `maxAttempts`
-     * (i.e. `attempt === maxAttempts`). False when metadata is unavailable.
+     * True when `attempt === maxAttempts`. False when metadata is unavailable.
      *
-     * NOTE: This does NOT mean "no further attempts will run." `RetryOptions.handle`
-     * may abort the retry loop sooner by rejecting an exception, in which case
-     * the actual last execution can have `isMaxAttempt === false`.
+     * This only means the attempt reached the policy's ceiling, not that it was
+     * the last one to run: if `retryTimeoutInMilliseconds` stops retries early,
+     * the final attempt can have `isMaxAttempt === false`.
      */
     readonly isMaxAttempt: boolean;
     /**
@@ -71,8 +69,7 @@ export interface InstanceRetryHistory {
     readonly instanceId: string;
     /** All activity scheduling events that carried retry tags, in history order. */
     readonly attempts: ActivityRetryRecord[];
-    /** Same aggregate semantics as the orchestration-span attribute:
-     *  count of TaskScheduledEvents with attempt > 1. */
+    /** Count of TaskScheduled events with attempt > 1. */
     readonly retryAttemptCount: number;
     /** True iff at least one retried activity has a TaskFailed for an
      *  attempt where attempt === maxAttempts. */
@@ -92,10 +89,8 @@ export interface InstanceRetryHistory {
 
 /**
  * Strict decimal parser. Returns the integer when input is a non-empty string
- * matching `^[1-9][0-9]*$` (or `"0"`); returns `undefined` otherwise.
- * Matches `int.TryParse(s, NumberStyles.None, CultureInfo.InvariantCulture)`
- * semantics on the extension side. No whitespace, signs, hex, or scientific
- * notation. ASCII decimal only.
+ * matching `^[1-9][0-9]*$` (or `"0"`); returns `undefined` otherwise. No
+ * whitespace, signs, hex, or scientific notation. ASCII decimal only.
  */
 function parsePositiveInt(raw: unknown): number | undefined {
     if (typeof raw === "number" && Number.isInteger(raw) && raw >= 0) {
@@ -116,8 +111,8 @@ function parsePositiveInt(raw: unknown): number | undefined {
     return n;
 }
 
-/** Internal test hook — exported under a deliberately-ugly name for use by
- *  the cross-stack test-vector fixture. NOT part of the public API. */
+/** Internal test hook, exported under a deliberately-ugly name. NOT part of
+ *  the public API. */
 export const __internalParsePositiveInt = parsePositiveInt;
 
 // ---------------------------------------------------------------------------
@@ -157,13 +152,14 @@ export function getActivityInvocationInfo(context: InvocationContext): ActivityI
         attempt === undefined ||
         maxAttempts === undefined ||
         attempt < 1 ||
+        maxAttempts < 1 ||
         maxAttempts < attempt
     ) {
         return makeUnavailable();
     }
 
-    // Prefer the precomputed boolean from the extension when present (saves the
-    // round-trip and lets future telemetry distinguish Handle()-aborted cases).
+    // Prefer the precomputed boolean when present; otherwise fall back to
+    // comparing the attempt counter against maxAttempts.
     const isMaxAttemptRaw = meta[TRIGGER_KEY_IS_MAX_ATTEMPT];
     const isMaxAttempt =
         typeof isMaxAttemptRaw === "boolean" ? isMaxAttemptRaw : attempt === maxAttempts;
@@ -181,10 +177,9 @@ function makeUnavailable(): ActivityInvocationInfo {
 
 /** Minimal shape of the getStatus payload we depend on.
  *  `DurableClient.getStatus` returns a `DurableOrchestrationStatus`, whose
- *  constructor already normalizes the two possible history keys
- *  (`history` from raw DTFx-style management APIs and `historyEvents` from the
- *  HTTP RPC status response) into a single `history` field. We therefore only
- *  depend on `history` here. */
+ *  constructor already normalizes the two possible history keys (`history` and
+ *  `historyEvents`) into a single `history` field. We therefore only depend on
+ *  `history` here. */
 interface DurableClientLike {
     getStatus(
         instanceId: string,
@@ -196,7 +191,7 @@ interface DurableClientLike {
  * Detects the "instance does not exist" signal from a thrown `getStatus` error.
  *
  * `DurableClient.getStatus` does not return `undefined` for a missing instance —
- * it throws when the extension replies with HTTP 404. We recover that single case
+ * it throws when the status request returns HTTP 404. We recover that single case
  * and map it back to the documented "missing instance" contract (return
  * `undefined`), while letting every other error (e.g. HTTP 500) propagate.
  */
@@ -218,12 +213,10 @@ function isInstanceNotFoundError(error: unknown): boolean {
  * returned history to identify activity invocations carrying `dt.retry.*` tags.
  *
  * **Tag-location compatibility.** Tags are read from two places, in priority order:
- *   1. `TaskScheduledEvent.Tags` — the canonical source of truth (raw DTFx history).
- *   2. `TaskCompletedEvent.Tags` / `TaskFailedEvent.Tags` — set by the Functions
- *      extension's `AddScheduledEventDataAndAggregate` post-processor, which
- *      folds TaskScheduled events away and propagates their Tags onto the
- *      aggregated Completed/Failed event. This is what `DurableClient.getStatus`
- *      actually returns over the HTTP RPC endpoint.
+ *   1. `TaskScheduledEvent.Tags` — the canonical source of truth in raw history.
+ *   2. `TaskCompletedEvent.Tags` / `TaskFailedEvent.Tags` — some status responses
+ *      fold the TaskScheduled events away and propagate their Tags onto the
+ *      aggregated Completed/Failed event, so we read them there as well.
  *
  * Returns `undefined` when the instance does not exist. `getStatus` signals a
  * missing instance by throwing (HTTP 404); that throw is caught here and mapped
@@ -234,8 +227,8 @@ function isInstanceNotFoundError(error: unknown): boolean {
  * proportional payload size on the underlying `getStatus` call — there is
  * no pagination.
  *
- * **Latency:** polling latency = customer's polling interval. There is no push
- * notification — for subscribe-style alerts use OTel span attributes instead.
+ * **Latency:** polling latency = the caller's polling interval. There is no push
+ * notification.
  *
  * **Backend dependency:** Backends that do not preserve
  * `TaskScheduledEvent.Tags` through persistence drop retry metadata.
@@ -278,9 +271,9 @@ export async function getInstanceRetryHistory(
         readonly tags?: Record<string, string>;
     }
 
-    // Property casing on getStatus payload — Spike #2 in the design called for
-    // empirical verification. We defensively accept both Tags/tags and
-    // EventType/eventType etc. Adjust this normalizer once Spike #2 resolves.
+    // The getStatus payload may use either Pascal-case or camel-case property
+    // names depending on the transport, so we defensively accept both
+    // (Tags/tags, EventType/eventType, etc.).
     function normalize(raw: unknown): NormalizedEvent | undefined {
         if (typeof raw !== "object" || raw === null) {
             return undefined;
@@ -298,10 +291,9 @@ export async function getInstanceRetryHistory(
             eventType === "TaskScheduled"
                 ? o["EventId"] ?? o["eventId"]
                 : o["TaskScheduledId"] ?? o["taskScheduledId"];
-        // The activity name lives under different keys depending on whether
-        // the response is raw DTFx history (`Name`/`name`) or post-processed
-        // by the extension's HTTP RPC layer (`FunctionName`/`functionName` —
-        // moved over by AddScheduledEventDataAndAggregate).
+        // The activity name lives under different keys depending on the
+        // response shape: raw history uses `Name`/`name`, while aggregated
+        // status responses use `FunctionName`/`functionName`.
         const name = (o["Name"] ?? o["name"] ?? o["FunctionName"] ?? o["functionName"]) as
             | string
             | undefined;
@@ -343,8 +335,7 @@ export async function getInstanceRetryHistory(
     let sawAnyTaskScheduled = false;
     let sawAnyAggregated = false;
 
-    // Path A: raw DTFx-style history with TaskScheduled events that still carry
-    // Tags. This is what direct backend history APIs would return.
+    // Path A: raw history where TaskScheduled events still carry their Tags.
     for (const e of normalized) {
         if (e.eventType !== "TaskScheduled") continue;
         sawAnyTaskScheduled = true;
@@ -358,6 +349,7 @@ export async function getInstanceRetryHistory(
             attempt === undefined ||
             maxAttempts === undefined ||
             attempt < 1 ||
+            maxAttempts < 1 ||
             maxAttempts < attempt
         ) {
             continue;
@@ -385,11 +377,11 @@ export async function getInstanceRetryHistory(
         if (isMax && recordStatus === "failed") retryMaxAttemptsReached = true;
     }
 
-    // Path B: HTTP RPC status-response shape — TaskScheduled events
-    // are folded away by the host's response post-processor and their Tags are
-    // propagated onto the aggregated TaskCompleted / TaskFailed event. Only run
-    // when Path A produced nothing (i.e. no raw TaskScheduled events were
-    // present in the response) to avoid double-counting on hybrid shapes.
+    // Path B: aggregated status-response shape — the TaskScheduled events are
+    // folded away and their Tags are propagated onto the aggregated
+    // TaskCompleted / TaskFailed event. Only run when Path A produced nothing
+    // (i.e. no raw TaskScheduled events were present) to avoid double-counting
+    // on hybrid shapes.
     if (attempts.length === 0) {
         for (const e of normalized) {
             if (e.eventType !== "TaskCompleted" && e.eventType !== "TaskFailed") continue;
@@ -403,6 +395,7 @@ export async function getInstanceRetryHistory(
                 attempt === undefined ||
                 maxAttempts === undefined ||
                 attempt < 1 ||
+                maxAttempts < 1 ||
                 maxAttempts < attempt
             ) {
                 continue;
@@ -413,8 +406,8 @@ export async function getInstanceRetryHistory(
             const recordStatus = e.eventType === "TaskCompleted" ? "completed" : "failed";
 
             attempts.push({
-                // For aggregated events, the FunctionName (set by the
-                // extension's post-processor) is the activity name source.
+                // For aggregated events, the FunctionName is the activity name
+                // source.
                 activityName: e.name ?? "",
                 taskScheduledId: e.scheduledId ?? -1,
                 attempt,

--- a/test/unit/retryvisibility-spec.ts
+++ b/test/unit/retryvisibility-spec.ts
@@ -1,0 +1,158 @@
+import chai = require("chai");
+import nock = require("nock");
+import url = require("url");
+import { OrchestrationClientInputData } from "../../src/durableClient/OrchestrationClientInputData";
+import { DurableClient } from "../../src/durableClient/DurableClient";
+import { getInstanceRetryHistory } from "../../src/retryVisibility";
+
+const expect = chai.expect;
+const URL = url.URL;
+
+const externalOrigin = "https://durable.gov";
+const externalBaseUrl = `${externalOrigin}/runtime/webhooks/durableTask`;
+const testRpcOrigin = "http://127.0.0.1:17071";
+const testRpcBaseUrl = `${testRpcOrigin}/durabletask/`;
+const testTaskHubName = "MyTaskHub";
+const testConnectionName = "MyStorageAccount";
+
+// Same binding shape the DurableClient tests use: rpcBaseUrl present so getStatus
+// takes the fast local RPC path that nock can intercept.
+const durableClientBindingInputJson = JSON.stringify({
+    taskHubName: testTaskHubName,
+    creationUrls: {},
+    managementUrls: {
+        id: "INSTANCEID",
+        statusQueryGetUri: `${externalBaseUrl}/instances/INSTANCEID?taskHub=${testTaskHubName}&connection=${testConnectionName}`,
+        sendEventPostUri: `${externalBaseUrl}/instances/INSTANCEID/raiseEvent/{eventName}?taskHub=${testTaskHubName}&connection=${testConnectionName}`,
+        terminatePostUri: `${externalBaseUrl}/instances/INSTANCEID/?taskHub=${testTaskHubName}&connection=${testConnectionName}`,
+        rewindPostUri: `${externalBaseUrl}/instances/INSTANCEID/?taskHub=${testTaskHubName}&connection=${testConnectionName}`,
+        purgeHistoryDeleteUri: `${externalBaseUrl}/instances/INSTANCEID/?taskHub=${testTaskHubName}&connection=${testConnectionName}`,
+        suspendPostUri: `${externalBaseUrl}/instances/INSTANCEID/?taskHub=${testTaskHubName}&connection=${testConnectionName}`,
+        resumePostUri: `${externalBaseUrl}/instances/INSTANCEID/?taskHub=${testTaskHubName}&connection=${testConnectionName}`,
+    },
+    baseUrl: externalBaseUrl,
+    rpcBaseUrl: testRpcBaseUrl,
+});
+
+function makeClient(): DurableClient {
+    const input = JSON.parse(durableClientBindingInputJson) as OrchestrationClientInputData;
+    return new DurableClient(input);
+}
+
+function instanceUrl(instanceId: string): URL {
+    return new URL(`${testRpcOrigin}/durabletask/instances/${instanceId}`);
+}
+
+describe("getInstanceRetryHistory()", () => {
+    before(() => {
+        if (!nock.isActive()) {
+            nock.activate();
+        }
+    });
+
+    after(() => {
+        nock.restore();
+    });
+
+    afterEach(() => {
+        nock.cleanAll();
+    });
+
+    // Regression guard. DurableClient.getStatus signals a missing instance by
+    // THROWING an Error whose message contains "HTTP 404 response" — it does not
+    // return undefined. getInstanceRetryHistory depends on that wording to map a
+    // missing instance back to `undefined`. If the 404 message ever changes, this
+    // test fails, catching a silent regression where a missing instance would
+    // start throwing to callers instead of returning undefined.
+    it("returns undefined when the instance does not exist (HTTP 404)", async () => {
+        const client = makeClient();
+        const instanceId = "missing-instance";
+        const expectedUrl = instanceUrl(instanceId);
+
+        const scope = nock(expectedUrl.origin).get(expectedUrl.pathname).query(true).reply(404);
+
+        const result = await getInstanceRetryHistory(client, instanceId);
+
+        expect(scope.isDone()).to.equal(true);
+        expect(result).to.equal(undefined);
+    });
+
+    // Non-not-found failures must surface to the caller, not be swallowed as
+    // "missing instance".
+    it("propagates non-not-found errors (HTTP 500)", async () => {
+        const client = makeClient();
+        const instanceId = "boom";
+        const expectedUrl = instanceUrl(instanceId);
+
+        const scope = nock(expectedUrl.origin)
+            .get(expectedUrl.pathname)
+            .query(true)
+            .reply(500, { error: "kaboom" });
+
+        let caught: unknown;
+        try {
+            await getInstanceRetryHistory(client, instanceId);
+        } catch (err) {
+            caught = err;
+        }
+
+        expect(scope.isDone()).to.equal(true);
+        expect(caught).to.be.instanceOf(Error);
+        expect((caught as Error).message).to.contain("500");
+    });
+
+    it("projects retry history from history tags", async () => {
+        const client = makeClient();
+        const instanceId = "retried-instance";
+        const expectedUrl = instanceUrl(instanceId);
+
+        const scope = nock(expectedUrl.origin)
+            .get(expectedUrl.pathname)
+            .query(true)
+            .reply(200, {
+                name: "MyOrchestration",
+                instanceId,
+                input: null,
+                output: null,
+                createdTime: "2020-01-01T05:00:00Z",
+                lastUpdatedTime: "2020-01-01T05:05:00Z",
+                runtimeStatus: "Completed",
+                history: [
+                    {
+                        EventType: "TaskScheduled",
+                        EventId: 1,
+                        Name: "FlakyActivity",
+                        Tags: { "dt.retry.attempt": "1", "dt.retry.maxAttempts": "3" },
+                    },
+                    {
+                        EventType: "TaskFailed",
+                        TaskScheduledId: 1,
+                    },
+                    {
+                        EventType: "TaskScheduled",
+                        EventId: 2,
+                        Name: "FlakyActivity",
+                        Tags: { "dt.retry.attempt": "2", "dt.retry.maxAttempts": "3" },
+                    },
+                    {
+                        EventType: "TaskCompleted",
+                        TaskScheduledId: 2,
+                    },
+                ],
+            });
+
+        const result = await getInstanceRetryHistory(client, instanceId);
+
+        expect(scope.isDone()).to.equal(true);
+        if (result === undefined) {
+            throw new Error("expected a retry history result, got undefined");
+        }
+        expect(result.instanceId).to.equal(instanceId);
+        expect(result.retryMetadataAvailable).to.equal(true);
+        expect(result.attempts.length).to.equal(2);
+        // Only the second scheduling (attempt 2) counts as a retry (attempt > 1).
+        expect(result.retryAttemptCount).to.equal(1);
+        // The max attempt (3) never failed, so the max-attempts-reached flag is false.
+        expect(result.retryMaxAttemptsReached).to.equal(false);
+    });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,6 +5,7 @@ export * from "./activity";
 export * from "./durableClient";
 export * from "./entity";
 export * from "./orchestration";
+export * from "./retryVisibility";
 export * from "./task";
 
 export * as app from "./app";

--- a/types/retryVisibility.d.ts
+++ b/types/retryVisibility.d.ts
@@ -1,0 +1,104 @@
+import { InvocationContext } from "@azure/functions";
+import { DurableClient } from "./durableClient";
+
+/**
+ * Per-attempt retry metadata for an activity invocation.
+ * Returned by {@link getActivityInvocationInfo}.
+ */
+export interface ActivityInvocationInfo {
+    /** 1-based attempt counter; defaults to 1 when metadata is unavailable. */
+    readonly attempt: number;
+    /** Policy ceiling (the `maxAttempts` value passed to `RetryOptions`);
+     *  defaults to 1 when metadata is unavailable. */
+    readonly maxAttempts: number;
+    /**
+     * True when the retry counter has reached the policy's `maxAttempts`
+     * (i.e. `attempt === maxAttempts`). False when metadata is unavailable.
+     *
+     * ⚠️ This does NOT mean "no further attempts will run." `RetryOptions.handle`
+     * may abort the retry loop sooner by rejecting an exception, in which case
+     * the actual last execution can have `isMaxAttempt === false`.
+     */
+    readonly isMaxAttempt: boolean;
+    /**
+     * False when retry metadata could not be recovered (no retry policy in use,
+     * or backend does not roundtrip Tags). The only safe way to distinguish a
+     * genuine first attempt from missing metadata.
+     */
+    readonly metadataAvailable: boolean;
+}
+
+/**
+ * One activity invocation record in an instance's projected retry history.
+ * See {@link getInstanceRetryHistory}.
+ */
+export interface ActivityRetryRecord {
+    readonly activityName: string;
+    readonly taskScheduledId: number;
+    readonly attempt: number;
+    readonly maxAttempts: number;
+    readonly isMaxAttempt: boolean;
+    readonly status: "running" | "completed" | "failed";
+}
+
+/**
+ * Projected retry history for an orchestration instance, returned by
+ * {@link getInstanceRetryHistory}.
+ */
+export interface InstanceRetryHistory {
+    readonly instanceId: string;
+    /** All activity scheduling events that carried retry tags, in history order. */
+    readonly attempts: ActivityRetryRecord[];
+    /** Same aggregate semantics as the orchestration-span attribute:
+     *  count of TaskScheduledEvents with attempt > 1. */
+    readonly retryAttemptCount: number;
+    /** True iff at least one retried activity has a TaskFailed for an
+     *  attempt where attempt === maxAttempts. */
+    readonly retryMaxAttemptsReached: boolean;
+    /**
+     * True when retry metadata for this instance is available and the counts
+     * above are trustworthy. False when retry metadata could not be recovered
+     * — currently for backends that don't roundtrip TaskScheduledEvent.Tags
+     * (Azure Storage, MSSQL, Netherite in v1).
+     */
+    readonly retryMetadataAvailable: boolean;
+}
+
+/**
+ * Read the current retry attempt information for an activity invocation.
+ *
+ * When the activity was scheduled with a `RetryOptions` policy AND the backend
+ * preserves `TaskScheduledEvent.Tags` (currently DTS only), returns the parsed
+ * attempt counter, policy ceiling, and an `isMaxAttempt` flag.
+ *
+ * When metadata is unavailable (no retry policy, non-DTS backend, parsing
+ * failure), returns a fallback shape with `metadataAvailable: false`.
+ *
+ * ⚠️ The `metadataAvailable` flag is the ONLY safe way to distinguish a genuine
+ * first attempt from missing metadata. `info.attempt === 1` is true in both
+ * cases.
+ *
+ * @example
+ *   const info = getActivityInvocationInfo(context);
+ *   if (info.metadataAvailable && info.attempt > 1) {
+ *       context.log(`retry attempt ${info.attempt} of ${info.maxAttempts}`);
+ *   }
+ */
+export function getActivityInvocationInfo(context: InvocationContext): ActivityInvocationInfo;
+
+/**
+ * Project retry history for an orchestration instance.
+ *
+ * Returns `undefined` when the instance does not exist (matches `DurableClient.getStatus`).
+ * Walks the orchestration's history (downloaded via `getStatus`, O(history length)),
+ * filters to `TaskScheduled` events carrying `dt.retry.*` tags, joins each to its
+ * matching `TaskCompleted` / `TaskFailed` (or marks `"running"` if neither has
+ * appeared yet), and returns the projection.
+ *
+ * Use `retryMetadataAvailable` to distinguish "no retries happened" from "we
+ * don't know if retries happened."
+ */
+export function getInstanceRetryHistory(
+    client: DurableClient,
+    instanceId: string
+): Promise<InstanceRetryHistory | undefined>;

--- a/types/retryVisibility.d.ts
+++ b/types/retryVisibility.d.ts
@@ -15,7 +15,7 @@ export interface ActivityInvocationInfo {
      * True when the retry counter has reached the policy's `maxAttempts`
      * (i.e. `attempt === maxAttempts`). False when metadata is unavailable.
      *
-     * ⚠️ This does NOT mean "no further attempts will run." `RetryOptions.handle`
+     * NOTE: This does NOT mean "no further attempts will run." `RetryOptions.handle`
      * may abort the retry loop sooner by rejecting an exception, in which case
      * the actual last execution can have `isMaxAttempt === false`.
      */
@@ -74,7 +74,7 @@ export interface InstanceRetryHistory {
  * When metadata is unavailable (no retry policy, non-DTS backend, parsing
  * failure), returns a fallback shape with `metadataAvailable: false`.
  *
- * ⚠️ The `metadataAvailable` flag is the ONLY safe way to distinguish a genuine
+ * NOTE: The `metadataAvailable` flag is the ONLY safe way to distinguish a genuine
  * first attempt from missing metadata. `info.attempt === 1` is true in both
  * cases.
  *

--- a/types/retryVisibility.d.ts
+++ b/types/retryVisibility.d.ts
@@ -58,8 +58,8 @@ export interface InstanceRetryHistory {
     /**
      * True when retry metadata for this instance is available and the counts
      * above are trustworthy. False when retry metadata could not be recovered
-     * — currently for backends that don't roundtrip TaskScheduledEvent.Tags
-     * (Azure Storage, MSSQL, Netherite in v1).
+     * — typically when the backend in use does not preserve
+     * `TaskScheduledEvent.Tags` through persistence.
      */
     readonly retryMetadataAvailable: boolean;
 }

--- a/types/retryVisibility.d.ts
+++ b/types/retryVisibility.d.ts
@@ -12,12 +12,11 @@ export interface ActivityInvocationInfo {
      *  defaults to 1 when metadata is unavailable. */
     readonly maxAttempts: number;
     /**
-     * True when the retry counter has reached the policy's `maxAttempts`
-     * (i.e. `attempt === maxAttempts`). False when metadata is unavailable.
+     * True when `attempt === maxAttempts`. False when metadata is unavailable.
      *
-     * NOTE: This does NOT mean "no further attempts will run." `RetryOptions.handle`
-     * may abort the retry loop sooner by rejecting an exception, in which case
-     * the actual last execution can have `isMaxAttempt === false`.
+     * This only means the attempt reached the policy's ceiling, not that it was
+     * the last one to run: if `retryTimeoutInMilliseconds` stops retries early,
+     * the final attempt can have `isMaxAttempt === false`.
      */
     readonly isMaxAttempt: boolean;
     /**
@@ -49,8 +48,7 @@ export interface InstanceRetryHistory {
     readonly instanceId: string;
     /** All activity scheduling events that carried retry tags, in history order. */
     readonly attempts: ActivityRetryRecord[];
-    /** Same aggregate semantics as the orchestration-span attribute:
-     *  count of TaskScheduledEvents with attempt > 1. */
+    /** Count of TaskScheduled events with attempt > 1. */
     readonly retryAttemptCount: number;
     /** True iff at least one retried activity has a TaskFailed for an
      *  attempt where attempt === maxAttempts. */
@@ -68,11 +66,12 @@ export interface InstanceRetryHistory {
  * Read the current retry attempt information for an activity invocation.
  *
  * When the activity was scheduled with a `RetryOptions` policy AND the backend
- * preserves `TaskScheduledEvent.Tags` (currently DTS only), returns the parsed
- * attempt counter, policy ceiling, and an `isMaxAttempt` flag.
+ * preserves `TaskScheduledEvent.Tags`, returns the parsed attempt counter,
+ * policy ceiling, and an `isMaxAttempt` flag.
  *
- * When metadata is unavailable (no retry policy, non-DTS backend, parsing
- * failure), returns a fallback shape with `metadataAvailable: false`.
+ * When metadata is unavailable (no retry policy, a backend that does not
+ * preserve the tags, or parsing failure), returns a fallback shape with
+ * `metadataAvailable: false`.
  *
  * NOTE: The `metadataAvailable` flag is the ONLY safe way to distinguish a genuine
  * first attempt from missing metadata. `info.attempt === 1` is true in both


### PR DESCRIPTION
## Summary

Two new public helpers for the activity retry visibility feature.

### `getActivityInvocationInfo(context)` — activity-side

Reads `durabletask.attempt` / `maxAttempts` / `isMaxAttempt` trigger
metadata exposed on the activity trigger binding for activities scheduled
with a `RetryOptions` policy.

```ts
interface ActivityInvocationInfo {
    readonly attempt: number;       // counter starts at 1; defaults to 1 when unavailable
    readonly maxAttempts: number;   // defaults to 1 when unavailable
    readonly isMaxAttempt: boolean;
    readonly metadataAvailable: boolean;  // ONLY reliable "is this real?" check
}
```

`metadataAvailable: false` is the only safe way to distinguish a genuine
first attempt from missing metadata — `info.attempt === 1` is true in both
cases.

### `getInstanceRetryHistory(client, instanceId)` — client-side

Projects per-activity retry history from `client.getStatus(instanceId,
{showHistory: true})`. Returns `undefined` if the instance does not exist.

```ts
interface InstanceRetryHistory {
    readonly instanceId: string;
    readonly attempts: ActivityRetryRecord[];
    readonly retryAttemptCount: number;          // attempts > 1
    readonly retryMaxAttemptsReached: boolean;
    readonly retryMetadataAvailable: boolean;
}
```

## Implementation notes

- **Two projection paths**:
  - *Path A* — raw DTFx history: walks `TaskScheduledEvent.Tags`, joins to
    `TaskCompleted`/`TaskFailed` via `EventId` ↔ `TaskScheduledId`.
  - *Path B* — the HTTP RPC status response shape: `TaskScheduled` events
    are folded away by the host post-processor, with `Tags` propagated onto
    the aggregated event. Path B walks those aggregated events directly
    when Path A finds nothing.
- Strict-decimal parser shared by both helpers — matches the producer-side
  `int.TryParse(s, NumberStyles.None, CultureInfo.InvariantCulture)`
  contract.
- `DurableOrchestrationStatus` constructor now reads
  `init.history ?? init.historyEvents` — the HTTP RPC status response uses
  `historyEvents`, programmatic status APIs use `history`.

## Files

- `src/retryVisibility.ts` (new) — both helpers + shared parser.
- `src/orchestrations/DurableOrchestrationStatus.ts` — accept either
  history key.
- `src/index.ts` — export the two new helpers.
- `types/retryVisibility.d.ts` (new) + `types/index.d.ts` — public typings.

## Compatibility

- Both helpers are net new — no API breaks.
- Activities without a retry policy see `metadataAvailable: false`.
- `DurableOrchestrationStatus` constructor change is backward-compatible
  (`history` key still wins when present).