### PR TITLE
Route npm dependency restores through CFS

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@azure:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@opentelemetry:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Note: [Azurite V3](https://github.com/Azure/Azurite) does not have support for T
 
 Create a folder say AzureWebJobsStorage
 
-`npm install azurite@2.7.1 -g`
+`sudo env NPM_CONFIG_USERCONFIG="$(git rev-parse --show-toplevel)/.npmrc" npm install azurite@2.7.1 -g`
 
 `azurite -l ./AzureWebJobsStorage`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Note: [Azurite V3](https://github.com/Azure/Azurite) does not have support for T
 
 Create a folder say AzureWebJobsStorage
 
-`sudo env NPM_CONFIG_USERCONFIG="$(git rev-parse --show-toplevel)/.npmrc" npm install azurite@2.7.1 -g`
+`npm install azurite@2.7.1 -g`
 
 `azurite -l ./AzureWebJobsStorage`
 

--- a/azure-pipelines/templates/build.yml
+++ b/azure-pipelines/templates/build.yml
@@ -14,6 +14,10 @@ jobs:
             inputs:
                 versionSpec: 20.x
             displayName: "Install Node.js"
+          - task: npmAuthenticate@0
+            displayName: "Authenticate to CFS npm feed"
+            inputs:
+                workingFile: "$(System.DefaultWorkingDirectory)/.npmrc"
           - script: npm ci
             displayName: "npm ci"
           - script: npm run-script build
@@ -25,6 +29,6 @@ jobs:
           - task: CopyFiles@2
             displayName: "Copy package to staging"
             inputs:
-                SourceFolder: $(System.DefaultWorkingDirectory)
+                SourceFolder: "$(System.DefaultWorkingDirectory)"
                 Contents: "*.tgz"
-                TargetFolder: $(Build.ArtifactStagingDirectory)
+                TargetFolder: "$(Build.ArtifactStagingDirectory)"

--- a/azure-pipelines/templates/test.yml
+++ b/azure-pipelines/templates/test.yml
@@ -17,6 +17,10 @@ jobs:
             inputs:
                 versionSpec: $(NODE_VERSION)
             displayName: "Install Node dependencies"
+          - task: npmAuthenticate@0
+            displayName: "Authenticate to CFS npm feed"
+            inputs:
+                workingFile: "$(System.DefaultWorkingDirectory)/.npmrc"
           - script: npm ci
             displayName: "npm ci"
           - script: npm run test
@@ -36,12 +40,16 @@ jobs:
                 Contents: "**"
                 TargetFolder: "$(Agent.BuildDirectory)/test-app"
                 CleanTargetFolder: true
-          - script: npm install $(System.DefaultWorkingDirectory)/package.tgz
+          - task: npmAuthenticate@0
+            displayName: "Authenticate copied test app to CFS npm feed"
+            inputs:
+                workingFile: "$(Agent.BuildDirectory)/test-app/.npmrc"
+          - script: npm install "$(System.DefaultWorkingDirectory)/package.tgz"
             displayName: "Install packed durable-functions module (test app)"
-            workingDirectory: $(Agent.BuildDirectory)/test-app
+            workingDirectory: "$(Agent.BuildDirectory)/test-app"
           - script: npm install
             displayName: "npm install (test app)"
-            workingDirectory: $(Agent.BuildDirectory)/test-app
+            workingDirectory: "$(Agent.BuildDirectory)/test-app"
           - script: npm run build
             displayName: "Build smoke test app"
             workingDirectory: "$(Agent.BuildDirectory)/test-app"

--- a/test/test-app/.funcignore
+++ b/test/test-app/.funcignore
@@ -1,6 +1,7 @@
 *.js.map
 *.ts
 .git*
+.npmrc
 .vscode
 __azurite_db*__.json
 __blobstorage__

--- a/test/test-app/.npmrc
+++ b/test/test-app/.npmrc
@@ -1,0 +1,3 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@azure:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@opentelemetry:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/


### PR DESCRIPTION
## Summary

- route repository-owned npm restores through `azfunc/public/upstream-public`, including explicit mappings for every scoped production dependency
- authenticate both root and detached smoke-test pipeline contexts before npm runs, and quote interpolated paths
- preserve customer-facing samples and lockfile URLs while keeping `.npmrc` out of npm packs and Functions deployment content
- make the documented global Azurite install preserve `NPM_CONFIG_USERCONFIG` through `sudo env`

The repository audit found npm manifests only. There are no repository NuGet or Python manifests/configuration to onboard; customer-created `extensions.csproj`/`func extensions install` guidance and sample npm trees remain unchanged.

## Validation

- restored the root graph from an empty npm cache with ephemeral Azure Artifacts authentication; verbose requests used `pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public` and Azure Artifacts blob hosts, with no direct npmjs.org, nuget.org, or PyPI traffic
- ran `npm run test`, `npm run test:nolint`, and `npm run build` (307 tests passing in each test run; existing non-null-assertion lint warning remains)
- ran production prune, `npm pack --dry-run --json`, `npm publish --dry-run --json`, and a real pack; the 206-entry archive contained no `.npmrc`, credentials, lockfiles, or `node_modules`
- installed the packed SDK and restored/built the detached test app from a Windows path containing spaces using argument-array invocation and an empty cache; no direct public-registry traffic
- installed global `azurite@2.7.1` from an empty cache through CFS with an explicit user config
- exercised `npm audit` through CFS; it reports the existing 8 dependency findings (1 low, 3 moderate, 4 high) without suppression