### PR TITLE
Migrate Inventory-as-Code ownership from c5281ccb-b379-4acf-9099-95a37f9805f3 to e8fdf03b-44f7-48d3-8653-a744c922a342

### DIFF
--- a/es-metadata.yml
+++ b/es-metadata.yml
@@ -5,7 +5,7 @@ providers:
   metadata:
     isProduction: true
     accountableOwners:
-      service: c5281ccb-b379-4acf-9099-95a37f9805f3
+      service: e8fdf03b-44f7-48d3-8653-a744c922a342
     routing:
       defaultAreaPath:
         org: azfunc


### PR DESCRIPTION
This pull request migrates repository ownership through Inventory-as-Code.

- Source Service Tree service: `c5281ccb-b379-4acf-9099-95a37f9805f3`
- Target Service Tree service: `e8fdf03b-44f7-48d3-8653-a744c922a342`
- Scope: only the root `es-metadata.yml` InventoryAsCode `metadata.accountableOwners.service` scalar

The target Product Catalog mapping is established immediately after this pull request is opened. Source
eviction remains a required external action in the repository portal. No other repository metadata or
source files are changed. This pull request is intentionally not auto-merged.

<!-- product-catalog-repo-migrator:c5281ccb-b379-4acf-9099-95a37f9805f3:e8fdf03b-44f7-48d3-8653-a744c922a342 -->