### PR TITLE
Expose orchestration version on DurableOrchestrationStatus 

### DIFF
--- a/src/orchestrations/DurableOrchestrationStatus.ts
+++ b/src/orchestrations/DurableOrchestrationStatus.ts
@@ -3,6 +3,7 @@ import { OrchestrationRuntimeStatus } from "./OrchestrationRuntimeStatus";
 
 export class DurableOrchestrationStatus implements types.DurableOrchestrationStatus {
     public readonly name: string;
+    public readonly version?: string;
     public readonly instanceId: string;
     public readonly createdTime: Date;
     public readonly lastUpdatedTime: Date;
@@ -23,6 +24,7 @@ export class DurableOrchestrationStatus implements types.DurableOrchestrationSta
         }
 
         this.name = init.name;
+        this.version = init.version;
         this.instanceId = init.instanceId;
         this.createdTime = new Date(init.createdTime);
         this.lastUpdatedTime = new Date(init.lastUpdatedTime);
@@ -38,6 +40,7 @@ export class DurableOrchestrationStatus implements types.DurableOrchestrationSta
         return (
             objAsInit !== undefined &&
             typeof objAsInit.name === "string" &&
+            (objAsInit.version === undefined || typeof objAsInit.version === "string") &&
             typeof objAsInit.instanceId === "string" &&
             (typeof objAsInit.createdTime === "string" || objAsInit.createdTime instanceof Date) &&
             (typeof objAsInit.lastUpdatedTime === "string" ||
@@ -51,6 +54,7 @@ export class DurableOrchestrationStatus implements types.DurableOrchestrationSta
 
 interface DurableOrchestrationStatusInit {
     name: string;
+    version?: string;
     instanceId: string;
     createdTime: string | Date;
     lastUpdatedTime: string | Date;

--- a/test/unit/orchestrationclient-spec.ts
+++ b/test/unit/orchestrationclient-spec.ts
@@ -138,6 +138,7 @@ describe("Orchestration Client", () => {
 
             const expectedStatus = new DurableOrchestrationStatus({
                 name: defaultOrchestrationName,
+                version: "2.0",
                 instanceId: defaultInstanceId,
                 createdTime: new Date(),
                 lastUpdatedTime: new Date(),
@@ -161,6 +162,7 @@ describe("Orchestration Client", () => {
 
             const result = await client.getStatus(defaultInstanceId);
             expect(scope.isDone()).to.be.equal(true);
+            expect(result.version).to.be.equal("2.0");
             expect(JSON.stringify(result)).to.be.equal(JSON.stringify(expectedStatus));
         });
 
@@ -535,6 +537,7 @@ describe("Orchestration Client", () => {
             const expectedStatuses: DurableOrchestrationStatus[] = [
                 new DurableOrchestrationStatus({
                     name: defaultOrchestrationName,
+                    version: "2.0",
                     instanceId: defaultInstanceId,
                     createdTime: new Date(),
                     lastUpdatedTime: new Date(),
@@ -552,6 +555,7 @@ describe("Orchestration Client", () => {
 
             const result = await client.getStatusAll();
             expect(scope.isDone()).to.be.equal(true);
+            expect(result[0].version).to.be.equal("2.0");
             expect(JSON.stringify(result)).to.be.equal(JSON.stringify(expectedStatuses));
         });
     });
@@ -586,6 +590,7 @@ describe("Orchestration Client", () => {
             const expectedStatuses: DurableOrchestrationStatus[] = [
                 new DurableOrchestrationStatus({
                     name: defaultOrchestrationName,
+                    version: "2.0",
                     instanceId: defaultInstanceId,
                     createdTime: new Date(),
                     lastUpdatedTime: new Date(),
@@ -607,6 +612,7 @@ describe("Orchestration Client", () => {
                 runtimeStatus: runtimeStatuses,
             });
             expect(scope.isDone()).to.be.equal(true);
+            expect(result[0].version).to.be.equal("2.0");
             expect(JSON.stringify(result)).to.be.equal(JSON.stringify(expectedStatuses));
         });
 

--- a/types/orchestration.d.ts
+++ b/types/orchestration.d.ts
@@ -339,6 +339,13 @@ export declare class DurableOrchestrationStatus {
     readonly name: string;
 
     /**
+     * The version assigned to the orchestration instance.
+     *
+     * This value is `undefined` when version information is unavailable.
+     */
+    readonly version?: string;
+
+    /**
      * The unique ID of the instance.
      *
      * The instance ID is generated and fixed when the orchestrator


### PR DESCRIPTION
## Summary

Expose orchestration version information on `DurableOrchestrationStatus`.

When the Durable Functions extension returns a `version` field in status responses, the JavaScript SDK now maps it to `status.version` for:

- `getStatus()`
- `getStatusAll()`
- `getStatusBy()`


## Example

```js
const status = await client.getStatus("order-123");

context.log(status.version); // "2.0"
```

The status returned by `getStatus()` includes the version:

```json
{
  "name": "processOrder",
  "instanceId": "order-123",
  "version": "2.0",
  "runtimeStatus": "Running",
  "createdTime": "2026-08-27T17:00:00.000Z",
  "lastUpdatedTime": "2026-08-27T17:00:05.000Z",
  "input": {},
  "customStatus": null,
  "output": null
}
```

If version information is unavailable, `status.version` is `undefined`.

## Why

Durable Functions JavaScript supports assigning orchestration versions, but callers could not retrieve the effective version through the standard JavaScript status APIs.

This makes it possible to validate deployments, diagnose version-specific issues, and identify orchestration instances running a specific version.

## Testing

- JavaScript SDK build passed.
- Relevant orchestration client status/query unit tests passed.
- Verified with the extension BasicNode E2E test using a locally packed SDK package.

## Notes

- Companion Durable Functions extension PR: #
- `version` is optional for compatibility with older extension responses and historical orchestration instances