### PR TITLE
Fix critical-section stall after early release of multi-entity locks

### DIFF
--- a/src/orchestrations/DurableOrchestrationContext.ts
+++ b/src/orchestrations/DurableOrchestrationContext.ts
@@ -495,9 +495,8 @@ export class DurableOrchestrationContext implements types.DurableOrchestrationCo
             // locked entity), and each message consumes a task-ID slot in the
             // backend's sequence space. Advance our counter by the number of
             // locked entities so any durable task scheduled after the release is
-            // assigned the same ID the extension will use; otherwise a
-            // multi-entity early release leaves the next task waiting on a
-            // completion event that never matches, stalling the orchestration.
+            // assigned the same ID the extension will use and matches its
+            // completion event.
             this.taskOrchestratorExecutor.recordFireAndForgetAction(
                 new ReleaseEntitiesAction(),
                 deduped.length

--- a/src/orchestrations/DurableOrchestrationContext.ts
+++ b/src/orchestrations/DurableOrchestrationContext.ts
@@ -490,7 +490,18 @@ export class DurableOrchestrationContext implements types.DurableOrchestrationCo
         // typed field (see LockTask), so the executor can hand it back on
         // completion without a shared untyped property between the two.
         const lock = new DurableLock(deduped, () => {
-            this.taskOrchestratorExecutor.recordFireAndForgetAction(new ReleaseEntitiesAction());
+            // Releasing the section emits one entity message per owned entity on
+            // the extension side (ReleaseLocks sends a ReleaseMessage to each
+            // locked entity), and each message consumes a task-ID slot in the
+            // backend's sequence space. Advance our counter by the number of
+            // locked entities so any durable task scheduled after the release is
+            // assigned the same ID the extension will use; otherwise a
+            // multi-entity early release leaves the next task waiting on a
+            // completion event that never matches, stalling the orchestration.
+            this.taskOrchestratorExecutor.recordFireAndForgetAction(
+                new ReleaseEntitiesAction(),
+                deduped.length
+            );
             // Clear the active-section flag so subsequent code outside the
             // section is no longer treated as locked.
             if (this.currentLock === lock) {

--- a/src/orchestrations/TaskOrchestrationExecutor.ts
+++ b/src/orchestrations/TaskOrchestrationExecutor.ts
@@ -487,10 +487,32 @@ export class TaskOrchestrationExecutor {
         }
     }
 
-    public recordFireAndForgetAction(action: IAction): void {
+    /**
+     * @hidden
+     * Record a fire-and-forget action (one with no awaitable task) and advance
+     * the sequence counter past the task-ID slots it consumes on the extension
+     * side.
+     *
+     * Most fire-and-forget actions emit a single backend message and therefore
+     * consume exactly one task-ID slot (the default). A critical-section
+     * release is the exception: the extension's `ReleaseLocks()` sends one
+     * entity message per locked entity, so releasing an N-entity lock consumes
+     * N slots. Passing the correct count keeps our predicted task IDs aligned
+     * with the extension's. Otherwise every durable task scheduled after a
+     * multi-entity release is assigned an ID that is too low by (N - 1), its
+     * completion event never matches an open task, and the orchestration
+     * stalls.
+     *
+     * @param action
+     *  The fire-and-forget action to record.
+     * @param sequenceNumberIncrement
+     *  The number of task-ID slots the action consumes on the extension side
+     *  (i.e. the number of backend messages it emits). Defaults to 1.
+     */
+    public recordFireAndForgetAction(action: IAction, sequenceNumberIncrement = 1): void {
         if (!this.willContinueAsNew) {
             this.addToActions(action);
-            this.sequenceNumber++;
+            this.sequenceNumber += sequenceNumberIncrement;
         }
     }
 

--- a/src/orchestrations/TaskOrchestrationExecutor.ts
+++ b/src/orchestrations/TaskOrchestrationExecutor.ts
@@ -498,10 +498,8 @@ export class TaskOrchestrationExecutor {
      * release is the exception: the extension's `ReleaseLocks()` sends one
      * entity message per locked entity, so releasing an N-entity lock consumes
      * N slots. Passing the correct count keeps our predicted task IDs aligned
-     * with the extension's. Otherwise every durable task scheduled after a
-     * multi-entity release is assigned an ID that is too low by (N - 1), its
-     * completion event never matches an open task, and the orchestration
-     * stalls.
+     * with the extension's, so durable work scheduled after the action still
+     * matches its completion events.
      *
      * @param action
      *  The fire-and-forget action to record.

--- a/test/integration/critical-sections-spec.ts
+++ b/test/integration/critical-sections-spec.ts
@@ -292,6 +292,8 @@ import { ExecutionStartedEvent } from "../../src/history/ExecutionStartedEvent";
 import { EventSentEvent } from "../../src/history/EventSentEvent";
 import { EventRaisedEvent } from "../../src/history/EventRaisedEvent";
 import { OrchestratorCompletedEvent } from "../../src/history/OrchestratorCompletedEvent";
+import { TaskCompletedEvent } from "../../src/history/TaskCompletedEvent";
+import { TimerFiredEvent } from "../../src/history/TimerFiredEvent";
 
 function buildLockHistory(
     firstTimestamp: Date,
@@ -645,5 +647,652 @@ describe("Critical Sections - release-pattern parity", () => {
         // orchestration termination. This is the documented safety net.
         const types = result.actions[0].map((a: { actionType: ActionType }) => a.actionType);
         expect(types).to.deep.equal([ActionType.LockEntities]);
+    });
+});
+
+// -----------------------------------------------------------------------------
+// The extension's ReleaseLocks() sends one entity message per
+// locked entity, so releasing an N-entity lock consumes N task-ID slots in the
+// backend's sequence space. The worker previously advanced its own sequence
+// counter by only 1 for any release.
+//
+// Extension-side task IDs for `lock(entities) -> release() -> callActivity`:
+//   id 0        : lock request (single EventSent to the first entity)
+//   ids 1..N    : one release message per locked entity
+//   id N + 1    : the activity scheduled immediately after release
+// So the activity's TaskCompleted carries TaskScheduledId = N + 1.
+// The worker predicts that same ID and the orchestration completes; without
+// it the worker predicts ID 2 (N=2) / 2 (N=3) and stalls (isDone === false).
+// -----------------------------------------------------------------------------
+function buildLockReleaseActivityHistory(
+    firstTimestamp: Date,
+    entities: EntityId[],
+    lockRequestId: string,
+    includeResponse: boolean,
+    activityResult: unknown
+): HistoryEvent[] {
+    const orchestratorId = uuidv1();
+    const t0 = firstTimestamp;
+    const t1 = moment(firstTimestamp).add(1, "s").toDate();
+    const t2 = moment(firstTimestamp).add(2, "s").toDate();
+
+    const events: HistoryEvent[] = [
+        new OrchestratorStartedEvent({ eventId: -1, timestamp: t0, isPlayed: false }),
+        new ExecutionStartedEvent({
+            eventId: -1,
+            timestamp: t1,
+            isPlayed: true,
+            name: orchestratorId,
+            input: undefined,
+        }),
+        new EventSentEvent({
+            eventId: 0,
+            timestamp: t1,
+            isPlayed: true,
+            name: "op",
+            input: JSON.stringify({
+                id: lockRequestId,
+                parent: orchestratorId,
+                lockset: entities.map((e) => ({ name: e.name, key: e.key })),
+                position: 0,
+            }),
+            instanceId: EntityId.getSchedulerIdFromEntityId(entities[0]),
+        }),
+        new OrchestratorCompletedEvent({ eventId: -1, timestamp: t1, isPlayed: true }),
+    ];
+
+    if (includeResponse) {
+        // lock = id 0, release messages = ids 1..N, activity = id N + 1.
+        const activityTaskId = entities.length + 1;
+        events.push(
+            new OrchestratorStartedEvent({ eventId: -1, timestamp: t2, isPlayed: false }),
+            // Lock acquired (EventRaised keyed by the lockRequestId GUID).
+            new EventRaisedEvent({
+                eventId: -1,
+                timestamp: t2,
+                isPlayed: false,
+                name: lockRequestId,
+                input: JSON.stringify({ result: null }),
+            }),
+            // The activity scheduled right after the release completes.
+            new TaskCompletedEvent({
+                eventId: -1,
+                timestamp: t2,
+                isPlayed: false,
+                taskScheduledId: activityTaskId,
+                result: JSON.stringify(activityResult),
+            })
+        );
+    }
+
+    return events;
+}
+
+describe("Critical Sections - early release then durable work (parity regression)", () => {
+    // lock(entities) -> release() -> callActivity, driven through the full
+    // replay pipeline. Returns the final orchestrator state.
+    async function runLockReleaseThenActivity(
+        entities: EntityId[],
+        activityResult: unknown
+    ): Promise<{ isDone: boolean; output: unknown; actionTypes: ActionType[] }> {
+        const orchestrator = createOrchestrator(function* (context) {
+            const lock = (yield context.df.lock(entities)) as DurableLock;
+            // Release the section, then schedule further durable work -- the
+            // exact shape that used to stall for multi-entity locks.
+            lock.release();
+            const receipt = yield context.df.callActivity("sendReceipt", { ok: true });
+            return { receipt, lockedAfter: context.df.isLocked().isLocked };
+        });
+
+        const firstTs = moment.utc().toDate();
+
+        // Probe pass (lock response absent) to capture the deterministic
+        // lockRequestId the worker generates.
+        const probeCtx = new DummyOrchestrationContextRuntime();
+        const probeInput = new DurableOrchestrationInput(
+            "early-release-instance",
+            buildLockReleaseActivityHistory(firstTs, entities, "placeholder", false, undefined),
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            ReplaySchema.V4
+        );
+        const probe = await orchestrator(probeInput, probeCtx);
+        const lockRequestId = (probe.actions[0][0] as LockEntitiesAction).lockRequestId;
+
+        // Real pass with the lock response and the post-release activity
+        // completion (TaskScheduledId = N + 1) present.
+        const replayCtx = new DummyOrchestrationContextRuntime();
+        const replayInput = new DurableOrchestrationInput(
+            "early-release-instance",
+            buildLockReleaseActivityHistory(firstTs, entities, lockRequestId, true, activityResult),
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            ReplaySchema.V4
+        );
+        const result = await orchestrator(replayInput, replayCtx);
+        return {
+            isDone: result.isDone,
+            output: result.output,
+            actionTypes: result.actions[0].map((a: { actionType: ActionType }) => a.actionType),
+        };
+    }
+
+    it("completes after a 2-entity lock is released and an activity is scheduled", async () => {
+        const a = new EntityId("Account", "A");
+        const b = new EntityId("Account", "B");
+        const result = await runLockReleaseThenActivity([a, b], "receipt-AB");
+
+        // Without the fix the activity's completion (TaskScheduledId = 3) never
+        // matches the worker-predicted ID (2), so isDone would be false.
+        expect(result.isDone).to.equal(true);
+        expect(result.output).to.deep.equal({ receipt: "receipt-AB", lockedAfter: false });
+        expect(result.actionTypes).to.deep.equal([
+            ActionType.LockEntities,
+            ActionType.ReleaseEntities,
+            ActionType.CallActivity,
+        ]);
+    });
+
+    it("completes after a 3-entity lock is released and an activity is scheduled", async () => {
+        // Proves the counter advances by the lock-set size (N), not a fixed
+        // amount: here the activity's completion is TaskScheduledId = 4.
+        const a = new EntityId("Account", "A");
+        const b = new EntityId("Account", "B");
+        const c = new EntityId("Account", "C");
+        const result = await runLockReleaseThenActivity([a, b, c], "receipt-ABC");
+
+        expect(result.isDone).to.equal(true);
+        expect(result.output).to.deep.equal({ receipt: "receipt-ABC", lockedAfter: false });
+        expect(result.actionTypes).to.deep.equal([
+            ActionType.LockEntities,
+            ActionType.ReleaseEntities,
+            ActionType.CallActivity,
+        ]);
+    });
+});
+
+// -----------------------------------------------------------------------------
+// Many awaits after an early release (no cumulative drift)
+//
+// Extends the parity regression: after releasing a 2-entity lock, schedule
+// several sequential durable operations and prove every one of them resolves.
+// A single mis-count at the release knocks the IDs of *all* following awaits
+// out of alignment, so the failure surfaces on the first post-release await and
+// never recovers. These tests pin the whole post-release tail.
+//
+// ID layout for a 2-entity lock (N = 2):
+//   id 0        : lock request
+//   ids 1, 2    : the two release messages
+//   ids 3, 4... : each sequential durable op scheduled after the release
+// A non-durable statement (plain JS between yields) schedules no backend
+// message and therefore consumes no task-ID slot.
+// -----------------------------------------------------------------------------
+function buildLockReleaseThenActivitiesHistory(
+    firstTimestamp: Date,
+    entities: EntityId[],
+    lockRequestId: string,
+    includeResponse: boolean,
+    activityResults: unknown[]
+): HistoryEvent[] {
+    const orchestratorId = uuidv1();
+    const t0 = firstTimestamp;
+    const t1 = moment(firstTimestamp).add(1, "s").toDate();
+    const t2 = moment(firstTimestamp).add(2, "s").toDate();
+
+    const events: HistoryEvent[] = [
+        new OrchestratorStartedEvent({ eventId: -1, timestamp: t0, isPlayed: false }),
+        new ExecutionStartedEvent({
+            eventId: -1,
+            timestamp: t1,
+            isPlayed: true,
+            name: orchestratorId,
+            input: undefined,
+        }),
+        new EventSentEvent({
+            eventId: 0,
+            timestamp: t1,
+            isPlayed: true,
+            name: "op",
+            input: JSON.stringify({
+                id: lockRequestId,
+                parent: orchestratorId,
+                lockset: entities.map((e) => ({ name: e.name, key: e.key })),
+                position: 0,
+            }),
+            instanceId: EntityId.getSchedulerIdFromEntityId(entities[0]),
+        }),
+        new OrchestratorCompletedEvent({ eventId: -1, timestamp: t1, isPlayed: true }),
+    ];
+
+    if (includeResponse) {
+        // lock = id 0, release messages = ids 1..N, activities = ids N+1, N+2, ...
+        const firstActivityId = entities.length + 1;
+        events.push(
+            new OrchestratorStartedEvent({ eventId: -1, timestamp: t2, isPlayed: false }),
+            new EventRaisedEvent({
+                eventId: -1,
+                timestamp: t2,
+                isPlayed: false,
+                name: lockRequestId,
+                input: JSON.stringify({ result: null }),
+            })
+        );
+        activityResults.forEach((res, i) => {
+            events.push(
+                new TaskCompletedEvent({
+                    eventId: -1,
+                    timestamp: t2,
+                    isPlayed: false,
+                    taskScheduledId: firstActivityId + i,
+                    result: JSON.stringify(res),
+                })
+            );
+        });
+    }
+
+    return events;
+}
+
+describe("Critical Sections - many awaits after early release", () => {
+    // Two-pass driver: a probe pass (lock response absent) captures the
+    // deterministic lockRequestId, then a real pass replays with the lock
+    // response and every post-release activity completion present.
+    async function driveLockReleaseThenActivities(
+        orchestrator: ReturnType<typeof createOrchestrator>,
+        entities: EntityId[],
+        activityResults: unknown[],
+        label: string
+    ): Promise<{ isDone: boolean; output: unknown; actionTypes: ActionType[] }> {
+        const firstTs = moment.utc().toDate();
+
+        const probeInput = new DurableOrchestrationInput(
+            label,
+            buildLockReleaseThenActivitiesHistory(firstTs, entities, "placeholder", false, []),
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            ReplaySchema.V4
+        );
+        const probe = await orchestrator(probeInput, new DummyOrchestrationContextRuntime());
+        const lockRequestId = (probe.actions[0][0] as LockEntitiesAction).lockRequestId;
+
+        const replayInput = new DurableOrchestrationInput(
+            label,
+            buildLockReleaseThenActivitiesHistory(
+                firstTs,
+                entities,
+                lockRequestId,
+                true,
+                activityResults
+            ),
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            ReplaySchema.V4
+        );
+        const result = await orchestrator(replayInput, new DummyOrchestrationContextRuntime());
+        return {
+            isDone: result.isDone,
+            output: result.output,
+            actionTypes: result.actions[0].map((a: { actionType: ActionType }) => a.actionType),
+        };
+    }
+
+    it("completes when 4 awaits follow an early release", async () => {
+        const a = new EntityId("Account", "A");
+        const b = new EntityId("Account", "B");
+        // Four post-release activities -> TaskScheduledId 3, 4, 5, 6.
+        const results = ["r1", "r2", "r3", "r4"];
+
+        const orchestrator = createOrchestrator(function* (context) {
+            const lock = (yield context.df.lock(a, b)) as DurableLock;
+            lock.release();
+            const o1 = yield context.df.callActivity("act", 1);
+            const o2 = yield context.df.callActivity("act", 2);
+            const o3 = yield context.df.callActivity("act", 3);
+            const o4 = yield context.df.callActivity("act", 4);
+            return [o1, o2, o3, o4];
+        });
+
+        const result = await driveLockReleaseThenActivities(
+            orchestrator,
+            [a, b],
+            results,
+            "release-4-awaits"
+        );
+
+        // A miscounted release would strand the FIRST post-release await and
+        // never reach the 4th, so isDone proves the whole tail stayed aligned.
+        expect(result.isDone).to.equal(true);
+        expect(result.output).to.deep.equal(["r1", "r2", "r3", "r4"]);
+        expect(result.actionTypes).to.deep.equal([
+            ActionType.LockEntities,
+            ActionType.ReleaseEntities,
+            ActionType.CallActivity,
+            ActionType.CallActivity,
+            ActionType.CallActivity,
+            ActionType.CallActivity,
+        ]);
+    });
+
+    it("completes with 2 awaits, a non-durable statement, then 3 more awaits after release", async () => {
+        const a = new EntityId("Account", "A");
+        const b = new EntityId("Account", "B");
+        // Five post-release activities -> TaskScheduledId 3, 4, 5, 6, 7. The
+        // plain `localSum` statement between them schedules nothing, so it must
+        // NOT consume a task-ID slot; if it (or the release) miscounts, ids 5-7
+        // never match and the orchestration stalls.
+        const results = [10, 20, 100, 200, 300];
+
+        const orchestrator = createOrchestrator(function* (context) {
+            const lock = (yield context.df.lock(a, b)) as DurableLock;
+            lock.release();
+            const r1 = yield context.df.callActivity("act", 1);
+            const r2 = yield context.df.callActivity("act", 2);
+            // Non-durable line: pure JS, no yield, no backend message.
+            const localSum = (r1 as number) + (r2 as number);
+            const r3 = yield context.df.callActivity("act", 3);
+            const r4 = yield context.df.callActivity("act", 4);
+            const r5 = yield context.df.callActivity("act", 5);
+            return { r1, r2, r3, r4, r5, localSum };
+        });
+
+        const result = await driveLockReleaseThenActivities(
+            orchestrator,
+            [a, b],
+            results,
+            "release-2-nondurable-3"
+        );
+
+        expect(result.isDone).to.equal(true);
+        expect(result.output).to.deep.equal({
+            r1: 10,
+            r2: 20,
+            r3: 100,
+            r4: 200,
+            r5: 300,
+            localSum: 30,
+        });
+        expect(result.actionTypes).to.deep.equal([
+            ActionType.LockEntities,
+            ActionType.ReleaseEntities,
+            ActionType.CallActivity,
+            ActionType.CallActivity,
+            ActionType.CallActivity,
+            ActionType.CallActivity,
+            ActionType.CallActivity,
+        ]);
+    });
+});
+
+// -----------------------------------------------------------------------------
+// Post-release op-type coverage (timer + entity)
+//
+// The early-release stall reproduced for EVERY durable op type scheduled after
+// the release, each of which resolves through a DIFFERENT completion-matching
+// path in the executor:
+//   - activity -> TaskCompleted keyed by TaskScheduledId   (covered above)
+//   - timer    -> TimerFired    keyed by TimerId
+//   - entity   -> EventSent re-key (by request GUID) then EventRaised by Name
+// The activity tests already prove the counter realigns; these prove the
+// realigned id lands the post-release op correctly in the timer and entity
+// paths too. For a 2-entity lock the post-release op is id 3 (lock = 0, the two
+// release messages = 1 and 2).
+// -----------------------------------------------------------------------------
+
+// Shared prefix: OrchestratorStarted + ExecutionStarted + the lock's EventSent
+// (id 0) + OrchestratorCompleted. The lock acquisition is surfaced later as an
+// EventRaised keyed by the lockRequestId GUID, exactly like buildLockHistory.
+function lockPrefixEvents(
+    orchestratorId: string,
+    t0: Date,
+    t1: Date,
+    entities: EntityId[],
+    lockRequestId: string
+): HistoryEvent[] {
+    return [
+        new OrchestratorStartedEvent({ eventId: -1, timestamp: t0, isPlayed: false }),
+        new ExecutionStartedEvent({
+            eventId: -1,
+            timestamp: t1,
+            isPlayed: true,
+            name: orchestratorId,
+            input: undefined,
+        }),
+        new EventSentEvent({
+            eventId: 0,
+            timestamp: t1,
+            isPlayed: true,
+            name: "op",
+            input: JSON.stringify({
+                id: lockRequestId,
+                parent: orchestratorId,
+                lockset: entities.map((e) => ({ name: e.name, key: e.key })),
+                position: 0,
+            }),
+            instanceId: EntityId.getSchedulerIdFromEntityId(entities[0]),
+        }),
+        new OrchestratorCompletedEvent({ eventId: -1, timestamp: t1, isPlayed: true }),
+    ];
+}
+
+// lock(entities) -> release() -> createTimer. The timer's completion is a
+// TimerFired keyed by TimerId = N + 1 (entities.length + 1).
+function buildLockReleaseTimerHistory(
+    firstTimestamp: Date,
+    entities: EntityId[],
+    lockRequestId: string,
+    includeResponse: boolean
+): HistoryEvent[] {
+    const orchestratorId = uuidv1();
+    const t0 = firstTimestamp;
+    const t1 = moment(firstTimestamp).add(1, "s").toDate();
+    const t2 = moment(firstTimestamp).add(2, "s").toDate();
+
+    const events = lockPrefixEvents(orchestratorId, t0, t1, entities, lockRequestId);
+
+    if (includeResponse) {
+        const timerId = entities.length + 1;
+        events.push(
+            new OrchestratorStartedEvent({ eventId: -1, timestamp: t2, isPlayed: false }),
+            new EventRaisedEvent({
+                eventId: -1,
+                timestamp: t2,
+                isPlayed: false,
+                name: lockRequestId,
+                input: JSON.stringify({ result: null }),
+            }),
+            new TimerFiredEvent({
+                eventId: -1,
+                timestamp: t2,
+                isPlayed: false,
+                timerId,
+                fireAt: t2,
+            })
+        );
+    }
+
+    return events;
+}
+
+// lock(entities) -> release() -> callEntity(target, "get"). The entity call is
+// scheduled as id N + 1; its EventSent (EventId = N + 1) re-keys the open task
+// to the request GUID, then an EventRaised by that GUID delivers the response.
+function buildLockReleaseEntityHistory(
+    firstTimestamp: Date,
+    entities: EntityId[],
+    target: EntityId,
+    lockRequestId: string,
+    entityRequestId: string,
+    includeResponse: boolean,
+    entityResult: unknown
+): HistoryEvent[] {
+    const orchestratorId = uuidv1();
+    const t0 = firstTimestamp;
+    const t1 = moment(firstTimestamp).add(1, "s").toDate();
+    const t2 = moment(firstTimestamp).add(2, "s").toDate();
+
+    const events = lockPrefixEvents(orchestratorId, t0, t1, entities, lockRequestId);
+
+    if (includeResponse) {
+        const entityCallTaskId = entities.length + 1;
+        events.push(
+            new OrchestratorStartedEvent({ eventId: -1, timestamp: t2, isPlayed: false }),
+            // Lock acquired.
+            new EventRaisedEvent({
+                eventId: -1,
+                timestamp: t2,
+                isPlayed: false,
+                name: lockRequestId,
+                input: JSON.stringify({ result: null }),
+            }),
+            // The post-release callEntity's EventSent. EventId must equal the
+            // task's predicted id (N + 1) so the executor re-keys it to the
+            // request GUID; this is the entity-specific completion path.
+            new EventSentEvent({
+                eventId: entityCallTaskId,
+                timestamp: t2,
+                isPlayed: false,
+                name: "op",
+                input: JSON.stringify({
+                    id: entityRequestId,
+                    parent: orchestratorId,
+                    name: "get",
+                }),
+                instanceId: EntityId.getSchedulerIdFromEntityId(target),
+            }),
+            // The entity response, keyed by the request GUID.
+            new EventRaisedEvent({
+                eventId: -1,
+                timestamp: t2,
+                isPlayed: false,
+                name: entityRequestId,
+                input: JSON.stringify({ result: JSON.stringify(entityResult) }),
+            })
+        );
+    }
+
+    return events;
+}
+
+describe("Critical Sections - post-release op-type coverage", () => {
+    it("completes when a timer is scheduled after an early release", async () => {
+        const a = new EntityId("Account", "A");
+        const b = new EntityId("Account", "B");
+
+        const orchestrator = createOrchestrator(function* (context) {
+            const lock = (yield context.df.lock(a, b)) as DurableLock;
+            lock.release();
+            // Durable timer AFTER release (TimerFired keyed by TimerId = 3).
+            const fireAt = new Date(context.df.currentUtcDateTime.getTime() + 1000);
+            yield context.df.createTimer(fireAt);
+            return { firedAfterRelease: true, lockedAfter: context.df.isLocked().isLocked };
+        });
+
+        const firstTs = moment.utc().toDate();
+        const probeInput = new DurableOrchestrationInput(
+            "release-then-timer",
+            buildLockReleaseTimerHistory(firstTs, [a, b], "placeholder", false),
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            ReplaySchema.V4
+        );
+        const probe = await orchestrator(probeInput, new DummyOrchestrationContextRuntime());
+        const lockRequestId = (probe.actions[0][0] as LockEntitiesAction).lockRequestId;
+
+        const replayInput = new DurableOrchestrationInput(
+            "release-then-timer",
+            buildLockReleaseTimerHistory(firstTs, [a, b], lockRequestId, true),
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            ReplaySchema.V4
+        );
+        const result = await orchestrator(replayInput, new DummyOrchestrationContextRuntime());
+
+        expect(result.isDone).to.equal(true);
+        expect(result.output).to.deep.equal({ firedAfterRelease: true, lockedAfter: false });
+        expect(
+            result.actions[0].map((x: { actionType: ActionType }) => x.actionType)
+        ).to.deep.equal([
+            ActionType.LockEntities,
+            ActionType.ReleaseEntities,
+            ActionType.CreateTimer,
+        ]);
+    });
+
+    it("completes when a callEntity is scheduled after an early release", async () => {
+        const a = new EntityId("Account", "A");
+        const b = new EntityId("Account", "B");
+        const target = new EntityId("Account", "C"); // unlocked once the section is released
+        const entityRequestId = "entity-req-guid"; // authored on both EventSent input and EventRaised name
+
+        const orchestrator = createOrchestrator(function* (context) {
+            const lock = (yield context.df.lock(a, b)) as DurableLock;
+            lock.release();
+            // Durable callEntity AFTER release (scheduled as id 3, resolved via
+            // the EventSent re-key -> EventRaised path).
+            const value = yield context.df.callEntity(target, "get");
+            return { value, lockedAfter: context.df.isLocked().isLocked };
+        });
+
+        const firstTs = moment.utc().toDate();
+        const probeInput = new DurableOrchestrationInput(
+            "release-then-entity",
+            buildLockReleaseEntityHistory(
+                firstTs,
+                [a, b],
+                target,
+                "placeholder",
+                entityRequestId,
+                false,
+                undefined
+            ),
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            ReplaySchema.V4
+        );
+        const probe = await orchestrator(probeInput, new DummyOrchestrationContextRuntime());
+        const lockRequestId = (probe.actions[0][0] as LockEntitiesAction).lockRequestId;
+
+        const replayInput = new DurableOrchestrationInput(
+            "release-then-entity",
+            buildLockReleaseEntityHistory(
+                firstTs,
+                [a, b],
+                target,
+                lockRequestId,
+                entityRequestId,
+                true,
+                42
+            ),
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            ReplaySchema.V4
+        );
+        const result = await orchestrator(replayInput, new DummyOrchestrationContextRuntime());
+
+        expect(result.isDone).to.equal(true);
+        expect(result.output).to.deep.equal({ value: 42, lockedAfter: false });
+        expect(
+            result.actions[0].map((x: { actionType: ActionType }) => x.actionType)
+        ).to.deep.equal([
+            ActionType.LockEntities,
+            ActionType.ReleaseEntities,
+            ActionType.CallEntity,
+        ]);
     });
 });

--- a/test/integration/critical-sections-spec.ts
+++ b/test/integration/critical-sections-spec.ts
@@ -810,6 +810,59 @@ describe("Critical Sections - early release then durable work", () => {
             ActionType.CallActivity,
         ]);
     });
+
+    it("double release() advances the counter only once and emits one ReleaseEntities", async () => {
+        // release() is idempotent: the second call is a no-op, so the counter
+        // advances by N exactly once and the activity still lands at
+        // TaskScheduledId = N + 1 = 3 for a 2-entity lock. A second advance
+        // would schedule the activity at id 5, leaving the id-3 completion
+        // unmatched and the orchestration stalled.
+        const a = new EntityId("Account", "A");
+        const b = new EntityId("Account", "B");
+
+        const orchestrator = createOrchestrator(function* (context) {
+            const lock = (yield context.df.lock(a, b)) as DurableLock;
+            lock.release();
+            lock.release(); // idempotent: must not advance the counter again
+            const receipt = yield context.df.callActivity("sendReceipt", { ok: true });
+            return { receipt };
+        });
+
+        const firstTs = moment.utc().toDate();
+        const probeInput = new DurableOrchestrationInput(
+            "double-release-instance",
+            buildLockReleaseActivityHistory(firstTs, [a, b], "placeholder", false, undefined),
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            ReplaySchema.V4
+        );
+        const probe = await orchestrator(probeInput, new DummyOrchestrationContextRuntime());
+        const lockRequestId = (probe.actions[0][0] as LockEntitiesAction).lockRequestId;
+
+        const replayInput = new DurableOrchestrationInput(
+            "double-release-instance",
+            buildLockReleaseActivityHistory(firstTs, [a, b], lockRequestId, true, "receipt-AB"),
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            ReplaySchema.V4
+        );
+        const result = await orchestrator(replayInput, new DummyOrchestrationContextRuntime());
+
+        expect(result.isDone).to.equal(true);
+        expect(result.output).to.deep.equal({ receipt: "receipt-AB" });
+        // Only one ReleaseEntities action despite two release() calls.
+        expect(
+            result.actions[0].map((x: { actionType: ActionType }) => x.actionType)
+        ).to.deep.equal([
+            ActionType.LockEntities,
+            ActionType.ReleaseEntities,
+            ActionType.CallActivity,
+        ]);
+    });
 });
 
 // -----------------------------------------------------------------------------
@@ -1288,5 +1341,77 @@ describe("Critical Sections - post-release op-type coverage", () => {
             ActionType.ReleaseEntities,
             ActionType.CallEntity,
         ]);
+    });
+});
+
+// -----------------------------------------------------------------------------
+// Fire-and-forget increment - signalEntity default path
+//
+// recordFireAndForgetAction is shared by two callers: the lock release (which
+// passes the lock-set size) and signalEntity (which uses the default increment
+// of 1). These tests pin that default: a signal consumes exactly one task-ID
+// slot, so a durable op scheduled after it lands at the next id and resolves.
+//   id 0 : the signal (fire-and-forget, no completion event)
+//   id 1 : the activity scheduled immediately after the signal
+// -----------------------------------------------------------------------------
+function buildSignalThenActivityHistory(
+    firstTimestamp: Date,
+    activityResult: unknown
+): HistoryEvent[] {
+    const orchestratorId = uuidv1();
+    const t0 = firstTimestamp;
+    const t1 = moment(firstTimestamp).add(1, "s").toDate();
+    const t2 = moment(firstTimestamp).add(2, "s").toDate();
+
+    return [
+        new OrchestratorStartedEvent({ eventId: -1, timestamp: t0, isPlayed: false }),
+        new ExecutionStartedEvent({
+            eventId: -1,
+            timestamp: t1,
+            isPlayed: true,
+            name: orchestratorId,
+            input: undefined,
+        }),
+        new OrchestratorCompletedEvent({ eventId: -1, timestamp: t1, isPlayed: true }),
+        new OrchestratorStartedEvent({ eventId: -1, timestamp: t2, isPlayed: false }),
+        // The signal consumed slot 0; the activity scheduled after it is slot 1.
+        new TaskCompletedEvent({
+            eventId: -1,
+            timestamp: t2,
+            isPlayed: false,
+            taskScheduledId: 1,
+            result: JSON.stringify(activityResult),
+        }),
+    ];
+}
+
+describe("Critical Sections - signalEntity fire-and-forget increment", () => {
+    it("a durable op after signalEntity stays aligned (default increment of 1)", async () => {
+        const orchestrator = createOrchestrator(function* (context) {
+            // signalEntity is the other caller of recordFireAndForgetAction and
+            // relies on the default increment of 1. The activity scheduled right
+            // after must land at task id 1 and resolve.
+            context.df.signalEntity(new EntityId("Account", "Z"), "ping");
+            const result = yield context.df.callActivity("afterSignal", null);
+            return { result };
+        });
+
+        const firstTs = moment.utc().toDate();
+        const input = new DurableOrchestrationInput(
+            "signal-then-activity",
+            buildSignalThenActivityHistory(firstTs, "signal-ok"),
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            ReplaySchema.V4
+        );
+        const result = await orchestrator(input, new DummyOrchestrationContextRuntime());
+
+        expect(result.isDone).to.equal(true);
+        expect(result.output).to.deep.equal({ result: "signal-ok" });
+        expect(
+            result.actions[0].map((x: { actionType: ActionType }) => x.actionType)
+        ).to.deep.equal([ActionType.SignalEntity, ActionType.CallActivity]);
     });
 });

--- a/test/integration/critical-sections-spec.ts
+++ b/test/integration/critical-sections-spec.ts
@@ -651,18 +651,16 @@ describe("Critical Sections - release-pattern parity", () => {
 });
 
 // -----------------------------------------------------------------------------
-// The extension's ReleaseLocks() sends one entity message per
-// locked entity, so releasing an N-entity lock consumes N task-ID slots in the
-// backend's sequence space. The worker previously advanced its own sequence
-// counter by only 1 for any release.
+// Builds the history for `lock(entities) -> release() -> callActivity`.
 //
-// Extension-side task IDs for `lock(entities) -> release() -> callActivity`:
+// The extension's ReleaseLocks() sends one entity message per locked entity, so
+// releasing an N-entity lock consumes N task-ID slots in the backend's sequence
+// space. The extension-side task IDs are:
 //   id 0        : lock request (single EventSent to the first entity)
 //   ids 1..N    : one release message per locked entity
 //   id N + 1    : the activity scheduled immediately after release
-// So the activity's TaskCompleted carries TaskScheduledId = N + 1.
-// The worker predicts that same ID and the orchestration completes; without
-// it the worker predicts ID 2 (N=2) / 2 (N=3) and stalls (isDone === false).
+// So the activity's TaskCompleted carries TaskScheduledId = N + 1, and the
+// worker advances its sequence counter by N at the release to match it.
 // -----------------------------------------------------------------------------
 function buildLockReleaseActivityHistory(
     firstTimestamp: Date,
@@ -728,7 +726,7 @@ function buildLockReleaseActivityHistory(
     return events;
 }
 
-describe("Critical Sections - early release then durable work (parity regression)", () => {
+describe("Critical Sections - early release then durable work", () => {
     // lock(entities) -> release() -> callActivity, driven through the full
     // replay pipeline. Returns the final orchestrator state.
     async function runLockReleaseThenActivity(
@@ -737,8 +735,7 @@ describe("Critical Sections - early release then durable work (parity regression
     ): Promise<{ isDone: boolean; output: unknown; actionTypes: ActionType[] }> {
         const orchestrator = createOrchestrator(function* (context) {
             const lock = (yield context.df.lock(entities)) as DurableLock;
-            // Release the section, then schedule further durable work -- the
-            // exact shape that used to stall for multi-entity locks.
+            // Release the section, then schedule further durable work.
             lock.release();
             const receipt = yield context.df.callActivity("sendReceipt", { ok: true });
             return { receipt, lockedAfter: context.df.isLocked().isLocked };
@@ -786,8 +783,8 @@ describe("Critical Sections - early release then durable work (parity regression
         const b = new EntityId("Account", "B");
         const result = await runLockReleaseThenActivity([a, b], "receipt-AB");
 
-        // Without the fix the activity's completion (TaskScheduledId = 3) never
-        // matches the worker-predicted ID (2), so isDone would be false.
+        // The activity completes as TaskScheduledId = N + 1 = 3; the worker must
+        // advance its counter by N = 2 at the release for the IDs to line up.
         expect(result.isDone).to.equal(true);
         expect(result.output).to.deep.equal({ receipt: "receipt-AB", lockedAfter: false });
         expect(result.actionTypes).to.deep.equal([
@@ -816,13 +813,13 @@ describe("Critical Sections - early release then durable work (parity regression
 });
 
 // -----------------------------------------------------------------------------
-// Many awaits after an early release (no cumulative drift)
+// Many awaits after an early release
 //
-// Extends the parity regression: after releasing a 2-entity lock, schedule
-// several sequential durable operations and prove every one of them resolves.
-// A single mis-count at the release knocks the IDs of *all* following awaits
-// out of alignment, so the failure surfaces on the first post-release await and
-// never recovers. These tests pin the whole post-release tail.
+// After releasing a 2-entity lock, schedule several sequential durable
+// operations and prove every one of them resolves. The release advances the
+// worker's task-ID counter by the lock-set size so the IDs of all following
+// awaits stay aligned with the extension; these tests pin the whole
+// post-release tail, not just the first op.
 //
 // ID layout for a 2-entity lock (N = 2):
 //   id 0        : lock request
@@ -967,8 +964,8 @@ describe("Critical Sections - many awaits after early release", () => {
             "release-4-awaits"
         );
 
-        // A miscounted release would strand the FIRST post-release await and
-        // never reach the 4th, so isDone proves the whole tail stayed aligned.
+        // Every post-release await must resolve in order; isDone confirms the
+        // whole tail stayed aligned with the extension's task IDs.
         expect(result.isDone).to.equal(true);
         expect(result.output).to.deep.equal(["r1", "r2", "r3", "r4"]);
         expect(result.actionTypes).to.deep.equal([
@@ -986,8 +983,7 @@ describe("Critical Sections - many awaits after early release", () => {
         const b = new EntityId("Account", "B");
         // Five post-release activities -> TaskScheduledId 3, 4, 5, 6, 7. The
         // plain `localSum` statement between them schedules nothing, so it must
-        // NOT consume a task-ID slot; if it (or the release) miscounts, ids 5-7
-        // never match and the orchestration stalls.
+        // NOT consume a task-ID slot.
         const results = [10, 20, 100, 200, 300];
 
         const orchestrator = createOrchestrator(function* (context) {
@@ -1034,16 +1030,14 @@ describe("Critical Sections - many awaits after early release", () => {
 // -----------------------------------------------------------------------------
 // Post-release op-type coverage (timer + entity)
 //
-// The early-release stall reproduced for EVERY durable op type scheduled after
-// the release, each of which resolves through a DIFFERENT completion-matching
-// path in the executor:
+// Each durable op type resolves through a different completion-matching path in
+// the executor:
 //   - activity -> TaskCompleted keyed by TaskScheduledId   (covered above)
 //   - timer    -> TimerFired    keyed by TimerId
 //   - entity   -> EventSent re-key (by request GUID) then EventRaised by Name
-// The activity tests already prove the counter realigns; these prove the
-// realigned id lands the post-release op correctly in the timer and entity
-// paths too. For a 2-entity lock the post-release op is id 3 (lock = 0, the two
-// release messages = 1 and 2).
+// These confirm the post-release op's task ID lands correctly in the timer and
+// entity paths too. For a 2-entity lock the post-release op is id 3 (lock = 0,
+// the two release messages = 1 and 2).
 // -----------------------------------------------------------------------------
 
 // Shared prefix: OrchestratorStarted + ExecutionStarted + the lock's EventSent


### PR DESCRIPTION
## Summary

The JS SDK and the Durable extension each assign sequential integer IDs to durable operations, and those IDs must stay in lockstep for replay to match completions to the right `yield`. When a critical section is released, the extension sends **one message per locked entity** (N messages for an N-entity lock), consuming N ID slots — but the SDK only advanced its own counter by **1**. So after releasing a multi-entity lock, every following durable operation (activity, entity call, timer) was registered under an ID that was too low by **(N − 1)**; its completion event never matched, the generator never resumed, and the orchestration hung in `Running` forever. The bug was invisible for single-entity locks (N = 1, drift 0) and only appeared once you locked 2+ entities and then did more durable work after release.

## Example

```js
const lock = yield ctx.df.lock(a, b);     // 2-entity lock
yield ctx.df.callEntity(a, "add", -10);
yield ctx.df.callEntity(b, "add", 10);
lock.release();                            // extension sends 2 release messages
const receipt = yield ctx.df.callActivity("sendReceipt", {...}); // ← hangs
```

| Operation | Extension ID | SDK ID (buggy) |
|-----------|-------------|----------------|
| lock | 0 | 0 |
| callEntity(a) | 1 | 1 |
| callEntity(b) | 2 | 2 |
| release → a | 3 | — (+1 only) |
| release → b | 4 | — |
| `sendReceipt` | **5** | **4** ✗ |

The activity completes as `TaskScheduledId = 5`, but the SDK registered it as `4`, so
the lookup misses and the result is parked forever in `deferredTasks`.

## Fix

`release()` now advances the SDK counter by the **number of locked entities**
(`deduped.length`) instead of 1, so post-release IDs realign with the extension.

- `src/orchestrations/TaskOrchestrationExecutor.ts` — `recordFireAndForgetAction(action, sequenceNumberIncrement = 1)`
- `src/orchestrations/DurableOrchestrationContext.ts` — release callback passes `deduped.length`

This matches .NET, where the in-proc `ReleaseLocks()` naturally advances the same
counter by N. Regression tests cover 2- and 3-entity locks (the 3-entity case proves
the increment scales with N, not a fixed +2).
