### PR TITLE
Fix orchestrations stalling when external events arrive before `waitForExternalEvent` is registered

### DIFF
--- a/src/orchestrations/TaskOrchestrationExecutor.ts
+++ b/src/orchestrations/TaskOrchestrationExecutor.ts
@@ -511,9 +511,10 @@ export class TaskOrchestrationExecutor {
 
             // If the task's ID can be found in deferred tasks, then we have already processed
             // a history event that contains a result for this task. Drain one entry from the
-            // per-ID FIFO queue so that the user-code may proceed executing. Multiple queued
-            // entries (e.g. two same-named external events that both arrived early) will be
-            // consumed across successive `trackOpenTask` registrations.
+            // per-ID FIFO queue so that the user-code may proceed executing. The drain may
+            // synchronously complete this task (and propagate to its parent); `tryResumingUserCode`
+            // then re-yields and registers the next waiter within the same execution, which is how
+            // multiple same-named early events are delivered to successive waits in one replay.
             const taskId = task.id as number | string;
             const deferredQueue = this.deferredTasks[taskId];
             if (deferredQueue !== undefined && deferredQueue.length > 0) {

--- a/src/orchestrations/TaskOrchestrationExecutor.ts
+++ b/src/orchestrations/TaskOrchestrationExecutor.ts
@@ -508,11 +508,12 @@ export class TaskOrchestrationExecutor {
             // per-ID FIFO queue so that the user-code may proceed executing. Multiple queued
             // entries (e.g. two same-named external events that both arrived early) will be
             // consumed across successive `trackOpenTask` registrations.
-            const deferredQueue = this.deferredTasks[task.id];
+            const taskId = task.id as number | string;
+            const deferredQueue = this.deferredTasks[taskId];
             if (deferredQueue !== undefined && deferredQueue.length > 0) {
-                const taskUpdateAction = deferredQueue.shift() as () => void;
+                const taskUpdateAction = deferredQueue.shift()!;
                 if (deferredQueue.length === 0) {
-                    delete this.deferredTasks[task.id];
+                    delete this.deferredTasks[taskId];
                 }
                 taskUpdateAction();
             }

--- a/src/orchestrations/TaskOrchestrationExecutor.ts
+++ b/src/orchestrations/TaskOrchestrationExecutor.ts
@@ -68,7 +68,10 @@ export class TaskOrchestrationExecutor {
         this.openTasks = {};
         this.openEvents = {};
         this.actions = [];
-        this.deferredTasks = {};
+        // Use a prototype-less object so that string keys which happen to match
+        // members of `Object.prototype` (e.g. an external event named "toString")
+        // do not collide with inherited properties.
+        this.deferredTasks = Object.create(null);
 
         this.output = undefined;
         this.exception = undefined;

--- a/src/orchestrations/TaskOrchestrationExecutor.ts
+++ b/src/orchestrations/TaskOrchestrationExecutor.ts
@@ -65,15 +65,12 @@ export class TaskOrchestrationExecutor {
 
         this.sequenceNumber = 0;
         this.willContinueAsNew = false;
+        this.actions = [];
         // Use prototype-less objects so that string keys which happen to match
         // members of `Object.prototype` (e.g. an external event named "toString")
         // do not collide with inherited properties.
         this.openTasks = Object.create(null);
         this.openEvents = Object.create(null);
-        this.actions = [];
-        // Use a prototype-less object so that string keys which happen to match
-        // members of `Object.prototype` (e.g. an external event named "toString")
-        // do not collide with inherited properties.
         this.deferredTasks = Object.create(null);
 
         this.output = undefined;

--- a/src/orchestrations/TaskOrchestrationExecutor.ts
+++ b/src/orchestrations/TaskOrchestrationExecutor.ts
@@ -27,7 +27,7 @@ export class TaskOrchestrationExecutor {
     private exception: Error | undefined;
     private orchestratorReturned: boolean;
     private generator: Generator<TaskBase, any, any>;
-    private deferredTasks: Record<number | string, () => void>;
+    private deferredTasks: Record<number | string, Array<() => void>>;
     private sequenceNumber: number;
     private schemaVersion: ReplaySchema;
     public willContinueAsNew: boolean;
@@ -308,7 +308,10 @@ export class TaskOrchestrationExecutor {
                     this.setTaskValue(event, isSuccess, idKey);
                     return; // we return because the task is yet to be scheduled
                 };
-                this.deferredTasks[key] = updateTask.bind(this);
+                if (this.deferredTasks[key] === undefined) {
+                    this.deferredTasks[key] = [];
+                }
+                this.deferredTasks[key].push(updateTask.bind(this));
                 return;
             }
         } else {
@@ -425,13 +428,18 @@ export class TaskOrchestrationExecutor {
             if (newTask.state !== TaskState.Running) {
                 this.tryResumingUserCode();
             } else {
-                // The task hasn't completed, we add it to the open (incomplete) task list
+                // Record the task's action (only for user-declared, not-yet-scheduled tasks).
+                if (newTask instanceof DFTask && !newTask.alreadyScheduled) {
+                    this.markAsScheduled(newTask);
+                    this.addToActions(newTask.actionObj);
+                }
+
+                // Register the task as open; this may complete it if its result was already processed.
                 this.trackOpenTask(newTask);
-                // We only keep track of actions from user-declared tasks, not from
-                // tasks generated internally to facilitate history-processing.
-                if (this.currentTask instanceof DFTask && !this.currentTask.alreadyScheduled) {
-                    this.markAsScheduled(this.currentTask);
-                    this.addToActions(this.currentTask.actionObj);
+
+                // If the task got completed during registration, resume the generator now.
+                if (newTask.state !== TaskState.Running) {
+                    this.tryResumingUserCode();
                 }
             }
         }
@@ -496,10 +504,16 @@ export class TaskOrchestrationExecutor {
             }
 
             // If the task's ID can be found in deferred tasks, then we have already processed
-            // the history event that contains the result for this task. Therefore, we immediately
-            // assign this task's result so that the user-code may proceed executing.
-            if (this.deferredTasks.hasOwnProperty(task.id)) {
-                const taskUpdateAction = this.deferredTasks[task.id];
+            // a history event that contains a result for this task. Drain one entry from the
+            // per-ID FIFO queue so that the user-code may proceed executing. Multiple queued
+            // entries (e.g. two same-named external events that both arrived early) will be
+            // consumed across successive `trackOpenTask` registrations.
+            const deferredQueue = this.deferredTasks[task.id];
+            if (deferredQueue !== undefined && deferredQueue.length > 0) {
+                const taskUpdateAction = deferredQueue.shift() as () => void;
+                if (deferredQueue.length === 0) {
+                    delete this.deferredTasks[task.id];
+                }
                 taskUpdateAction();
             }
         }

--- a/src/orchestrations/TaskOrchestrationExecutor.ts
+++ b/src/orchestrations/TaskOrchestrationExecutor.ts
@@ -65,8 +65,11 @@ export class TaskOrchestrationExecutor {
 
         this.sequenceNumber = 0;
         this.willContinueAsNew = false;
-        this.openTasks = {};
-        this.openEvents = {};
+        // Use prototype-less objects so that string keys which happen to match
+        // members of `Object.prototype` (e.g. an external event named "toString")
+        // do not collide with inherited properties.
+        this.openTasks = Object.create(null);
+        this.openEvents = Object.create(null);
         this.actions = [];
         // Use a prototype-less object so that string keys which happen to match
         // members of `Object.prototype` (e.g. an external event named "toString")

--- a/src/orchestrations/TaskOrchestrationExecutor.ts
+++ b/src/orchestrations/TaskOrchestrationExecutor.ts
@@ -434,13 +434,14 @@ export class TaskOrchestrationExecutor {
             if (newTask.state !== TaskState.Running) {
                 this.tryResumingUserCode();
             } else {
-                // Record the task's action (only for user-declared, not-yet-scheduled tasks).
+                // Record the action, but only for user-declared tasks we haven't scheduled yet
+                // (skip internal/history-processing tasks and replayed ones).
                 if (newTask instanceof DFTask && !newTask.alreadyScheduled) {
                     this.markAsScheduled(newTask);
                     this.addToActions(newTask.actionObj);
                 }
 
-                // Register the task as open; this may complete it if its result was already processed.
+                // Register the task as open (may resolve it immediately from a queued early event).
                 this.trackOpenTask(newTask);
 
                 // If the task got completed during registration, resume the generator now.
@@ -511,10 +512,9 @@ export class TaskOrchestrationExecutor {
 
             // If the task's ID can be found in deferred tasks, then we have already processed
             // a history event that contains a result for this task. Drain one entry from the
-            // per-ID FIFO queue so that the user-code may proceed executing. The drain may
-            // synchronously complete this task (and propagate to its parent); `tryResumingUserCode`
-            // then re-yields and registers the next waiter within the same execution, which is how
-            // multiple same-named early events are delivered to successive waits in one replay.
+            // per-ID FIFO queue to unblock the user code. The drain may complete this task
+            // synchronously, so when several events share a name, each queued one is handed to the
+            // next wait for that name as the generator advances.
             const taskId = task.id as number | string;
             const deferredQueue = this.deferredTasks[taskId];
             if (deferredQueue !== undefined && deferredQueue.length > 0) {

--- a/test/integration/orchestrator-spec.ts
+++ b/test/integration/orchestrator-spec.ts
@@ -2435,7 +2435,7 @@ describe("Orchestrator", () => {
             );
         });
 
-        // Regression tests for when an external event  arrives in
+        // Regression tests for when an external event arrives in
         // history BEFORE its `waitForExternalEvent` is registered must still
         // resume the orchestration. Before the fix in TaskOrchestrationExecutor,
         // these scenarios stalled in `Running` indefinitely.

--- a/test/integration/orchestrator-spec.ts
+++ b/test/integration/orchestrator-spec.ts
@@ -2590,6 +2590,33 @@ describe("Orchestrator", () => {
             expect(state.isDone).to.equal(true);
             expect(state.output).to.deep.equal([eventPayload, `Hello, ${activityInput}!`]);
         });
+
+        // Event names matching `Object.prototype` members (e.g. "toString")
+        // must not collide with inherited properties on `openTasks`/`openEvents`.
+        const prototypeKeyEventNames = ["toString", "constructor", "hasOwnProperty", "valueOf"];
+        prototypeKeyEventNames.forEach((eventName) => {
+            it(`completes when the external event name collides with Object.prototype ("${eventName}")`, async () => {
+                const orchestrator = TestOrchestrations.WaitForNamedEvent;
+                const eventPayload = { handled: eventName };
+                const mockContext = new DummyOrchestrationContext();
+                const orchestrationInput = new DurableOrchestrationInput(
+                    "",
+                    TestHistories.GetEventRaisedForName(
+                        moment.utc().toDate(),
+                        "WaitForNamedEvent",
+                        eventName,
+                        eventPayload
+                    ),
+                    eventName
+                );
+
+                const result = await orchestrator(orchestrationInput, mockContext);
+
+                const state = result as OrchestratorState;
+                expect(state.isDone).to.equal(true);
+                expect(state.output).to.deep.equal(eventPayload);
+            });
+        });
     });
 
     describe("Task.all() and Task.any()", () => {

--- a/test/integration/orchestrator-spec.ts
+++ b/test/integration/orchestrator-spec.ts
@@ -2434,6 +2434,158 @@ describe("Orchestrator", () => {
                 )
             );
         });
+
+        // Regression tests for when an external event  arrives in
+        // history BEFORE its `waitForExternalEvent` is registered must still
+        // resume the orchestration. Before the fix in TaskOrchestrationExecutor,
+        // these scenarios stalled in `Running` indefinitely.
+        it("completes when external event arrives before waitForExternalEvent is registered", async () => {
+            const orchestrator = TestOrchestrations.ActivityThenWaitForEvent;
+            const activityInput = "Tokyo";
+            const eventPayload = { ok: true };
+            const mockContext = new DummyOrchestrationContext();
+            const orchestrationInput = new DurableOrchestrationInput(
+                "",
+                TestHistories.GetActivityThenWaitForEvent_EventBeforeActivityCompletion(
+                    moment.utc().toDate(),
+                    "ActivityThenWaitForEvent",
+                    activityInput,
+                    "continue",
+                    eventPayload
+                ),
+                activityInput
+            );
+
+            const result = await orchestrator(orchestrationInput, mockContext);
+
+            expect(result).to.deep.equal(
+                new OrchestratorState(
+                    {
+                        isDone: true,
+                        output: eventPayload,
+                        actions: [
+                            [new CallActivityAction("Hello", activityInput)],
+                            [
+                                new WaitForExternalEventAction(
+                                    "continue",
+                                    ExternalEventType.ExternalEvent
+                                ),
+                            ],
+                        ],
+                        schemaVersion: ReplaySchema.V1,
+                    },
+                    true
+                )
+            );
+        });
+
+        it("preserves action order when activity completes and event arrives in the same execution", async () => {
+            // Parity guard for the normal-order path: the action stream must remain
+            // [CallActivity("Hello"), WaitForExternalEvent("continue")].
+            const orchestrator = TestOrchestrations.ActivityThenWaitForEvent;
+            const activityInput = "Osaka";
+            const eventPayload = "go";
+            const mockContext = new DummyOrchestrationContext();
+            const orchestrationInput = new DurableOrchestrationInput(
+                "",
+                TestHistories.GetActivityThenWaitForEvent_EventBeforeActivityCompletion(
+                    moment.utc().toDate(),
+                    "ActivityThenWaitForEvent",
+                    activityInput,
+                    "continue",
+                    eventPayload
+                ),
+                activityInput
+            );
+
+            const result = await orchestrator(orchestrationInput, mockContext);
+
+            const state = result as OrchestratorState;
+            // Flatten the per-execution action lists into a single ordered array.
+            const flattened = state.actions.reduce<unknown[]>(
+                (acc, batch) => acc.concat(batch as unknown[]),
+                []
+            );
+            expect(flattened).to.have.lengthOf(2);
+            expect(flattened[0]).to.be.instanceOf(CallActivityAction);
+            expect(flattened[1]).to.be.instanceOf(WaitForExternalEventAction);
+            expect(state.isDone).to.equal(true);
+            expect(state.output).to.equal(eventPayload);
+        });
+
+        it("drains queued early events of the same name in FIFO order", async () => {
+            // Two early events of the same name must be delivered to two
+            // `waitForExternalEvent("continue")` calls in arrival order.
+            const orchestrator = TestOrchestrations.TwoWaitsSameEvent;
+            const mockContext = new DummyOrchestrationContext();
+            const orchestrationInput = new DurableOrchestrationInput(
+                "",
+                TestHistories.GetTwoEarlyEventsSameName(
+                    moment.utc().toDate(),
+                    "TwoWaitsSameEvent",
+                    "continue",
+                    "first",
+                    "second"
+                ),
+                undefined
+            );
+
+            const result = await orchestrator(orchestrationInput, mockContext);
+
+            const state = result as OrchestratorState;
+            expect(state.isDone).to.equal(true);
+            expect(state.output).to.deep.equal(["first", "second"]);
+        });
+
+        it("delivers distinct early events to their matching waits", async () => {
+            // Distinct early events should be routed by name.
+            const orchestrator = TestOrchestrations.TwoWaitsDistinctEvents;
+            const mockContext = new DummyOrchestrationContext();
+            const orchestrationInput = new DurableOrchestrationInput(
+                "",
+                TestHistories.GetTwoEarlyEventsDistinctNames(
+                    moment.utc().toDate(),
+                    "TwoWaitsDistinctEvents",
+                    "alpha",
+                    "A",
+                    "beta",
+                    "B"
+                ),
+                undefined
+            );
+
+            const result = await orchestrator(orchestrationInput, mockContext);
+
+            const state = result as OrchestratorState;
+            expect(state.isDone).to.equal(true);
+            expect(state.output).to.deep.equal(["A", "B"]);
+        });
+
+        it("Task.all over an early event + activity still completes", async () => {
+            // Ensure the `Task.all` compound-task path is not regressed when one
+            // of the children is satisfied by an early external event.
+            const orchestrator = TestOrchestrations.AllWaitAndActivity;
+            const eventPayload = { ready: 1 };
+            const activityInput = "Tokyo";
+            const mockContext = new DummyOrchestrationContext();
+            const orchestrationInput = new DurableOrchestrationInput(
+                "",
+                TestHistories.GetAllWaitAndActivity_EarlyEvent(
+                    moment.utc().toDate(),
+                    "AllWaitAndActivity",
+                    activityInput,
+                    "continue",
+                    eventPayload
+                ),
+                undefined
+            );
+
+            const result = await orchestrator(orchestrationInput, mockContext);
+
+            const state = result as OrchestratorState;
+            expect(state.isDone).to.equal(true);
+            expect(state.output).to.deep.equal([eventPayload, `Hello, ${activityInput}!`]);
+        });
     });
 
     describe("Task.all() and Task.any()", () => {

--- a/test/integration/orchestrator-spec.ts
+++ b/test/integration/orchestrator-spec.ts
@@ -2479,44 +2479,6 @@ describe("Orchestrator", () => {
             );
         });
 
-        it("preserves action order when activity completes and event arrives in the same execution", async () => {
-            // Parity guard for action ordering: even when the `EventRaised` for
-            // `"continue"` arrives in the same replay as the activity's
-            // `TaskCompleted` (the early-event ordering), the recorded action
-            // stream must remain [CallActivity("Hello"), WaitForExternalEvent("continue")]
-            // — i.e. the order of the orchestrator's yields, not the order of
-            // the satisfying history events.
-            const orchestrator = TestOrchestrations.ActivityThenWaitForEvent;
-            const activityInput = "Osaka";
-            const eventPayload = "go";
-            const mockContext = new DummyOrchestrationContext();
-            const orchestrationInput = new DurableOrchestrationInput(
-                "",
-                TestHistories.GetActivityThenWaitForEvent_EventBeforeActivityCompletion(
-                    moment.utc().toDate(),
-                    "ActivityThenWaitForEvent",
-                    activityInput,
-                    "continue",
-                    eventPayload
-                ),
-                activityInput
-            );
-
-            const result = await orchestrator(orchestrationInput, mockContext);
-
-            const state = result as OrchestratorState;
-            // Flatten the per-execution action lists into a single ordered array.
-            const flattened = state.actions.reduce<unknown[]>(
-                (acc, batch) => acc.concat(batch as unknown[]),
-                []
-            );
-            expect(flattened).to.have.lengthOf(2);
-            expect(flattened[0]).to.be.instanceOf(CallActivityAction);
-            expect(flattened[1]).to.be.instanceOf(WaitForExternalEventAction);
-            expect(state.isDone).to.equal(true);
-            expect(state.output).to.equal(eventPayload);
-        });
-
         it("drains queued early events of the same name in FIFO order", async () => {
             // Two early events of the same name must be delivered to two
             // `waitForExternalEvent("continue")` calls in arrival order.

--- a/test/integration/orchestrator-spec.ts
+++ b/test/integration/orchestrator-spec.ts
@@ -2480,8 +2480,12 @@ describe("Orchestrator", () => {
         });
 
         it("preserves action order when activity completes and event arrives in the same execution", async () => {
-            // Parity guard for the normal-order path: the action stream must remain
-            // [CallActivity("Hello"), WaitForExternalEvent("continue")].
+            // Parity guard for action ordering: even when the `EventRaised` for
+            // `"continue"` arrives in the same replay as the activity's
+            // `TaskCompleted` (the early-event ordering), the recorded action
+            // stream must remain [CallActivity("Hello"), WaitForExternalEvent("continue")]
+            // — i.e. the order of the orchestrator's yields, not the order of
+            // the satisfying history events.
             const orchestrator = TestOrchestrations.ActivityThenWaitForEvent;
             const activityInput = "Osaka";
             const eventPayload = "go";

--- a/test/testobjects/TestOrchestrations.ts
+++ b/test/testobjects/TestOrchestrations.ts
@@ -433,6 +433,41 @@ export class TestOrchestrations {
         return returnValue;
     });
 
+    // Yields a single activity, then waits on an external event. If the event
+    // arrives before the wait is registered, the orchestration should still
+    // complete and return the event payload.
+    public static ActivityThenWaitForEvent: any = createOrchestrator(function* (context: any) {
+        const input = context.df.getInput();
+        yield context.df.callActivity("Hello", input);
+        const evt = yield context.df.waitForExternalEvent("continue");
+        return evt;
+    });
+
+    // Waits on the same-named event twice. If two `continue` events arrived early,
+    // the first wait should resolve with the first event's payload and the second
+    // wait with the second event's payload (FIFO drain).
+    public static TwoWaitsSameEvent: any = createOrchestrator(function* (context: any) {
+        const first = yield context.df.waitForExternalEvent("continue");
+        const second = yield context.df.waitForExternalEvent("continue");
+        return [first, second];
+    });
+
+    // Two waits on distinct early events.
+    public static TwoWaitsDistinctEvents: any = createOrchestrator(function* (context: any) {
+        const a = yield context.df.waitForExternalEvent("alpha");
+        const b = yield context.df.waitForExternalEvent("beta");
+        return [a, b];
+    });
+
+    // `Task.all` over a wait and an activity, with the external event arriving
+    // before the wait is registered.
+    public static AllWaitAndActivity: any = createOrchestrator(function* (context: any) {
+        const waitTask = context.df.waitForExternalEvent("continue");
+        const activityTask = context.df.callActivity("Hello", "Tokyo");
+        const results = yield context.df.Task.all([waitTask, activityTask]);
+        return results;
+    });
+
     public static WaitOnTimer: any = createOrchestrator(function* (context: any) {
         const fireAt = context.df.getInput();
 

--- a/test/testobjects/TestOrchestrations.ts
+++ b/test/testobjects/TestOrchestrations.ts
@@ -485,6 +485,17 @@ export class TestOrchestrations {
         return results;
     });
 
+    // Waits on an external event whose name is supplied as the orchestrator input.
+    // Used to verify that event names which collide with members of
+    // `Object.prototype` (e.g. "toString", "constructor", "hasOwnProperty") are
+    // handled correctly and do not resolve to inherited properties on the internal
+    // `openTasks`/`openEvents` maps.
+    public static WaitForNamedEvent: any = createOrchestrator(function* (context: any) {
+        const eventName = context.df.getInput();
+        const evt = yield context.df.waitForExternalEvent(eventName);
+        return evt;
+    });
+
     public static WaitOnTimer: any = createOrchestrator(function* (context: any) {
         const fireAt = context.df.getInput();
 

--- a/test/testobjects/TestOrchestrations.ts
+++ b/test/testobjects/TestOrchestrations.ts
@@ -446,14 +446,23 @@ export class TestOrchestrations {
     // Waits on the same-named event twice. If two `continue` events arrived early,
     // the first wait should resolve with the first event's payload and the second
     // wait with the second event's payload (FIFO drain).
+    //
+    // The leading activity yield is required so that the orchestrator is suspended
+    // on a non-event task when the two early `EventRaised` history entries are
+    // processed. Without it, the first wait would already be registered by the
+    // time the first event is replayed, so both events would be delivered via
+    // `openEvents` and the `deferredTasks` FIFO queue would never be exercised.
     public static TwoWaitsSameEvent: any = createOrchestrator(function* (context: any) {
+        yield context.df.callActivity("Hello", "Prep");
         const first = yield context.df.waitForExternalEvent("continue");
         const second = yield context.df.waitForExternalEvent("continue");
         return [first, second];
     });
 
-    // Two waits on distinct early events.
+    // Two waits on distinct early events. See `TwoWaitsSameEvent` for why a
+    // leading activity yield is required to actually exercise the deferred path.
     public static TwoWaitsDistinctEvents: any = createOrchestrator(function* (context: any) {
+        yield context.df.callActivity("Hello", "Prep");
         const a = yield context.df.waitForExternalEvent("alpha");
         const b = yield context.df.waitForExternalEvent("beta");
         return [a, b];
@@ -461,7 +470,15 @@ export class TestOrchestrations {
 
     // `Task.all` over a wait and an activity, with the external event arriving
     // before the wait is registered.
+    //
+    // The leading `Prep` activity yield is required for the same reason as
+    // `TwoWaitsSameEvent`: without it, the `Task.all` (and therefore the
+    // `waitForExternalEvent` child) would be registered during `ExecutionStarted`,
+    // so the early `EventRaised` would be delivered via `openEvents` instead of
+    // `deferredTasks`, and the new FIFO drain logic in `trackOpenTask` would
+    // never be hit on the compound-task path.
     public static AllWaitAndActivity: any = createOrchestrator(function* (context: any) {
+        yield context.df.callActivity("Hello", "Prep");
         const waitTask = context.df.waitForExternalEvent("continue");
         const activityTask = context.df.callActivity("Hello", "Tokyo");
         const results = yield context.df.Task.all([waitTask, activityTask]);

--- a/test/testobjects/testhistories.ts
+++ b/test/testobjects/testhistories.ts
@@ -2477,6 +2477,52 @@ export class TestHistories {
     }
 
     /**
+     * Regression history for external event names that collide with `Object.prototype`
+     * members (e.g. "toString"). The orchestrator waits for the event name passed as
+     * its input, then the event is raised under that name. Before the prototype-less
+     * hardening of `openTasks`/`openEvents`, this threw a `TypeError`.
+     */
+    public static GetEventRaisedForName(
+        firstTimestamp: Date,
+        orchestratorName: string,
+        eventName: string,
+        eventPayload: unknown
+    ): HistoryEvent[] {
+        const t1 = moment(firstTimestamp).add(1, "s").toDate();
+        return [
+            new OrchestratorStartedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: false,
+            }),
+            new ExecutionStartedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: true,
+                name: orchestratorName,
+                input: JSON.stringify(eventName),
+            }),
+            new OrchestratorCompletedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: false,
+            }),
+            new OrchestratorStartedEvent({
+                eventId: -1,
+                timestamp: t1,
+                isPlayed: false,
+            }),
+            new EventRaisedEvent({
+                eventId: -1,
+                timestamp: t1,
+                isPlayed: false,
+                name: eventName,
+                input: JSON.stringify(eventPayload),
+            }),
+        ];
+    }
+
+    /**
      * Regression history where the orchestrator yields an activity first, then
      * waits for an external event. The history places the `EventRaised` *before*
      * the activity's `TaskCompleted`, simulating an Azure Storage backend committing

--- a/test/testobjects/testhistories.ts
+++ b/test/testobjects/testhistories.ts
@@ -2540,9 +2540,12 @@ export class TestHistories {
     }
 
     /**
-     * Regression history for the FIFO-drain path: the orchestrator issues two
-     * `waitForExternalEvent` calls of the same name; both events arrive before
-     * either wait is registered.
+     * Regression history for the FIFO-drain path: the orchestrator yields on a
+     * `Hello` activity, then issues two same-named `waitForExternalEvent`
+     * calls. Both events arrive while the activity is still pending, so they
+     * are processed before either wait is registered and must therefore be
+     * queued in `deferredTasks["<eventName>"]` and drained in FIFO order when
+     * the waits register after the activity completes.
      */
     public static GetTwoEarlyEventsSameName(
         firstTimestamp: Date,
@@ -2550,90 +2553,6 @@ export class TestHistories {
         eventName: string,
         firstPayload: unknown,
         secondPayload: unknown
-    ): HistoryEvent[] {
-        return [
-            new OrchestratorStartedEvent({
-                eventId: -1,
-                timestamp: firstTimestamp,
-                isPlayed: false,
-            }),
-            new ExecutionStartedEvent({
-                eventId: -1,
-                timestamp: firstTimestamp,
-                isPlayed: true,
-                name: orchestratorName,
-                input: undefined,
-            }),
-            new EventRaisedEvent({
-                eventId: -1,
-                timestamp: firstTimestamp,
-                isPlayed: false,
-                name: eventName,
-                input: JSON.stringify(firstPayload),
-            }),
-            new EventRaisedEvent({
-                eventId: -1,
-                timestamp: moment(firstTimestamp).add(1, "ms").toDate(),
-                isPlayed: false,
-                name: eventName,
-                input: JSON.stringify(secondPayload),
-            }),
-        ];
-    }
-
-    /**
-     * Regression history where two distinct external events arrive before either
-     * of two corresponding `waitForExternalEvent` calls is registered.
-     */
-    public static GetTwoEarlyEventsDistinctNames(
-        firstTimestamp: Date,
-        orchestratorName: string,
-        firstName: string,
-        firstPayload: unknown,
-        secondName: string,
-        secondPayload: unknown
-    ): HistoryEvent[] {
-        return [
-            new OrchestratorStartedEvent({
-                eventId: -1,
-                timestamp: firstTimestamp,
-                isPlayed: false,
-            }),
-            new ExecutionStartedEvent({
-                eventId: -1,
-                timestamp: firstTimestamp,
-                isPlayed: true,
-                name: orchestratorName,
-                input: undefined,
-            }),
-            new EventRaisedEvent({
-                eventId: -1,
-                timestamp: firstTimestamp,
-                isPlayed: false,
-                name: firstName,
-                input: JSON.stringify(firstPayload),
-            }),
-            new EventRaisedEvent({
-                eventId: -1,
-                timestamp: moment(firstTimestamp).add(1, "ms").toDate(),
-                isPlayed: false,
-                name: secondName,
-                input: JSON.stringify(secondPayload),
-            }),
-        ];
-    }
-
-    /**
-     * Regression history for `Task.all([waitForExternalEvent, callActivity])`
-     * where the external event arrives before the wait is registered. Both events
-     * must be satisfied for the all-task to complete.
-     */
-    public static GetAllWaitAndActivity_EarlyEvent(
-        firstTimestamp: Date,
-        orchestratorName: string,
-        activityInput: string,
-        eventName: string,
-        eventPayload: unknown
     ): HistoryEvent[] {
         const t1 = moment(firstTimestamp).add(1, "s").toDate();
         return [
@@ -2654,7 +2573,83 @@ export class TestHistories {
                 timestamp: firstTimestamp,
                 isPlayed: false,
                 name: "Hello",
-                input: JSON.stringify(activityInput),
+                input: JSON.stringify("Prep"),
+            }),
+            new OrchestratorCompletedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: false,
+            }),
+            new OrchestratorStartedEvent({
+                eventId: -1,
+                timestamp: t1,
+                isPlayed: false,
+            }),
+            // Both events arrive before the activity completes, so neither wait
+            // is registered yet; they must end up in `deferredTasks[eventName]`.
+            new EventRaisedEvent({
+                eventId: -1,
+                timestamp: t1,
+                isPlayed: false,
+                name: eventName,
+                input: JSON.stringify(firstPayload),
+            }),
+            new EventRaisedEvent({
+                eventId: -1,
+                timestamp: moment(t1).add(1, "ms").toDate(),
+                isPlayed: false,
+                name: eventName,
+                input: JSON.stringify(secondPayload),
+            }),
+            // Activity completes — generator resumes, registers the first wait
+            // (drains the first queued entry), then the second wait (drains
+            // the second queued entry).
+            new TaskCompletedEvent({
+                eventId: -1,
+                timestamp: moment(t1).add(2, "ms").toDate(),
+                isPlayed: false,
+                taskScheduledId: 0,
+                result: JSON.stringify("Hello, Prep!"),
+            }),
+        ];
+    }
+
+    /**
+     * Regression history where two distinct external events arrive before either
+     * of two corresponding `waitForExternalEvent` calls is registered. As with
+     * `GetTwoEarlyEventsSameName`, the leading `Hello` activity is required to
+     * keep the orchestrator suspended on a non-event task while the two
+     * `EventRaised` history entries are processed, so each event is routed
+     * through `deferredTasks[<name>]` instead of `openEvents[<name>]`.
+     */
+    public static GetTwoEarlyEventsDistinctNames(
+        firstTimestamp: Date,
+        orchestratorName: string,
+        firstName: string,
+        firstPayload: unknown,
+        secondName: string,
+        secondPayload: unknown
+    ): HistoryEvent[] {
+        const t1 = moment(firstTimestamp).add(1, "s").toDate();
+        return [
+            new OrchestratorStartedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: false,
+            }),
+            new ExecutionStartedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: true,
+                name: orchestratorName,
+                input: undefined,
+            }),
+            new TaskScheduledEvent({
+                eventId: 0,
+                timestamp: firstTimestamp,
+                isPlayed: false,
+                name: "Hello",
+                input: JSON.stringify("Prep"),
             }),
             new OrchestratorCompletedEvent({
                 eventId: -1,
@@ -2670,14 +2665,102 @@ export class TestHistories {
                 eventId: -1,
                 timestamp: t1,
                 isPlayed: false,
-                name: eventName,
-                input: JSON.stringify(eventPayload),
+                name: firstName,
+                input: JSON.stringify(firstPayload),
+            }),
+            new EventRaisedEvent({
+                eventId: -1,
+                timestamp: moment(t1).add(1, "ms").toDate(),
+                isPlayed: false,
+                name: secondName,
+                input: JSON.stringify(secondPayload),
             }),
             new TaskCompletedEvent({
                 eventId: -1,
-                timestamp: t1,
+                timestamp: moment(t1).add(2, "ms").toDate(),
                 isPlayed: false,
                 taskScheduledId: 0,
+                result: JSON.stringify("Hello, Prep!"),
+            }),
+        ];
+    }
+
+    /**
+     * Regression history for `Task.all([waitForExternalEvent, callActivity])`
+     * where the external event arrives before the wait is registered. Both
+     * tasks must be satisfied for the all-task to complete.
+     *
+     * The orchestrator first yields on a leading `Hello`/`Prep` activity so it
+     * is provably suspended on a non-event task when the `EventRaised` history
+     * entry is processed. That forces the event through `deferredTasks` and
+     * exercises the deferred-drain path on the compound-task child registration
+     * inside `trackOpenTask`.
+     */
+    public static GetAllWaitAndActivity_EarlyEvent(
+        firstTimestamp: Date,
+        orchestratorName: string,
+        activityInput: string,
+        eventName: string,
+        eventPayload: unknown
+    ): HistoryEvent[] {
+        const t1 = moment(firstTimestamp).add(1, "s").toDate();
+        const t2 = moment(t1).add(1, "ms").toDate();
+        const t3 = moment(t1).add(2, "ms").toDate();
+        return [
+            new OrchestratorStartedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: false,
+            }),
+            new ExecutionStartedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: true,
+                name: orchestratorName,
+                input: undefined,
+            }),
+            // Prep activity is registered first (sequence number 0).
+            new TaskScheduledEvent({
+                eventId: 0,
+                timestamp: firstTimestamp,
+                isPlayed: false,
+                name: "Hello",
+                input: JSON.stringify("Prep"),
+            }),
+            new OrchestratorCompletedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: false,
+            }),
+            new OrchestratorStartedEvent({
+                eventId: -1,
+                timestamp: t1,
+                isPlayed: false,
+            }),
+            // Early event: arrives before the `Task.all` (and therefore the wait)
+            // has been registered, so it is queued in `deferredTasks[eventName]`.
+            new EventRaisedEvent({
+                eventId: -1,
+                timestamp: t1,
+                isPlayed: false,
+                name: eventName,
+                input: JSON.stringify(eventPayload),
+            }),
+            // Prep activity completes — generator resumes, yields the `Task.all`,
+            // and the wait-child registration drains the deferred entry.
+            new TaskCompletedEvent({
+                eventId: -1,
+                timestamp: t2,
+                isPlayed: false,
+                taskScheduledId: 0,
+                result: JSON.stringify("Hello, Prep!"),
+            }),
+            // Tokyo activity (the second `Task.all` child) is the next scheduled task.
+            new TaskCompletedEvent({
+                eventId: -1,
+                timestamp: t3,
+                isPlayed: false,
+                taskScheduledId: 1,
                 result: JSON.stringify(`Hello, ${activityInput}!`),
             }),
         ];

--- a/test/testobjects/testhistories.ts
+++ b/test/testobjects/testhistories.ts
@@ -2755,7 +2755,15 @@ export class TestHistories {
                 taskScheduledId: 0,
                 result: JSON.stringify("Hello, Prep!"),
             }),
-            // Tokyo activity (the second `Task.all` child) is the next scheduled task.
+            // Tokyo activity (the second `Task.all` child) is scheduled when the
+            // `Task.all` is registered, then completes immediately afterward.
+            new TaskScheduledEvent({
+                eventId: 1,
+                timestamp: t2,
+                isPlayed: false,
+                name: "Hello",
+                input: JSON.stringify(activityInput),
+            }),
             new TaskCompletedEvent({
                 eventId: -1,
                 timestamp: t3,

--- a/test/testobjects/testhistories.ts
+++ b/test/testobjects/testhistories.ts
@@ -2476,6 +2476,213 @@ export class TestHistories {
         ];
     }
 
+    /**
+     * Regression history where the orchestrator yields an activity first, then
+     * waits for an external event. The history places the `EventRaised` *before*
+     * the activity's `TaskCompleted`, simulating an Azure Storage backend committing
+     * an early-arriving external event into history ahead of the activity completion.
+     */
+    public static GetActivityThenWaitForEvent_EventBeforeActivityCompletion(
+        firstTimestamp: Date,
+        orchestratorName: string,
+        activityInput: unknown,
+        eventName: string,
+        eventPayload: unknown
+    ): HistoryEvent[] {
+        const t1 = moment(firstTimestamp).add(1, "s").toDate();
+        return [
+            new OrchestratorStartedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: false,
+            }),
+            new ExecutionStartedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: true,
+                name: orchestratorName,
+                input: JSON.stringify(activityInput),
+            }),
+            new TaskScheduledEvent({
+                eventId: 0,
+                timestamp: firstTimestamp,
+                isPlayed: false,
+                name: "Hello",
+                input: JSON.stringify(activityInput),
+            }),
+            new OrchestratorCompletedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: false,
+            }),
+            new OrchestratorStartedEvent({
+                eventId: -1,
+                timestamp: t1,
+                isPlayed: false,
+            }),
+            // Early event: arrives before the wait is registered, and before the
+            // activity completion is processed by the executor.
+            new EventRaisedEvent({
+                eventId: -1,
+                timestamp: t1,
+                isPlayed: false,
+                name: eventName,
+                input: JSON.stringify(eventPayload),
+            }),
+            new TaskCompletedEvent({
+                eventId: -1,
+                timestamp: t1,
+                isPlayed: false,
+                taskScheduledId: 0,
+                result: JSON.stringify(`Hello, ${activityInput}!`),
+            }),
+        ];
+    }
+
+    /**
+     * Regression history for the FIFO-drain path: the orchestrator issues two
+     * `waitForExternalEvent` calls of the same name; both events arrive before
+     * either wait is registered.
+     */
+    public static GetTwoEarlyEventsSameName(
+        firstTimestamp: Date,
+        orchestratorName: string,
+        eventName: string,
+        firstPayload: unknown,
+        secondPayload: unknown
+    ): HistoryEvent[] {
+        return [
+            new OrchestratorStartedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: false,
+            }),
+            new ExecutionStartedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: true,
+                name: orchestratorName,
+                input: undefined,
+            }),
+            new EventRaisedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: false,
+                name: eventName,
+                input: JSON.stringify(firstPayload),
+            }),
+            new EventRaisedEvent({
+                eventId: -1,
+                timestamp: moment(firstTimestamp).add(1, "ms").toDate(),
+                isPlayed: false,
+                name: eventName,
+                input: JSON.stringify(secondPayload),
+            }),
+        ];
+    }
+
+    /**
+     * Regression history where two distinct external events arrive before either
+     * of two corresponding `waitForExternalEvent` calls is registered.
+     */
+    public static GetTwoEarlyEventsDistinctNames(
+        firstTimestamp: Date,
+        orchestratorName: string,
+        firstName: string,
+        firstPayload: unknown,
+        secondName: string,
+        secondPayload: unknown
+    ): HistoryEvent[] {
+        return [
+            new OrchestratorStartedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: false,
+            }),
+            new ExecutionStartedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: true,
+                name: orchestratorName,
+                input: undefined,
+            }),
+            new EventRaisedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: false,
+                name: firstName,
+                input: JSON.stringify(firstPayload),
+            }),
+            new EventRaisedEvent({
+                eventId: -1,
+                timestamp: moment(firstTimestamp).add(1, "ms").toDate(),
+                isPlayed: false,
+                name: secondName,
+                input: JSON.stringify(secondPayload),
+            }),
+        ];
+    }
+
+    /**
+     * Regression history for `Task.all([waitForExternalEvent, callActivity])`
+     * where the external event arrives before the wait is registered. Both events
+     * must be satisfied for the all-task to complete.
+     */
+    public static GetAllWaitAndActivity_EarlyEvent(
+        firstTimestamp: Date,
+        orchestratorName: string,
+        activityInput: string,
+        eventName: string,
+        eventPayload: unknown
+    ): HistoryEvent[] {
+        const t1 = moment(firstTimestamp).add(1, "s").toDate();
+        return [
+            new OrchestratorStartedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: false,
+            }),
+            new ExecutionStartedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: true,
+                name: orchestratorName,
+                input: undefined,
+            }),
+            new TaskScheduledEvent({
+                eventId: 0,
+                timestamp: firstTimestamp,
+                isPlayed: false,
+                name: "Hello",
+                input: JSON.stringify(activityInput),
+            }),
+            new OrchestratorCompletedEvent({
+                eventId: -1,
+                timestamp: firstTimestamp,
+                isPlayed: false,
+            }),
+            new OrchestratorStartedEvent({
+                eventId: -1,
+                timestamp: t1,
+                isPlayed: false,
+            }),
+            new EventRaisedEvent({
+                eventId: -1,
+                timestamp: t1,
+                isPlayed: false,
+                name: eventName,
+                input: JSON.stringify(eventPayload),
+            }),
+            new TaskCompletedEvent({
+                eventId: -1,
+                timestamp: t1,
+                isPlayed: false,
+                taskScheduledId: 0,
+                result: JSON.stringify(`Hello, ${activityInput}!`),
+            }),
+        ];
+    }
+
     private static TimerCreated(timestamp: Date, fireAt: Date, timerId: number): HistoryEvent[] {
         return [
             new OrchestratorStartedEvent({


### PR DESCRIPTION
## Description

When an `EventRaised` event landed in history before its `waitForExternalEvent` was registered (for example, after an activity completion that gates the wait), the orchestration stalled in `Running` forever. Two issues caused this:

1. `deferredTasks` stored a **single** callback per key, so a second early event for the same name silently overwrote the first — the original event was lost and any later wait for it hung indefinitely.
2. After a task was tracked as open, the executor never re-checked whether its result had already been deferred — so even a single early event could fail to wake the generator within the same execution.

## Fix

- Change `deferredTasks` to a per-ID **FIFO queue** (`Array<() => void>`) so multiple early events for the same name are preserved and drained in arrival order.
- In `tryResumingUserCode`, record the action and call `trackOpenTask` first, then re-check the task state and resume the generator if registration completed it (which now happens whenever a deferred entry is drained).

## Tests

Added regression coverage in `orchestrator-spec.ts`:

- Activity completion followed by an early-arriving external event completes the orchestration and preserves the `[CallActivity, WaitForExternalEvent]` action order.
- Two early events with the same name are delivered to two sequential waits in FIFO order.
- Distinct early events are routed to their matching waits by name.
- `Task.all([waitForExternalEvent, callActivity])` with an early event still completes.

Resolves #558 
